### PR TITLE
feat(M1): stage-1 capture hooks for Stop, SessionEnd, PreCompact

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -28,7 +28,7 @@ ai-knowledge-base doctor
 This will:
 
 1. Create `.ai/knowledge-base/` with the directory skeleton (`nodes/`, `_proposed/`, `_sessions/`, `_logs/`, plus `INDEX.md`, `GRAPH.md`, and a `README.md` that explains the layout to teammates).
-2. Create `.claude/` with the slash command for bootstrap. Hooks are registered in later phases as their scripts ship.
+2. Create `.claude/` with the bootstrap slash command and the compiled stage-1 capture hook (`kb-capture.mjs`). The hook is registered against `Stop`, `SessionEnd`, and `PreCompact` in `.claude/settings.json`. See [Reference > Hook events](../reference/hook-events.md) for what each one does.
 3. Create or extend `.gitignore` to keep `_sessions/` and `_logs/` out of git by default.
 4. Drop a `.pre-commit-config.yaml` with a [gitleaks](https://github.com/gitleaks/gitleaks) hook (or merge entry if you already have one).
 5. Write `.ai/.kb-builder/installed-version` recording which package version produced the templates.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -14,12 +14,23 @@ The package installs an `ai-knowledge-base` binary. After `npm install -g @e0ips
 ai-knowledge-base init --assistants <list> [--force]
 ```
 
-First-time setup for a repo. Copies the directory skeleton, slash commands, and pre-commit config; writes `.ai/.kb-builder/installed-version`.
+First-time setup for a repo. Copies the directory skeleton, slash commands, hook scripts, and pre-commit config; registers the capture hook against three Claude Code events; writes `.ai/.kb-builder/installed-version`.
 
 Flags:
 
 - `-a, --assistants <list>` (required) — comma-separated list of AI assistants to wire up. v1 supports `claude` only; the list form exists for forward compatibility.
 - `-f, --force` — overwrite existing files. Without this flag, re-running `init` on an already-initialized repo exits with a notice and does nothing.
+
+What `init` writes:
+
+- `.ai/knowledge-base/` — node directories, `_proposed/`, `_sessions/`, `_logs/`, plus an in-KB `README.md`, `INDEX.md`, and `GRAPH.md` stub.
+- `.claude/commands/kb-bootstrap.md` — the bootstrap slash command body (other slash commands ship in M3).
+- `.claude/hooks/kb-capture.mjs` — compiled stage-1 capture script (Stop / SessionEnd / PreCompact).
+- `.claude/settings.json` — registers the three hooks; merges with any existing user-defined hooks.
+- `.ai/.kb-builder/installed-version` — JSON marker recording the package version and selected assistants.
+- `.ai/.kb-builder/prompts/` — copy of the shipped prompts so you can review or override them locally.
+- `.gitignore` — appends a managed block listing `_sessions/`, `_logs/`, and state files.
+- `.pre-commit-config.yaml` — gitleaks hook (only if no config exists; otherwise the file is left alone with a warning).
 
 ## `doctor`
 

--- a/docs/reference/hook-events.md
+++ b/docs/reference/hook-events.md
@@ -1,0 +1,75 @@
+---
+title: Hook events
+parent: Reference
+nav_order: 3
+---
+
+# Hook events
+
+`init` registers a single hook script — `.claude/hooks/kb-capture.mjs` — against three Claude Code events. The script implements the **stage-1 capture** pipeline: dedup, secret-scan with redaction, write a session log to `.ai/knowledge-base/_sessions/`, and append to `.queue.json` for the stage-2 worker.
+
+## Registered events
+
+| Event | Why we capture | Behavior |
+|---|---|---|
+| `Stop` | Captures after every assistant turn ends. The transcript hash changes turn-by-turn, so this produces one log per substantive checkpoint within a session. | Synchronous, ≤1 s deadline. Dedup window prevents overlap with the other two events. |
+| `SessionEnd` | Captures when the user explicitly closes or clears the session. The strongest signal that the session is done. | Same pipeline as `Stop`. |
+| `PreCompact` | Fires immediately before Claude Code compacts context. Without this, content about to be discarded would be lost. | Same pipeline as `Stop`. The 1-second deadline still applies; if you have a very long transcript and capture would exceed it, the hook exits silently rather than blocking compaction. |
+
+All three events route through the same script, so the only difference in the resulting session log is the `captured_by` frontmatter field (`stop`, `session_end`, or `pre_compact`).
+
+## Recursion guard
+
+The hook checks `KB_BUILDER_INTERNAL=1` in its environment and exits immediately if set. Stage-2 (M2) and the curator (M3) spawn `claude -p` subprocesses with this env var so that the child Claude Code instance doesn't fire its own capture hooks and trigger recursive work.
+
+If you wrap the `claude` CLI in a script that spawns sessions for any reason, set `KB_BUILDER_INTERNAL=1` in those subprocesses.
+
+## What stage 1 does
+
+1. **Read hook input.** Claude Code passes a JSON payload on stdin (session id, transcript path, cwd, event name).
+2. **Parse the transcript.** The transcript file at `transcript_path` is a JSONL of conversation messages. We pull only `user` and `assistant` text content and render it as a role-tagged slice (`[USER]: …` / `[AGENT]: …`).
+3. **SHA-256 dedup.** The hash of the slice is checked against `_sessions/.dedup-cache.json`. If a matching hash exists and is less than 5 minutes old, capture exits silently — Stop/SessionEnd/PreCompact often fire in close succession over the same content.
+4. **Gitleaks scan + redact.** The slice is written to a temp file and passed to `gitleaks detect --no-git`. Findings are replaced with `[REDACTED:<RuleID>]` placeholders. If gitleaks isn't installed, hangs, or crashes, capture **aborts without writing a session log** — the security guarantee outweighs availability.
+5. **Write the session log.** `_sessions/<YYYYMMDD-HHmm-id>.md` with frontmatter (`schema_version: 1`, `stage_2_status: pending`, `gitleaks_status`, etc.) followed by the redacted slice under a `## Stage 1: redacted transcript slice` section. A `## Stage 2: structured summary` section is left empty for the M2 worker.
+6. **Append to the queue.** `_sessions/.queue.json` gets an entry pointing at the new log. Written atomically (temp file + rename).
+
+## What stage 1 does NOT do
+
+- Run the LLM. Stage 2 (M2) reads the queue asynchronously on the next `SessionStart` and spawns `claude -p` to produce structured proposals.
+- Block on long operations. The hook has a hard 1-second deadline. If anything (gitleaks, disk I/O) goes long, the hook exits silently and the content for that trigger is lost. Subsequent triggers (the next Stop, SessionEnd, PreCompact) will re-attempt.
+- Capture anything on `SessionStart`. That event is reserved for the stage-2 drain hook (M2) and the consume-side INDEX injection hook (M4).
+
+## Failure modes
+
+| Condition | Outcome |
+|---|---|
+| `KB_BUILDER_INTERNAL=1` | Hook exits immediately. No capture. |
+| Empty / malformed stdin | Hook exits silently. No capture. |
+| `transcript_path` missing or absent | Hook exits silently. No capture. |
+| Transcript has no user or assistant text | Hook exits silently. No capture. |
+| Hash matches a recent entry in `_sessions/.dedup-cache.json` | Skipped as duplicate. No capture. |
+| Gitleaks not on PATH or crashes | A `[ai-knowledge-base] gitleaks blocked stage-1 capture: …` line goes to stderr. **No session log is written.** Install gitleaks and the next trigger will succeed. |
+| 1-second deadline exceeded | Hook exits silently. The content is lost for this trigger; the next Stop/SessionEnd/PreCompact retries. |
+
+## Inspecting the registration
+
+After `init`, `.claude/settings.json` contains a block per event:
+
+```json
+{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "KB_BUILDER_HOOK=Stop node .claude/hooks/kb-capture.mjs"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+The same pattern repeats for `SessionEnd` and `PreCompact`. Existing user-defined hooks in the same file are preserved on re-init.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -8,7 +8,7 @@ permalink: /reference/
 # Reference
 
 - [CLI commands](cli.md) — every `ai-knowledge-base` subcommand.
+- [Hook events](hook-events.md) — the three capture triggers and the recursion guard.
 - Slash commands — _coming in M3._
 - Frontmatter schemas — _coming in M4._
-- Hook events — _coming in M1._
 - Failure modes — _coming progressively._

--- a/package.json
+++ b/package.json
@@ -33,9 +33,9 @@
     "node": ">=22.0.0"
   },
   "scripts": {
-    "build": "tsup",
+    "build": "npm run build:cli && npm run build:templates",
+    "build:cli": "tsup",
     "build:templates": "node ./scripts/build-templates.mjs",
-    "prebuild": "npm run build:templates",
     "dev": "tsup --watch",
     "lint": "eslint .",
     "format": "prettier --write .",

--- a/scripts/build-templates.mjs
+++ b/scripts/build-templates.mjs
@@ -1,15 +1,22 @@
 #!/usr/bin/env node
-// Copies src/templates-source/ → templates/ so the npm package ships
-// templates that `init` can read without requiring a TS build for them.
+// Builds the shipped `templates/` directory.
+//
+// 1. Copies `src/templates-source/` (static markdown, settings, etc.) → `templates/`.
+// 2. Copies any compiled hook scripts from `dist/hooks/` → `templates/claude/hooks/`.
+//
+// Run after `tsup` so the compiled hooks exist; the package's `prepare`
+// script wires this up.
 
-import { cpSync, existsSync, mkdirSync, rmSync } from 'node:fs';
-import { dirname, resolve } from 'node:path';
+import { cpSync, existsSync, mkdirSync, readdirSync, rmSync, statSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const root = resolve(here, '..');
 const src = resolve(root, 'src/templates-source');
 const dest = resolve(root, 'templates');
+const compiledHooksDir = resolve(root, 'dist/hooks');
+const destHooksDir = resolve(dest, 'claude/hooks');
 
 if (!existsSync(src)) {
   console.error(`Source not found: ${src}`);
@@ -20,3 +27,21 @@ rmSync(dest, { recursive: true, force: true });
 mkdirSync(dest, { recursive: true });
 cpSync(src, dest, { recursive: true });
 console.log(`Copied ${src} → ${dest}`);
+
+if (existsSync(compiledHooksDir)) {
+  mkdirSync(destHooksDir, { recursive: true });
+  let copied = 0;
+  for (const name of readdirSync(compiledHooksDir)) {
+    const from = join(compiledHooksDir, name);
+    if (!statSync(from).isFile()) continue;
+    if (!name.endsWith('.mjs')) continue;
+    cpSync(from, join(destHooksDir, name));
+    copied += 1;
+  }
+  console.log(`Copied ${copied} hook(s) from ${compiledHooksDir} → ${destHooksDir}`);
+} else {
+  console.warn(
+    `Compiled hooks directory not found: ${compiledHooksDir}. Run tsup first ` +
+      `(npm run build:cli). Continuing without hooks — templates may be incomplete.`,
+  );
+}

--- a/src/adapters/claude.ts
+++ b/src/adapters/claude.ts
@@ -1,5 +1,6 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
+import { parseTranscriptJsonl } from '../lib/transcript.js';
 import type {
   Adapter,
   HeadlessOpts,
@@ -73,8 +74,23 @@ export class ClaudeAdapter implements Adapter {
     writeFileSync(settingsFile, `${JSON.stringify(settings, null, 2)}\n`);
   }
 
-  async readTranscript(_hookInput: unknown): Promise<RoleTaggedTranscript> {
-    throw new Error('readTranscript() is implemented in M1');
+  /**
+   * Reads a Claude Code hook input and returns a role-tagged transcript.
+   * The hook input is expected to carry a `transcript_path` pointing at
+   * the JSONL session file on disk; we parse only user/assistant text
+   * messages, dropping tool calls and system events.
+   */
+  async readTranscript(hookInput: unknown): Promise<RoleTaggedTranscript> {
+    const input = hookInput as { transcript_path?: unknown } | null;
+    const path = input && typeof input.transcript_path === 'string' ? input.transcript_path : null;
+    if (!path) {
+      throw new Error('hook input is missing transcript_path');
+    }
+    if (!existsSync(path)) {
+      throw new Error(`transcript file not found: ${path}`);
+    }
+    const text = readFileSync(path, 'utf8');
+    return parseTranscriptJsonl(text);
   }
 
   async runHeadless<T>(

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -67,15 +67,18 @@ export async function runInit(opts: InitOptions): Promise<void> {
   // 1. Knowledge-base skeleton.
   copyTree(join(templatesDir, 'knowledge-base'), paths.kbDir);
 
-  // 2. Claude-specific files (commands + settings).
+  // 2. Claude-specific files (commands + settings + hooks).
   if (opts.assistants.includes('claude')) {
     const claudeAdapter = new ClaudeAdapter();
     const claudeTemplateDir = join(templatesDir, 'claude');
     if (existsSync(claudeTemplateDir)) {
       copyTree(claudeTemplateDir, paths.claudeDir);
     }
-    // In M0 there are no hooks to register; later phases extend this list.
-    await claudeAdapter.writeHookConfig(root, []);
+    await claudeAdapter.writeHookConfig(root, [
+      { event: 'Stop', scriptPath: '.claude/hooks/kb-capture.mjs' },
+      { event: 'SessionEnd', scriptPath: '.claude/hooks/kb-capture.mjs' },
+      { event: 'PreCompact', scriptPath: '.claude/hooks/kb-capture.mjs' },
+    ]);
   }
 
   // 3. Prompts under .ai/.kb-builder/prompts (for local override).

--- a/src/hooks/kb-capture.ts
+++ b/src/hooks/kb-capture.ts
@@ -1,0 +1,72 @@
+/**
+ * Stop / SessionEnd / PreCompact hook.
+ *
+ * Runs the deterministic stage-1 capture pipeline: dedup, gitleaks redact,
+ * write session log, append to queue. Must complete within 1 second on any
+ * trigger; if the wall-clock deadline elapses, exits silently to avoid
+ * blocking session shutdown.
+ */
+import { captureSession, type HookInput } from '../lib/capture.js';
+import { findRepoRoot, repoPaths } from '../lib/paths.js';
+
+const HARD_DEADLINE_MS = 1000;
+const PACKAGE_TAG = '[ai-knowledge-base]';
+
+async function main(): Promise<void> {
+  // Recursion guard: when stage-2 (M2) spawns `claude -p`, the child
+  // process may itself trigger Stop/PreCompact hooks. We disable the
+  // hook in those subprocesses by checking this env var.
+  if (process.env['KB_BUILDER_INTERNAL'] === '1') return;
+
+  // Hard wall-clock deadline. unref() so timer doesn't prevent natural exit.
+  const deadline = setTimeout(() => process.exit(0), HARD_DEADLINE_MS);
+  deadline.unref();
+
+  const raw = await readStdin();
+  let input: HookInput = {};
+  if (raw.trim().length > 0) {
+    try {
+      input = JSON.parse(raw) as HookInput;
+    } catch {
+      return;
+    }
+  }
+
+  const startCwd =
+    typeof input.cwd === 'string' && input.cwd.length > 0 ? input.cwd : process.cwd();
+  const root = findRepoRoot(startCwd);
+  const paths = repoPaths(root);
+
+  try {
+    const result = await captureSession(input, { sessionsDir: paths.sessionsDir });
+    if (result.status === 'gitleaks-blocked') {
+      process.stderr.write(
+        `${PACKAGE_TAG} gitleaks blocked stage-1 capture: ${result.error ?? 'unknown error'}\n`,
+      );
+    }
+    // All other statuses are intentionally silent. `ai-knowledge-base status`
+    // surfaces pending counts when the user wants to check.
+  } catch (err) {
+    process.stderr.write(
+      `${PACKAGE_TAG} capture error: ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+  }
+}
+
+function readStdin(): Promise<string> {
+  return new Promise((resolve) => {
+    if (process.stdin.isTTY) {
+      resolve('');
+      return;
+    }
+    let data = '';
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', (chunk: string) => {
+      data += chunk;
+    });
+    process.stdin.on('end', () => resolve(data));
+    process.stdin.on('error', () => resolve(''));
+  });
+}
+
+void main().catch(() => process.exit(0));

--- a/src/lib/capture.ts
+++ b/src/lib/capture.ts
@@ -1,0 +1,121 @@
+import { createHash } from 'node:crypto';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { isDuplicate, recordHash } from './dedup-cache.js';
+import type { GitleaksResult, GitleaksScanner } from './gitleaks.js';
+import { scanAndRedact } from './gitleaks.js';
+import { appendToQueue } from './queue.js';
+import type { CaptureTrigger } from './schemas.js';
+import { buildSessionLogFilename, renderSessionLog, writeSessionLog } from './session-log.js';
+import { parseTranscriptJsonl, renderRoleTagged } from './transcript.js';
+
+export interface HookInput {
+  session_id?: string;
+  transcript_path?: string;
+  hook_event_name?: string;
+  cwd?: string;
+}
+
+export type CaptureStatus =
+  | 'written'
+  | 'duplicate'
+  | 'no-content'
+  | 'no-transcript'
+  | 'gitleaks-blocked';
+
+export interface CaptureResult {
+  status: CaptureStatus;
+  sessionLogPath?: string;
+  gitleaksStatus?: GitleaksResult['status'];
+  error?: string;
+}
+
+export interface CaptureContext {
+  sessionsDir: string;
+  now?: () => Date;
+  scan?: GitleaksScanner;
+  scanTimeoutMs?: number;
+}
+
+const HOOK_EVENT_TO_TRIGGER: Record<string, CaptureTrigger> = {
+  Stop: 'stop',
+  SessionEnd: 'session_end',
+  PreCompact: 'pre_compact',
+};
+
+export function eventToTrigger(event: string | undefined): CaptureTrigger {
+  if (event && HOOK_EVENT_TO_TRIGGER[event]) {
+    return HOOK_EVENT_TO_TRIGGER[event];
+  }
+  return 'stop';
+}
+
+export async function captureSession(
+  input: HookInput,
+  ctx: CaptureContext,
+): Promise<CaptureResult> {
+  const trigger = eventToTrigger(input.hook_event_name);
+  const transcriptPath = input.transcript_path;
+  if (!transcriptPath || !existsSync(transcriptPath)) {
+    return {
+      status: 'no-transcript',
+      error: `transcript_path missing or absent: ${transcriptPath ?? '(none)'}`,
+    };
+  }
+
+  const transcriptText = readFileSync(transcriptPath, 'utf8');
+  const parsed = parseTranscriptJsonl(transcriptText);
+  const slice = renderRoleTagged(parsed);
+  if (!slice.trim()) {
+    return { status: 'no-content' };
+  }
+
+  const hash = `sha256:${createHash('sha256').update(slice).digest('hex')}`;
+  const dedupCacheFile = join(ctx.sessionsDir, '.dedup-cache.json');
+  const nowMs = (ctx.now?.() ?? new Date()).getTime();
+  if (isDuplicate(dedupCacheFile, hash, nowMs)) {
+    return { status: 'duplicate' };
+  }
+
+  const scan = ctx.scan ?? ((text: string) => scanAndRedact(text, ctx.scanTimeoutMs ?? 1000));
+  const gitleaks = await scan(slice);
+  if (gitleaks.status === 'blocked') {
+    return {
+      status: 'gitleaks-blocked',
+      gitleaksStatus: 'blocked',
+      ...(gitleaks.error !== undefined ? { error: gitleaks.error } : {}),
+    };
+  }
+
+  const capturedAt = (ctx.now?.() ?? new Date()).toISOString();
+  const sessionId =
+    typeof input.session_id === 'string' && input.session_id.length > 0
+      ? input.session_id
+      : hash.slice(7, 19);
+  const filename = buildSessionLogFilename(capturedAt, sessionId);
+  const body = renderSessionLog({
+    sessionId,
+    capturedBy: trigger,
+    capturedAt,
+    transcriptHash: hash,
+    gitleaksStatus: gitleaks.status,
+    body: gitleaks.status === 'redacted' ? gitleaks.redactedText : slice,
+  });
+
+  const sessionLogPath = writeSessionLog(ctx.sessionsDir, filename, body);
+  recordHash(dedupCacheFile, hash, nowMs);
+
+  appendToQueue(join(ctx.sessionsDir, '.queue.json'), {
+    session_id: sessionId,
+    session_log: filename,
+    captured_by: trigger,
+    captured_at: capturedAt,
+    attempts: 0,
+  });
+
+  return {
+    status: 'written',
+    sessionLogPath,
+    gitleaksStatus: gitleaks.status,
+  };
+}

--- a/src/lib/dedup-cache.ts
+++ b/src/lib/dedup-cache.ts
@@ -1,0 +1,41 @@
+import { existsSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
+import { DedupCacheFileSchema } from './schemas.js';
+
+export const DEDUP_TTL_MS = 5 * 60 * 1000;
+
+interface CacheEntry {
+  hash: string;
+  expires_at: string;
+}
+
+function loadEntries(file: string): CacheEntry[] {
+  if (!existsSync(file)) return [];
+  try {
+    const raw = JSON.parse(readFileSync(file, 'utf8')) as unknown;
+    const parsed = DedupCacheFileSchema.safeParse(raw);
+    if (parsed.success) return parsed.data.entries;
+    return [];
+  } catch {
+    return [];
+  }
+}
+
+function pruneExpired(entries: CacheEntry[], nowMs: number): CacheEntry[] {
+  return entries.filter((e) => {
+    const t = Date.parse(e.expires_at);
+    return Number.isFinite(t) && t > nowMs;
+  });
+}
+
+export function isDuplicate(cacheFile: string, hash: string, nowMs: number = Date.now()): boolean {
+  const entries = pruneExpired(loadEntries(cacheFile), nowMs);
+  return entries.some((e) => e.hash === hash);
+}
+
+export function recordHash(cacheFile: string, hash: string, nowMs: number = Date.now()): void {
+  const entries = pruneExpired(loadEntries(cacheFile), nowMs).filter((e) => e.hash !== hash);
+  entries.push({ hash, expires_at: new Date(nowMs + DEDUP_TTL_MS).toISOString() });
+  const tmp = `${cacheFile}.tmp`;
+  writeFileSync(tmp, `${JSON.stringify({ schema_version: 1, entries }, null, 2)}\n`);
+  renameSync(tmp, cacheFile);
+}

--- a/src/lib/gitleaks.ts
+++ b/src/lib/gitleaks.ts
@@ -1,0 +1,108 @@
+import { execFile } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+import type { GitleaksStatus } from './schemas.js';
+
+const exec = promisify(execFile);
+
+export interface GitleaksFinding {
+  RuleID: string;
+  Secret: string;
+  Match?: string;
+  StartLine?: number;
+  EndLine?: number;
+}
+
+export interface GitleaksResult {
+  status: GitleaksStatus;
+  redactedText: string;
+  findings: GitleaksFinding[];
+  error?: string;
+}
+
+export type GitleaksScanner = (text: string) => Promise<GitleaksResult>;
+
+/**
+ * Replaces each finding's `Secret` substring with `[REDACTED:<RuleID>]`.
+ * Replacements are applied longest-first so overlapping secrets don't
+ * leave partial leakage behind.
+ */
+export function redactSecrets(text: string, findings: GitleaksFinding[]): string {
+  const ordered = [...findings].sort((a, b) => (b.Secret?.length ?? 0) - (a.Secret?.length ?? 0));
+  let out = text;
+  for (const f of ordered) {
+    const secret = f.Secret;
+    if (typeof secret !== 'string' || secret.length === 0) continue;
+    out = out.split(secret).join(`[REDACTED:${f.RuleID}]`);
+  }
+  return out;
+}
+
+/**
+ * Runs gitleaks against the provided text. Times out after `timeoutMs`
+ * (default 1000 ms) and treats ENOENT (gitleaks not on PATH) and
+ * timeouts as `blocked` — the stage-1 capture aborts in those cases per
+ * IMPLEMENTATION §5.1.
+ */
+export async function scanAndRedact(text: string, timeoutMs = 1000): Promise<GitleaksResult> {
+  let dir: string | undefined;
+  try {
+    dir = mkdtempSync(join(tmpdir(), 'kb-gitleaks-'));
+    const inFile = join(dir, 'in.txt');
+    const reportFile = join(dir, 'report.json');
+    writeFileSync(inFile, text);
+    try {
+      await exec(
+        'gitleaks',
+        [
+          'detect',
+          '--no-git',
+          '--source',
+          inFile,
+          '--report-format',
+          'json',
+          '--report-path',
+          reportFile,
+          // Don't propagate non-zero exit just because findings were present;
+          // we read the report and decide.
+          '--exit-code',
+          '0',
+        ],
+        { timeout: timeoutMs },
+      );
+    } catch (err) {
+      const e = err as NodeJS.ErrnoException & { signal?: string };
+      const detail =
+        e.code === 'ENOENT'
+          ? 'gitleaks not found on PATH'
+          : e.signal === 'SIGTERM' || (typeof e.code === 'string' && e.code === 'ETIMEDOUT')
+            ? `gitleaks timed out after ${timeoutMs}ms`
+            : e.message;
+      return { status: 'blocked', redactedText: '', findings: [], error: detail };
+    }
+
+    let findings: GitleaksFinding[] = [];
+    try {
+      const raw = readFileSync(reportFile, 'utf8').trim();
+      if (raw.length > 0) {
+        const parsed = JSON.parse(raw) as unknown;
+        if (Array.isArray(parsed)) findings = parsed as GitleaksFinding[];
+      }
+    } catch {
+      // Missing report file means gitleaks didn't write one — treat as clean.
+    }
+
+    if (findings.length === 0) {
+      return { status: 'clean', redactedText: text, findings: [] };
+    }
+    return {
+      status: 'redacted',
+      redactedText: redactSecrets(text, findings),
+      findings,
+    };
+  } finally {
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  }
+}

--- a/src/lib/queue.ts
+++ b/src/lib/queue.ts
@@ -1,0 +1,29 @@
+import { existsSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
+import { QueueFileSchema, type QueueEntry, type QueueFile } from './schemas.js';
+
+export function readQueue(file: string): QueueFile {
+  if (!existsSync(file)) return { schema_version: 1, entries: [] };
+  try {
+    const raw = JSON.parse(readFileSync(file, 'utf8')) as unknown;
+    const parsed = QueueFileSchema.safeParse(raw);
+    if (parsed.success) return parsed.data;
+    return { schema_version: 1, entries: [] };
+  } catch {
+    return { schema_version: 1, entries: [] };
+  }
+}
+
+/**
+ * Appends an entry to the queue file atomically: read, append, write to a
+ * temp file, rename. Two interleaved appends from concurrent hooks may
+ * still race; in practice Stop/SessionEnd/PreCompact are unlikely to fire
+ * simultaneously on the same session, and the 5-min dedup window catches
+ * any duplicate content even if both writes survive.
+ */
+export function appendToQueue(file: string, entry: QueueEntry): void {
+  const queue = readQueue(file);
+  queue.entries.push(entry);
+  const tmp = `${file}.tmp`;
+  writeFileSync(tmp, `${JSON.stringify(queue, null, 2)}\n`);
+  renameSync(tmp, file);
+}

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -1,0 +1,59 @@
+import { z } from 'zod';
+
+export const CaptureTriggerSchema = z.enum(['stop', 'session_end', 'pre_compact', 'manual']);
+export type CaptureTrigger = z.infer<typeof CaptureTriggerSchema>;
+
+export const GitleaksStatusSchema = z.enum(['clean', 'redacted', 'blocked', 'skipped']);
+export type GitleaksStatus = z.infer<typeof GitleaksStatusSchema>;
+
+export const Stage2StatusSchema = z.enum(['pending', 'done', 'failed', 'skipped']);
+export type Stage2Status = z.infer<typeof Stage2StatusSchema>;
+
+export const SessionLogFrontmatterSchema = z.object({
+  schema_version: z.literal(1),
+  session_id: z.string(),
+  captured_by: CaptureTriggerSchema,
+  captured_at: z.string(),
+  transcript_hash: z.string(),
+  stage_2_status: Stage2StatusSchema,
+  stage_2_completed_at: z.string().nullable(),
+  stage_2_error: z.string().nullable(),
+  stage_2_log: z.string().nullable(),
+  gitleaks_status: GitleaksStatusSchema,
+  topics: z.array(z.string()),
+  proposals: z.object({
+    practice: z.array(z.unknown()),
+    map: z.array(z.unknown()),
+  }),
+});
+
+export type SessionLogFrontmatter = z.infer<typeof SessionLogFrontmatterSchema>;
+
+export const QueueEntrySchema = z.object({
+  session_id: z.string(),
+  session_log: z.string(),
+  captured_by: CaptureTriggerSchema,
+  captured_at: z.string(),
+  attempts: z.number().int().nonnegative(),
+});
+
+export type QueueEntry = z.infer<typeof QueueEntrySchema>;
+
+export const QueueFileSchema = z.object({
+  schema_version: z.literal(1),
+  entries: z.array(QueueEntrySchema),
+});
+
+export type QueueFile = z.infer<typeof QueueFileSchema>;
+
+export const DedupCacheEntrySchema = z.object({
+  hash: z.string(),
+  expires_at: z.string(),
+});
+
+export const DedupCacheFileSchema = z.object({
+  schema_version: z.literal(1),
+  entries: z.array(DedupCacheEntrySchema),
+});
+
+export type DedupCacheFile = z.infer<typeof DedupCacheFileSchema>;

--- a/src/lib/session-log.ts
+++ b/src/lib/session-log.ts
@@ -1,0 +1,80 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import type { CaptureTrigger, GitleaksStatus } from './schemas.js';
+
+export interface SessionLogInput {
+  sessionId: string;
+  capturedBy: CaptureTrigger;
+  capturedAt: string;
+  transcriptHash: string;
+  gitleaksStatus: GitleaksStatus;
+  body: string;
+}
+
+/**
+ * Renders the session log markdown including frontmatter. We emit YAML by
+ * hand (rather than via a dump library) because the frontmatter shape is
+ * small and stable, and the hook ships as compiled JS — avoiding extra
+ * runtime deps keeps the bundled hook small.
+ */
+export function renderSessionLog(input: SessionLogInput): string {
+  const lines = [
+    '---',
+    'schema_version: 1',
+    `session_id: ${yamlString(input.sessionId)}`,
+    `captured_by: ${input.capturedBy}`,
+    `captured_at: ${yamlString(input.capturedAt)}`,
+    `transcript_hash: ${yamlString(input.transcriptHash)}`,
+    'stage_2_status: pending',
+    'stage_2_completed_at: null',
+    'stage_2_error: null',
+    'stage_2_log: null',
+    `gitleaks_status: ${input.gitleaksStatus}`,
+    'topics: []',
+    'proposals:',
+    '  practice: []',
+    '  map: []',
+    '---',
+    '',
+    '## Stage 1: redacted transcript slice',
+    '',
+    input.body.trimEnd(),
+    '',
+    '## Stage 2: structured summary',
+    '',
+    '(populated by stage-2 worker)',
+    '',
+  ];
+  return lines.join('\n');
+}
+
+function yamlString(value: string): string {
+  // Always quote with JSON-style double quotes for safety; escapes special
+  // characters and ensures the value round-trips through gray-matter.
+  return JSON.stringify(value);
+}
+
+export function writeSessionLog(sessionsDir: string, filename: string, contents: string): string {
+  mkdirSync(sessionsDir, { recursive: true });
+  const path = join(sessionsDir, filename);
+  writeFileSync(path, contents);
+  return path;
+}
+
+/**
+ * Builds a stable, sortable filename for a session log:
+ * `YYYYMMDD-HHmm-<id>.md`. The id is sanitized and truncated; the
+ * timestamp comes from `capturedAt` (UTC) so logs sort chronologically.
+ */
+export function buildSessionLogFilename(capturedAt: string, sessionId: string): string {
+  const d = new Date(capturedAt);
+  const stamp =
+    `${d.getUTCFullYear()}${pad(d.getUTCMonth() + 1)}${pad(d.getUTCDate())}` +
+    `-${pad(d.getUTCHours())}${pad(d.getUTCMinutes())}`;
+  const short = sessionId.replace(/[^a-z0-9]/gi, '').slice(0, 12) || 'session';
+  return `${stamp}-${short}.md`;
+}
+
+function pad(n: number): string {
+  return n.toString().padStart(2, '0');
+}

--- a/src/lib/transcript.ts
+++ b/src/lib/transcript.ts
@@ -1,0 +1,81 @@
+/**
+ * Parses a Claude Code session JSONL transcript into role-tagged user and
+ * agent turns. Each line in the transcript is a JSON message; we keep only
+ * user and assistant messages and extract their textual content.
+ */
+
+export interface RoleTaggedTranscript {
+  user: string[];
+  agent: string[];
+  interleaved: Array<{ role: 'user' | 'agent'; text: string }>;
+}
+
+interface RawContentBlock {
+  type?: string;
+  text?: string;
+}
+
+interface RawMessage {
+  type?: string;
+  message?: {
+    role?: string;
+    content?: string | RawContentBlock[];
+  };
+  // Some transcript shapes inline content at the top level.
+  role?: string;
+  content?: string | RawContentBlock[];
+}
+
+function extractText(content: unknown): string {
+  if (typeof content === 'string') return content;
+  if (Array.isArray(content)) {
+    return content
+      .filter((c): c is RawContentBlock => !!c && typeof c === 'object')
+      .filter((c) => (c.type ?? 'text') === 'text')
+      .map((c) => (typeof c.text === 'string' ? c.text : ''))
+      .filter((s) => s.length > 0)
+      .join('\n');
+  }
+  return '';
+}
+
+export function parseTranscriptJsonl(text: string): RoleTaggedTranscript {
+  const out: RoleTaggedTranscript = { user: [], agent: [], interleaved: [] };
+  for (const rawLine of text.split('\n')) {
+    const line = rawLine.trim();
+    if (!line) continue;
+    let msg: RawMessage;
+    try {
+      msg = JSON.parse(line) as RawMessage;
+    } catch {
+      continue;
+    }
+    const role = msg.message?.role ?? msg.role ?? msg.type;
+    const content = msg.message?.content ?? msg.content;
+    if (role === 'user') {
+      const text = extractText(content);
+      if (text) {
+        out.user.push(text);
+        out.interleaved.push({ role: 'user', text });
+      }
+    } else if (role === 'assistant' || role === 'agent') {
+      const text = extractText(content);
+      if (text) {
+        out.agent.push(text);
+        out.interleaved.push({ role: 'agent', text });
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Renders the role-tagged transcript in the `[USER]: ...` / `[AGENT]: ...`
+ * format consumed by the stage-2 extraction prompt and stored in the
+ * session log under the "Stage 1: redacted transcript slice" section.
+ */
+export function renderRoleTagged(t: RoleTaggedTranscript): string {
+  return t.interleaved
+    .map((seg) => `[${seg.role === 'user' ? 'USER' : 'AGENT'}]: ${seg.text}`)
+    .join('\n\n');
+}

--- a/tests/hooks/kb-capture.test.ts
+++ b/tests/hooks/kb-capture.test.ts
@@ -1,0 +1,185 @@
+import { execFile } from 'node:child_process';
+import { existsSync, mkdirSync, readdirSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { cleanSandbox, makeSandbox, runCli } from '../helpers.js';
+
+const exec = promisify(execFile);
+let gitleaksAvailable = false;
+try {
+  await exec('gitleaks', ['version'], { timeout: 2000 });
+  gitleaksAvailable = true;
+} catch {
+  gitleaksAvailable = false;
+}
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, '../..');
+const hookPath = join(repoRoot, 'dist/hooks/kb-capture.mjs');
+
+async function gitInit(dir: string): Promise<void> {
+  await exec('git', ['init', '-q'], { cwd: dir });
+}
+
+interface SpawnResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+async function runHook(
+  cwd: string,
+  hookInput: Record<string, unknown>,
+  env: NodeJS.ProcessEnv = {},
+): Promise<SpawnResult> {
+  return new Promise((resolveFn) => {
+    const proc = execFile(
+      'node',
+      [hookPath],
+      { cwd, env: { ...process.env, NO_COLOR: '1', ...env } },
+      (err, stdout, stderr) => {
+        const code =
+          err && typeof (err as { code?: unknown }).code === 'number'
+            ? ((err as { code: number }).code as number)
+            : err
+              ? 1
+              : 0;
+        resolveFn({
+          stdout: stdout.toString(),
+          stderr: stderr.toString(),
+          exitCode: code,
+        });
+      },
+    );
+    proc.stdin?.write(JSON.stringify(hookInput));
+    proc.stdin?.end();
+  });
+}
+
+function writeTranscript(path: string): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(
+    path,
+    [
+      JSON.stringify({
+        type: 'user',
+        message: { role: 'user', content: 'use bravo_pii.cache for PII' },
+      }),
+      JSON.stringify({
+        type: 'assistant',
+        message: { role: 'assistant', content: [{ type: 'text', text: 'ok' }] },
+      }),
+    ].join('\n'),
+  );
+}
+
+describe('kb-capture hook (spawned)', () => {
+  let sandbox: string;
+
+  beforeEach(async () => {
+    sandbox = makeSandbox();
+    await gitInit(sandbox);
+    await runCli(sandbox, ['init', '--assistants', 'claude']);
+  });
+  afterEach(() => cleanSandbox(sandbox));
+
+  it('compiled hook bundle exists at dist/hooks/kb-capture.mjs', () => {
+    expect(existsSync(hookPath)).toBe(true);
+  });
+
+  it('exits silently with KB_BUILDER_INTERNAL=1 (recursion guard)', async () => {
+    const transcript = join(sandbox, 't.jsonl');
+    writeTranscript(transcript);
+
+    const result = await runHook(
+      sandbox,
+      {
+        session_id: 's1',
+        transcript_path: transcript,
+        hook_event_name: 'Stop',
+      },
+      { KB_BUILDER_INTERNAL: '1' },
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(sessionLogs(sandbox)).toHaveLength(0);
+  });
+
+  it.skipIf(gitleaksAvailable)(
+    'reports gitleaks-blocked to stderr when gitleaks is missing and writes no session log',
+    async () => {
+      const transcript = join(sandbox, 't.jsonl');
+      writeTranscript(transcript);
+
+      const result = await runHook(sandbox, {
+        session_id: 's1',
+        transcript_path: transcript,
+        hook_event_name: 'Stop',
+        cwd: sandbox,
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stderr).toContain('gitleaks');
+      expect(sessionLogs(sandbox)).toHaveLength(0);
+    },
+  );
+
+  it.skipIf(!gitleaksAvailable)(
+    'writes a session log + queue entry when gitleaks is available',
+    async () => {
+      const transcript = join(sandbox, 't.jsonl');
+      writeTranscript(transcript);
+
+      const result = await runHook(sandbox, {
+        session_id: 's1',
+        transcript_path: transcript,
+        hook_event_name: 'Stop',
+        cwd: sandbox,
+      });
+      expect(result.exitCode).toBe(0);
+      expect(sessionLogs(sandbox).length).toBeGreaterThan(0);
+      const queueFile = join(sandbox, '.ai/knowledge-base/_sessions/.queue.json');
+      expect(existsSync(queueFile)).toBe(true);
+    },
+  );
+
+  it('exits 0 on missing transcript without throwing', async () => {
+    const result = await runHook(sandbox, {
+      session_id: 's1',
+      transcript_path: join(sandbox, 'does-not-exist.jsonl'),
+      hook_event_name: 'Stop',
+      cwd: sandbox,
+    });
+    expect(result.exitCode).toBe(0);
+  });
+
+  it('exits 0 on empty stdin without throwing', async () => {
+    const result = await new Promise<SpawnResult>((resolveFn) => {
+      const proc = execFile(
+        'node',
+        [hookPath],
+        { cwd: sandbox, env: { ...process.env, NO_COLOR: '1' } },
+        (err, stdout, stderr) => {
+          const code =
+            err && typeof (err as NodeJS.ErrnoException).code === 'number'
+              ? ((err as { code: number }).code as number)
+              : 0;
+          resolveFn({
+            stdout: stdout.toString(),
+            stderr: stderr.toString(),
+            exitCode: code,
+          });
+        },
+      );
+      proc.stdin?.end();
+    });
+    expect(result.exitCode).toBe(0);
+  });
+});
+
+function sessionLogs(sandbox: string): string[] {
+  const sessionsDir = join(sandbox, '.ai/knowledge-base/_sessions');
+  if (!existsSync(sessionsDir)) return [];
+  return readdirSync(sessionsDir).filter((f) => f.endsWith('.md'));
+}

--- a/tests/init.test.ts
+++ b/tests/init.test.ts
@@ -37,6 +37,7 @@ describe('init', () => {
       '.ai/knowledge-base/_logs/bootstrap-incremental/.gitkeep',
       '.claude/settings.json',
       '.claude/commands/kb-bootstrap.md',
+      '.claude/hooks/kb-capture.mjs',
       '.ai/.kb-builder/installed-version',
       '.ai/.kb-builder/prompts/stage-2-extract.md',
       '.ai/.kb-builder/prompts/curator.md',
@@ -101,6 +102,21 @@ describe('init', () => {
     await runCli(sandbox, ['init', '--assistants', 'claude']);
     const after = readFileSync(join(sandbox, '.pre-commit-config.yaml'), 'utf8');
     expect(after).toBe(existing);
+  });
+
+  it('registers Stop, SessionEnd, and PreCompact capture hooks in .claude/settings.json', async () => {
+    await runCli(sandbox, ['init', '--assistants', 'claude']);
+    const settings = JSON.parse(readFileSync(join(sandbox, '.claude/settings.json'), 'utf8')) as {
+      hooks?: Record<string, Array<{ hooks: Array<{ type: string; command: string }> }>>;
+    };
+    expect(settings.hooks).toBeDefined();
+    for (const event of ['Stop', 'SessionEnd', 'PreCompact']) {
+      const entries = settings.hooks?.[event];
+      expect(entries, `expected hook entry for ${event}`).toBeDefined();
+      expect(entries?.[0]?.hooks[0]?.command).toBe(
+        `KB_BUILDER_HOOK=${event} node .claude/hooks/kb-capture.mjs`,
+      );
+    }
   });
 
   it('ships the rename — no references to the old `kb-builder` binary in copied prompts', async () => {

--- a/tests/lib/capture.test.ts
+++ b/tests/lib/capture.test.ts
@@ -1,0 +1,176 @@
+import { mkdirSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import matter from 'gray-matter';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { captureSession } from '../../src/lib/capture.js';
+import type { GitleaksScanner } from '../../src/lib/gitleaks.js';
+import { cleanSandbox, makeSandbox } from '../helpers.js';
+
+function fakeScanner(behavior: 'clean' | 'blocked' | 'redact' = 'clean'): GitleaksScanner {
+  return async (text: string) => {
+    if (behavior === 'blocked')
+      return { status: 'blocked', redactedText: '', findings: [], error: 'fake blocked' };
+    if (behavior === 'redact')
+      return {
+        status: 'redacted',
+        redactedText: text.replace(/sk-[a-z0-9]+/gi, '[REDACTED:test-secret]'),
+        findings: [{ RuleID: 'test-secret', Secret: 'sk-abc123' }],
+      };
+    return { status: 'clean', redactedText: text, findings: [] };
+  };
+}
+
+function makeTranscript(dir: string): string {
+  const path = join(dir, 'transcript.jsonl');
+  const lines = [
+    JSON.stringify({ type: 'user', message: { role: 'user', content: 'use bravo_pii.cache' } }),
+    JSON.stringify({
+      type: 'assistant',
+      message: { role: 'assistant', content: [{ type: 'text', text: 'understood' }] },
+    }),
+  ];
+  writeFileSync(path, lines.join('\n'));
+  return path;
+}
+
+describe('captureSession', () => {
+  let sandbox: string;
+  let sessionsDir: string;
+  let transcriptPath: string;
+
+  beforeEach(() => {
+    sandbox = makeSandbox();
+    sessionsDir = join(sandbox, '_sessions');
+    mkdirSync(sessionsDir, { recursive: true });
+    transcriptPath = makeTranscript(sandbox);
+  });
+  afterEach(() => cleanSandbox(sandbox));
+
+  it('writes a session log, dedup-cache entry, and queue entry on a fresh capture', async () => {
+    const result = await captureSession(
+      {
+        session_id: 'sess-1',
+        transcript_path: transcriptPath,
+        hook_event_name: 'Stop',
+      },
+      { sessionsDir, scan: fakeScanner('clean') },
+    );
+    expect(result.status).toBe('written');
+    expect(result.gitleaksStatus).toBe('clean');
+
+    // session log file exists with the expected frontmatter
+    const files = readdirSync(sessionsDir).filter((f) => f.endsWith('.md'));
+    expect(files).toHaveLength(1);
+    const logName = files[0];
+    expect(logName).toBeDefined();
+    const log = readFileSync(join(sessionsDir, logName as string), 'utf8');
+    const fm = matter(log).data as {
+      session_id: string;
+      captured_by: string;
+      stage_2_status: string;
+      gitleaks_status: string;
+      transcript_hash: string;
+    };
+    expect(fm.session_id).toBe('sess-1');
+    expect(fm.captured_by).toBe('stop');
+    expect(fm.stage_2_status).toBe('pending');
+    expect(fm.gitleaks_status).toBe('clean');
+    expect(fm.transcript_hash).toMatch(/^sha256:[0-9a-f]{64}$/);
+
+    // queue + dedup cache populated
+    const queue = JSON.parse(readFileSync(join(sessionsDir, '.queue.json'), 'utf8')) as {
+      entries: Array<{ session_id: string; session_log: string }>;
+    };
+    expect(queue.entries).toHaveLength(1);
+    expect(queue.entries[0]?.session_id).toBe('sess-1');
+    expect(queue.entries[0]?.session_log).toBe(logName);
+
+    const cache = JSON.parse(readFileSync(join(sessionsDir, '.dedup-cache.json'), 'utf8')) as {
+      entries: Array<{ hash: string; expires_at: string }>;
+    };
+    expect(cache.entries).toHaveLength(1);
+  });
+
+  it('returns duplicate status on a repeat within the dedup window', async () => {
+    const ctx = { sessionsDir, scan: fakeScanner('clean') };
+    const first = await captureSession(
+      { session_id: 'x', transcript_path: transcriptPath, hook_event_name: 'Stop' },
+      ctx,
+    );
+    expect(first.status).toBe('written');
+    const second = await captureSession(
+      { session_id: 'x', transcript_path: transcriptPath, hook_event_name: 'SessionEnd' },
+      ctx,
+    );
+    expect(second.status).toBe('duplicate');
+    // No second log written.
+    expect(readdirSync(sessionsDir).filter((f) => f.endsWith('.md'))).toHaveLength(1);
+  });
+
+  it('redacts findings into the session log when scanner returns redacted', async () => {
+    // Add a secret-shaped string to the transcript.
+    writeFileSync(
+      transcriptPath,
+      [
+        JSON.stringify({
+          type: 'user',
+          message: { role: 'user', content: 'key is sk-abc123 do not share' },
+        }),
+      ].join('\n'),
+    );
+    const result = await captureSession(
+      { session_id: 'secret-1', transcript_path: transcriptPath, hook_event_name: 'Stop' },
+      { sessionsDir, scan: fakeScanner('redact') },
+    );
+    expect(result.status).toBe('written');
+    expect(result.gitleaksStatus).toBe('redacted');
+
+    const log = readFileSync(
+      join(sessionsDir, readdirSync(sessionsDir).filter((f) => f.endsWith('.md'))[0] as string),
+      'utf8',
+    );
+    expect(log).toContain('[REDACTED:test-secret]');
+    expect(log).not.toContain('sk-abc123');
+  });
+
+  it('aborts without writing when the scanner is blocked', async () => {
+    const result = await captureSession(
+      { session_id: 'x', transcript_path: transcriptPath, hook_event_name: 'Stop' },
+      { sessionsDir, scan: fakeScanner('blocked') },
+    );
+    expect(result.status).toBe('gitleaks-blocked');
+    expect(result.error).toContain('fake blocked');
+    expect(readdirSync(sessionsDir).filter((f) => f.endsWith('.md'))).toHaveLength(0);
+  });
+
+  it('returns no-transcript when transcript_path is missing', async () => {
+    const result = await captureSession(
+      { session_id: 'x', transcript_path: '/nonexistent/path.jsonl', hook_event_name: 'Stop' },
+      { sessionsDir, scan: fakeScanner('clean') },
+    );
+    expect(result.status).toBe('no-transcript');
+  });
+
+  it('returns no-content when the transcript has no user or assistant text', async () => {
+    writeFileSync(transcriptPath, JSON.stringify({ type: 'system', content: 'nothing' }));
+    const result = await captureSession(
+      { session_id: 'x', transcript_path: transcriptPath, hook_event_name: 'Stop' },
+      { sessionsDir, scan: fakeScanner('clean') },
+    );
+    expect(result.status).toBe('no-content');
+  });
+
+  it('uses captured_by derived from hook_event_name', async () => {
+    const result = await captureSession(
+      { session_id: 'pc', transcript_path: transcriptPath, hook_event_name: 'PreCompact' },
+      { sessionsDir, scan: fakeScanner('clean') },
+    );
+    expect(result.status).toBe('written');
+    const log = readFileSync(
+      join(sessionsDir, readdirSync(sessionsDir).filter((f) => f.endsWith('.md'))[0] as string),
+      'utf8',
+    );
+    const fm = matter(log).data as { captured_by: string };
+    expect(fm.captured_by).toBe('pre_compact');
+  });
+});

--- a/tests/lib/dedup-cache.test.ts
+++ b/tests/lib/dedup-cache.test.ts
@@ -1,0 +1,49 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { isDuplicate, recordHash } from '../../src/lib/dedup-cache.js';
+import { cleanSandbox, makeSandbox } from '../helpers.js';
+
+describe('dedup-cache', () => {
+  let sandbox: string;
+  let cacheFile: string;
+
+  beforeEach(() => {
+    sandbox = makeSandbox();
+    cacheFile = join(sandbox, '.dedup-cache.json');
+  });
+  afterEach(() => cleanSandbox(sandbox));
+
+  it('returns false for an unseen hash', () => {
+    expect(isDuplicate(cacheFile, 'sha256:abc')).toBe(false);
+  });
+
+  it('records a hash and recognizes a repeat as duplicate', () => {
+    recordHash(cacheFile, 'sha256:abc');
+    expect(isDuplicate(cacheFile, 'sha256:abc')).toBe(true);
+  });
+
+  it('expires entries older than the 5-minute window', () => {
+    const t0 = Date.UTC(2026, 4, 11, 12, 0, 0); // 2026-05-11T12:00:00Z
+    recordHash(cacheFile, 'sha256:old', t0);
+    // 6 minutes later — outside the 5-minute window.
+    const t1 = t0 + 6 * 60 * 1000;
+    expect(isDuplicate(cacheFile, 'sha256:old', t1)).toBe(false);
+  });
+
+  it('treats a missing cache file as empty', () => {
+    expect(isDuplicate(cacheFile, 'sha256:nope')).toBe(false);
+    expect(existsSync(cacheFile)).toBe(false);
+  });
+
+  it('writes a valid JSON cache file (schema_version + entries)', () => {
+    recordHash(cacheFile, 'sha256:abc');
+    const parsed = JSON.parse(readFileSync(cacheFile, 'utf8')) as {
+      schema_version: number;
+      entries: Array<{ hash: string; expires_at: string }>;
+    };
+    expect(parsed.schema_version).toBe(1);
+    expect(parsed.entries).toHaveLength(1);
+    expect(parsed.entries[0]?.hash).toBe('sha256:abc');
+  });
+});

--- a/tests/lib/gitleaks.test.ts
+++ b/tests/lib/gitleaks.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { redactSecrets, type GitleaksFinding } from '../../src/lib/gitleaks.js';
+
+describe('redactSecrets', () => {
+  it('replaces single secrets with [REDACTED:RuleID]', () => {
+    const text = 'Hello SECRETXYZ world.';
+    const findings: GitleaksFinding[] = [{ RuleID: 'generic-api-key', Secret: 'SECRETXYZ' }];
+    expect(redactSecrets(text, findings)).toBe('Hello [REDACTED:generic-api-key] world.');
+  });
+
+  it('redacts longest secrets first to avoid partial overlap', () => {
+    const text = 'AKIAFOO and AKIAFOO12345.';
+    const findings: GitleaksFinding[] = [
+      { RuleID: 'short', Secret: 'AKIAFOO' },
+      { RuleID: 'long', Secret: 'AKIAFOO12345' },
+    ];
+    const out = redactSecrets(text, findings);
+    expect(out).toBe('[REDACTED:short] and [REDACTED:long].');
+  });
+
+  it('redacts every occurrence of the same secret', () => {
+    const findings: GitleaksFinding[] = [{ RuleID: 'token', Secret: 'tok_123' }];
+    expect(redactSecrets('A tok_123 B tok_123', findings)).toBe(
+      'A [REDACTED:token] B [REDACTED:token]',
+    );
+  });
+
+  it('skips findings with empty Secret', () => {
+    const findings: GitleaksFinding[] = [{ RuleID: 'r', Secret: '' }];
+    expect(redactSecrets('unchanged', findings)).toBe('unchanged');
+  });
+
+  it('returns unmodified text when no findings', () => {
+    expect(redactSecrets('clean text', [])).toBe('clean text');
+  });
+});

--- a/tests/lib/queue.test.ts
+++ b/tests/lib/queue.test.ts
@@ -1,0 +1,51 @@
+import { existsSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { appendToQueue, readQueue } from '../../src/lib/queue.js';
+import type { QueueEntry } from '../../src/lib/schemas.js';
+import { cleanSandbox, makeSandbox } from '../helpers.js';
+
+function entry(id: string): QueueEntry {
+  return {
+    session_id: id,
+    session_log: `${id}.md`,
+    captured_by: 'stop',
+    captured_at: '2026-05-11T12:00:00Z',
+    attempts: 0,
+  };
+}
+
+describe('queue', () => {
+  let sandbox: string;
+  let queueFile: string;
+
+  beforeEach(() => {
+    sandbox = makeSandbox();
+    queueFile = join(sandbox, '.queue.json');
+  });
+  afterEach(() => cleanSandbox(sandbox));
+
+  it('readQueue returns empty when missing', () => {
+    expect(readQueue(queueFile)).toEqual({ schema_version: 1, entries: [] });
+  });
+
+  it('appends entries cumulatively', () => {
+    appendToQueue(queueFile, entry('a'));
+    appendToQueue(queueFile, entry('b'));
+    const q = readQueue(queueFile);
+    expect(q.entries.map((e) => e.session_id)).toEqual(['a', 'b']);
+  });
+
+  it('appends atomically (no .tmp file left behind)', () => {
+    appendToQueue(queueFile, entry('a'));
+    expect(existsSync(`${queueFile}.tmp`)).toBe(false);
+    expect(existsSync(queueFile)).toBe(true);
+  });
+
+  it('tolerates a malformed existing queue file (resets to empty + appends)', () => {
+    writeFileSync(queueFile, 'not json{');
+    appendToQueue(queueFile, entry('a'));
+    const q = readQueue(queueFile);
+    expect(q.entries.map((e) => e.session_id)).toEqual(['a']);
+  });
+});

--- a/tests/lib/session-log.test.ts
+++ b/tests/lib/session-log.test.ts
@@ -1,0 +1,42 @@
+import matter from 'gray-matter';
+import { describe, expect, it } from 'vitest';
+import { buildSessionLogFilename, renderSessionLog } from '../../src/lib/session-log.js';
+import { SessionLogFrontmatterSchema } from '../../src/lib/schemas.js';
+
+describe('renderSessionLog', () => {
+  it('produces frontmatter that validates against the Zod schema', () => {
+    const md = renderSessionLog({
+      sessionId: 'abc',
+      capturedBy: 'stop',
+      capturedAt: '2026-05-11T12:00:00.000Z',
+      transcriptHash: 'sha256:deadbeef',
+      gitleaksStatus: 'clean',
+      body: '[USER]: hi\n\n[AGENT]: hello',
+    });
+    const parsed = matter(md);
+    const result = SessionLogFrontmatterSchema.safeParse(parsed.data);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.session_id).toBe('abc');
+      expect(result.data.captured_by).toBe('stop');
+      expect(result.data.gitleaks_status).toBe('clean');
+      expect(result.data.stage_2_status).toBe('pending');
+    }
+    expect(parsed.content).toContain('## Stage 1: redacted transcript slice');
+    expect(parsed.content).toContain('[USER]: hi');
+  });
+});
+
+describe('buildSessionLogFilename', () => {
+  it('uses YYYYMMDD-HHmm prefix and sanitized id', () => {
+    expect(buildSessionLogFilename('2026-05-11T12:34:00.000Z', 'sess-abc/123')).toBe(
+      '20260511-1234-sessabc123.md',
+    );
+  });
+
+  it('falls back to "session" when id has no alphanumerics', () => {
+    expect(buildSessionLogFilename('2026-05-11T12:34:00.000Z', '___')).toBe(
+      '20260511-1234-session.md',
+    );
+  });
+});

--- a/tests/lib/transcript.test.ts
+++ b/tests/lib/transcript.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { parseTranscriptJsonl, renderRoleTagged } from '../../src/lib/transcript.js';
+
+describe('parseTranscriptJsonl', () => {
+  it('extracts user and assistant text from JSONL', () => {
+    const jsonl = [
+      JSON.stringify({ type: 'user', message: { role: 'user', content: 'Hello' } }),
+      JSON.stringify({
+        type: 'assistant',
+        message: { role: 'assistant', content: [{ type: 'text', text: 'Hi there' }] },
+      }),
+      JSON.stringify({ type: 'user', message: { role: 'user', content: 'Use bravo_pii cache.' } }),
+    ].join('\n');
+
+    const parsed = parseTranscriptJsonl(jsonl);
+    expect(parsed.user).toEqual(['Hello', 'Use bravo_pii cache.']);
+    expect(parsed.agent).toEqual(['Hi there']);
+    expect(parsed.interleaved.map((s) => s.role)).toEqual(['user', 'agent', 'user']);
+  });
+
+  it('ignores tool_use and system blocks but keeps text blocks', () => {
+    const jsonl = [
+      JSON.stringify({
+        type: 'assistant',
+        message: {
+          role: 'assistant',
+          content: [
+            { type: 'text', text: 'Reading file...' },
+            { type: 'tool_use', id: 'x', name: 'Read', input: {} },
+          ],
+        },
+      }),
+      JSON.stringify({ type: 'system', content: 'compaction notice' }),
+    ].join('\n');
+
+    const parsed = parseTranscriptJsonl(jsonl);
+    expect(parsed.agent).toEqual(['Reading file...']);
+    expect(parsed.user).toEqual([]);
+  });
+
+  it('skips malformed JSON lines silently', () => {
+    const jsonl = [
+      'not json',
+      JSON.stringify({ type: 'user', message: { role: 'user', content: 'ok' } }),
+      '',
+    ].join('\n');
+    const parsed = parseTranscriptJsonl(jsonl);
+    expect(parsed.user).toEqual(['ok']);
+  });
+
+  it('renders role-tagged transcript with USER / AGENT prefixes', () => {
+    const t = {
+      user: ['hi'],
+      agent: ['hello'],
+      interleaved: [
+        { role: 'user' as const, text: 'hi' },
+        { role: 'agent' as const, text: 'hello' },
+      ],
+    };
+    expect(renderRoleTagged(t)).toBe('[USER]: hi\n\n[AGENT]: hello');
+  });
+});

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,16 +1,32 @@
 import { defineConfig } from 'tsup';
 
-export default defineConfig({
-  entry: ['src/cli.ts'],
-  format: ['esm'],
-  target: 'node22',
-  splitting: false,
-  sourcemap: true,
-  clean: true,
-  dts: false,
-  minify: false,
-  shims: false,
-  banner: {
-    js: '#!/usr/bin/env node',
+export default defineConfig([
+  {
+    entry: { cli: 'src/cli.ts' },
+    format: ['esm'],
+    target: 'node22',
+    splitting: false,
+    sourcemap: true,
+    clean: true,
+    dts: false,
+    minify: false,
+    shims: false,
+    banner: { js: '#!/usr/bin/env node' },
   },
-});
+  {
+    // Hooks ship as compiled, self-contained .mjs files. We use the
+    // .mjs extension so they run as ESM in consumer repos regardless
+    // of the consumer's package.json `type` field.
+    entry: { 'kb-capture': 'src/hooks/kb-capture.ts' },
+    outDir: 'dist/hooks',
+    format: ['esm'],
+    target: 'node22',
+    splitting: false,
+    sourcemap: false,
+    clean: false,
+    dts: false,
+    minify: false,
+    shims: false,
+    outExtension: () => ({ js: '.mjs' }),
+  },
+]);


### PR DESCRIPTION
## Summary

Ships **Phase M1** of `@e0ipso/ai-knowledge-base`: the deterministic stage-1 capture pipeline. A single compiled hook (`.claude/hooks/kb-capture.mjs`) registers against all three Claude Code events from this phase — `Stop`, `SessionEnd`, and `PreCompact` — per IMPLEMENTATION.md §5.1. PreCompact in particular is wired up now, not deferred, to keep content that's about to be compacted from being lost.

### Pipeline

```
Stop / SessionEnd / PreCompact
  └─ parse role-tagged transcript from the JSONL at transcript_path
  └─ SHA-256 over the slice; 5-minute rolling dedup cache
  └─ gitleaks scan + redact (or abort with gitleaks_status: blocked)
  └─ write _sessions/<YYYYMMDD-HHmm-id>.md with stage_2_status: pending
  └─ atomic append to _sessions/.queue.json
```

Hard 1-second wall-clock deadline; on overrun the hook exits silently so it never blocks session shutdown. `KB_BUILDER_INTERNAL=1` recursion guard prevents the M2 drain (and the future curator subprocess) from re-triggering capture on their own internal sessions.

### What landed

- **Compiled hook bundle** at `src/hooks/kb-capture.ts` → `dist/hooks/kb-capture.mjs` (13.7 KB). `.mjs` extension is required so the script runs as ESM in consumer repos regardless of their `package.json` `type` field.
- **Lib modules** under `src/lib/`: `schemas.ts` (Zod, every new state file carries `schema_version: 1`), `transcript.ts`, `dedup-cache.ts`, `gitleaks.ts` (injectable `GitleaksScanner` for hermetic tests), `queue.ts` (atomic append via temp + rename), `session-log.ts`, `capture.ts` (orchestrator).
- **Adapter:** `ClaudeAdapter.readTranscript()` is now implemented; `runHeadless()` remains stubbed for M2.
- **`init` updated** to register Stop / SessionEnd / PreCompact in `.claude/settings.json` and copy the compiled hook into `.claude/hooks/`.
- **Build pipeline:** tsup now emits two entries; `build-templates` runs after tsup and copies compiled hooks into `templates/claude/hooks/`. `prepare` chains both in order.

### Schemas (all `schema_version: 1`)

- Session-log frontmatter: `session_id`, `captured_by`, `captured_at`, `transcript_hash`, `stage_2_status`, `stage_2_completed_at`, `stage_2_error`, `stage_2_log`, `gitleaks_status`, `topics`, `proposals.{practice,map}`.
- Queue file: `{ schema_version, entries: [{ session_id, session_log, captured_by, captured_at, attempts }] }`.
- Dedup cache: `{ schema_version, entries: [{ hash, expires_at }] }` with a 5-minute TTL.

### Docs

- New page: `docs/reference/hook-events.md` — events table, recursion guard, failure modes, settings.json shape.
- `docs/reference/cli.md` — `init` now lists hook/hook-bundle outputs.
- `docs/getting-started/installation.md` — calls out the hook registration with a link to the events page.

## Test plan

- [x] `npm test` — 45 passing + 1 skipped (real-gitleaks E2E gate)
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] Manual sanity-check: `init` in a sandbox produces `.claude/hooks/kb-capture.mjs` plus the three event registrations in `.claude/settings.json`
- [ ] (Manual, follow-up) Verify the hook fires on a real Claude Code session for each of Stop / SessionEnd / PreCompact and writes a redacted log within the 1-second deadline
- [ ] (Manual, follow-up) Stress-test PreCompact on a long session per IMPLEMENTATION.md §12

### New tests

- `tests/lib/transcript.test.ts` — JSONL → role-tagged conversion, malformed-line tolerance, role-tagged rendering
- `tests/lib/dedup-cache.test.ts` — 5-minute TTL, missing-file handling, schema-valid output
- `tests/lib/queue.test.ts` — atomic append, malformed-file recovery, no leftover `.tmp`
- `tests/lib/gitleaks.test.ts` — `redactSecrets` pure function (longest-first ordering, repeats, empty-secret guard)
- `tests/lib/session-log.test.ts` — frontmatter validates against the Zod schema; filename builder corner cases
- `tests/lib/capture.test.ts` — full pipeline with an injected fake scanner: clean / redacted / blocked / duplicate / no-content / no-transcript / `captured_by` mapping
- `tests/hooks/kb-capture.test.ts` — spawned-bundle smoke: recursion guard, empty stdin, missing transcript, gitleaks-missing graceful failure (or success when gitleaks is on PATH)
- `tests/init.test.ts` — extended to assert `.claude/hooks/kb-capture.mjs` is copied and the three hook registrations land in `.claude/settings.json`

https://claude.ai/code/session_01CnFySzThho11FT64YcFDHu

---
_Generated by [Claude Code](https://claude.ai/code/session_01CnFySzThho11FT64YcFDHu)_