### PR TITLE
feat(M2): stage-2 drain hook with claude -p subprocess

### DIFF
--- a/docs/customization/index.md
+++ b/docs/customization/index.md
@@ -1,19 +1,16 @@
 ---
 title: Customization
 nav_order: 5
-has_children: false
+has_children: true
 permalink: /customization/
 ---
 
 # Customization
 
-_Filled in across M2–M3.5._
+Pages:
 
-Topics:
+- [Editing the stage-2 prompt](stage-2-prompt.md) — tune the capture extractor for your project's vocabulary.
+- Editing the curator prompt — _coming in M3._
+- Editing the bootstrap-incremental prompt — _coming in M3.5._
 
-- Editing the stage-2 extraction prompt (`templates/prompts/stage-2-extract.md`).
-- Editing the curator prompt (`templates/prompts/curator.md`).
-- Editing the bootstrap-incremental prompt (`templates/prompts/bootstrap-incremental.md`).
-- Settings reference (`.ai/knowledge-base/.config.json` and `~/.config/@e0ipso/ai-knowledge-base/config.json`).
-
-Prompts are copied to `.ai/.kb-builder/prompts/` during `init` so you can override locally; hooks pick up the local copy if present and fall back to the bundled template.
+Prompts are copied to `.ai/.kb-builder/prompts/` during `init` so you can override locally; hooks pick up the local copy if present and fall back to the bundled template. Reference settings live under [Reference > Settings](../reference/settings.md).

--- a/docs/customization/stage-2-prompt.md
+++ b/docs/customization/stage-2-prompt.md
@@ -1,0 +1,52 @@
+---
+title: Editing the stage-2 prompt
+parent: Customization
+nav_order: 1
+---
+
+# Editing the stage-2 extraction prompt
+
+The stage-2 prompt is the single most important quality lever in capture. It controls what the extractor treats as worth remembering and what it drops as noise. You should re-read it before tweaking it and re-run the fixture transcripts after every change.
+
+## Where the prompt lives
+
+Two copies of the prompt template exist:
+
+| Location | Used by | When edited |
+|---|---|---|
+| `templates/prompts/stage-2-extract.md` (inside the npm package) | First-time fallback if no per-repo override exists. | Edit upstream and bump the package version. |
+| `.ai/.kb-builder/prompts/stage-2-extract.md` (inside your repo, copied by `init`) | The stage-2 drain hook prefers this copy. | Edit locally to tune the extractor for your project's vocabulary. |
+
+When the drain hook spawns `claude -p`, it loads the override copy if present and falls back to the bundled template otherwise. The override is plain markdown — commit it like any other project asset.
+
+## Anatomy of the prompt
+
+The prompt has six sections:
+
+1. **Frontmatter comment** — `Version: N`. Bump this whenever you change behavior; the version is independent of the npm package version but should be noted in your project's changelog so reviewers know to re-calibrate fixtures.
+2. **"What you are looking for"** — defines practice and map nodes, lists trigger phrases ("no, use…", "we always…", "we have a…", named-entity introductions).
+3. **"What you are NOT looking for"** — the anti-examples that suppress noise: typos, file reads, agent paraphrases, generic programming knowledge.
+4. **Ownership boundary** — splits combined statements into a practice piece (imperative) and a map piece (named entity). Both passes never both capture the same content.
+5. **Inline example** — a small worked transcript with the expected JSON output. The most concrete signal to the model about what good output looks like.
+6. **Output schema** — the exact JSON shape the drain expects. `{ "practice": [...], "map": [...] }`, each candidate carrying `kind`, `tags`, `title`, `summary`, `body`, `confidence`, `supports_existing_node`, `contradicts_existing_node`.
+
+## Substitution
+
+The drain replaces the placeholder line `[TRANSCRIPT PLACEHOLDER — substituted at runtime]` with the redacted transcript slice from the session log. If you remove the placeholder, the drain appends the transcript at the end of the prompt instead — both shapes work, but keeping the placeholder lets you control exactly where in the prompt the transcript lands.
+
+## Calibrating with fixtures
+
+Two synthetic transcripts under `tests/fixtures/transcripts/` form the calibration targets:
+
+- **`routine-zero/`** — a session with no teaching moments. Correct output: empty `practice` and `map` arrays. If your prompt change causes this fixture to produce capture, the prompt is now over-capturing.
+- **`bravo-insider/`** — a session with four practice candidates (constructor DI, analytics dispatcher, per-user cache tags, schema.org emitter) and three map candidates (Bravo Insider, dispatcher, schema_emitter). The `expected.md` file in that directory is the canonical target.
+
+Run the fixtures end-to-end with the real `claude` CLI before shipping a prompt change. The mocked unit tests pin the schema and drain behaviour, but only the real `claude -p` invocation reveals whether the prompt still produces good output.
+
+## Schema-aware editing
+
+Output shape must continue to match `Stage2OutputSchema` (see `src/lib/schemas.ts`). Adding new fields to candidates is safe — the schema currently rejects unknown fields, so you'd also need to extend the Zod schema. Bump `schema_version` from 1 → 2 only if you remove a field, rename a field, or change a field's semantics; new optional fields do not bump the version (see [CONTRIBUTING.md](https://github.com/e0ipso/ai-knowledge-base/blob/main/CONTRIBUTING.md#schema-version-bump-policy)).
+
+## Reverting
+
+The drain hook always prefers the override copy. To revert to the bundled prompt without re-running `init`, delete `.ai/.kb-builder/prompts/stage-2-extract.md`. The next drain will load the package's bundled version.

--- a/docs/reference/hook-events.md
+++ b/docs/reference/hook-events.md
@@ -6,7 +6,10 @@ nav_order: 3
 
 # Hook events
 
-`init` registers a single hook script — `.claude/hooks/kb-capture.mjs` — against three Claude Code events. The script implements the **stage-1 capture** pipeline: dedup, secret-scan with redaction, write a session log to `.ai/knowledge-base/_sessions/`, and append to `.queue.json` for the stage-2 worker.
+`init` registers two hook scripts:
+
+- `.claude/hooks/kb-capture.mjs` — runs on `Stop`, `SessionEnd`, and `PreCompact`. Implements **stage-1 capture**: dedup, secret-scan with redaction, write a session log, append to `.queue.json`.
+- `.claude/hooks/kb-stage2-drain.mjs` — runs on `SessionStart` with `async: true`. Drains the stage-2 queue by spawning `claude -p` for each pending session log; updates the log's frontmatter with the structured extraction output.
 
 ## Registered events
 
@@ -15,12 +18,13 @@ nav_order: 3
 | `Stop` | Captures after every assistant turn ends. The transcript hash changes turn-by-turn, so this produces one log per substantive checkpoint within a session. | Synchronous, ≤1 s deadline. Dedup window prevents overlap with the other two events. |
 | `SessionEnd` | Captures when the user explicitly closes or clears the session. The strongest signal that the session is done. | Same pipeline as `Stop`. |
 | `PreCompact` | Fires immediately before Claude Code compacts context. Without this, content about to be discarded would be lost. | Same pipeline as `Stop`. The 1-second deadline still applies; if you have a very long transcript and capture would exceed it, the hook exits silently rather than blocking compaction. |
+| `SessionStart` | Runs the **stage-2 drain** (M2). For each entry in `.queue.json`, spawns `claude -p --output-format stream-json --verbose` against the redacted transcript slice and writes the structured extraction back into the session log's frontmatter. | `async: true` — stdout does not flow into the parent session. Stops after `drainBound` entries (default 5), the rest are deferred to the next session. |
 
-All three events route through the same script, so the only difference in the resulting session log is the `captured_by` frontmatter field (`stop`, `session_end`, or `pre_compact`).
+The three stage-1 events route through the same `kb-capture.mjs` script, so the only difference in the resulting session log is the `captured_by` frontmatter field (`stop`, `session_end`, or `pre_compact`). `SessionStart` is wired separately to `kb-stage2-drain.mjs`.
 
 ## Recursion guard
 
-The hook checks `KB_BUILDER_INTERNAL=1` in its environment and exits immediately if set. Stage-2 (M2) and the curator (M3) spawn `claude -p` subprocesses with this env var so that the child Claude Code instance doesn't fire its own capture hooks and trigger recursive work.
+Both hooks check `KB_BUILDER_INTERNAL=1` in their environment and exit immediately if set. The stage-2 drain (and the curator in M3) spawns `claude -p` subprocesses with this env var so that the child Claude Code instance doesn't fire its own capture or drain hooks and trigger recursive work.
 
 If you wrap the `claude` CLI in a script that spawns sessions for any reason, set `KB_BUILDER_INTERNAL=1` in those subprocesses.
 
@@ -37,7 +41,18 @@ If you wrap the `claude` CLI in a script that spawns sessions for any reason, se
 
 - Run the LLM. Stage 2 (M2) reads the queue asynchronously on the next `SessionStart` and spawns `claude -p` to produce structured proposals.
 - Block on long operations. The hook has a hard 1-second deadline. If anything (gitleaks, disk I/O) goes long, the hook exits silently and the content for that trigger is lost. Subsequent triggers (the next Stop, SessionEnd, PreCompact) will re-attempt.
-- Capture anything on `SessionStart`. That event is reserved for the stage-2 drain hook (M2) and the consume-side INDEX injection hook (M4).
+
+## Stage 2 (drain on SessionStart)
+
+The drain hook is async, so the user does not wait on it. Per invocation:
+
+1. **Recursion guard.** Exits immediately if `KB_BUILDER_INTERNAL=1` is set (the env var the drain itself sets on the children it spawns).
+2. **Lock.** Acquires the stage-2 lock in `.ai/.kb-builder/state.json` (PID + 30-minute TTL). If another drain is already running, this invocation exits without doing anything. Stale locks are reclaimed after TTL.
+3. **Load the prompt.** Prefers the per-repo override at `.ai/.kb-builder/prompts/stage-2-extract.md` (written by `init`); falls back to the version bundled with the package.
+4. **Iterate the queue.** Up to `drainBound` (default 5) entries per invocation. The rest are deferred to subsequent sessions.
+5. **Per entry:** loads the session log, extracts the redacted transcript slice, substitutes it into the prompt, spawns `claude -p --allowedTools '' --output-format stream-json --verbose`, and writes the full stream into `.ai/knowledge-base/_logs/stage-2/<session-id>__<timestamp>.jsonl`.
+6. **Parse the final result message.** Validated against the stage-2 Zod schema. On success: the session log's frontmatter is updated with `stage_2_status: done`, the log path, the populated `proposals.{practice,map}` arrays, and a deduped `topics` list.
+7. **Failure handling.** Parse error, schema mismatch, non-zero exit, or timeout (`stage2Timeout`, default 60 s) all count as one failed attempt. The entry rotates to the back of the queue with `attempts` incremented. After 3 attempts, the session log is marked `stage_2_status: skipped` and the entry is removed.
 
 ## Failure modes
 
@@ -72,4 +87,24 @@ After `init`, `.claude/settings.json` contains a block per event:
 }
 ```
 
-The same pattern repeats for `SessionEnd` and `PreCompact`. Existing user-defined hooks in the same file are preserved on re-init.
+The same pattern repeats for `SessionEnd` and `PreCompact`. `SessionStart` carries `"async": true` so the drain does not block session startup:
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "KB_BUILDER_HOOK=SessionStart node .claude/hooks/kb-stage2-drain.mjs",
+            "async": true
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Existing user-defined hooks in the same file are preserved on re-init.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -8,7 +8,8 @@ permalink: /reference/
 # Reference
 
 - [CLI commands](cli.md) — every `ai-knowledge-base` subcommand.
-- [Hook events](hook-events.md) — the three capture triggers and the recursion guard.
+- [Hook events](hook-events.md) — the four registered Claude Code events (capture + stage-2 drain).
+- [Settings](settings.md) — defaults for the stage-2 drain (bounds, timeouts, lock TTL).
 - Slash commands — _coming in M3._
 - Frontmatter schemas — _coming in M4._
 - Failure modes — _coming progressively._

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -1,0 +1,62 @@
+---
+title: Settings
+parent: Reference
+nav_order: 4
+---
+
+# Settings
+
+Settings are not yet exposed as a `.config.json` file (planned for M3). The defaults baked into the package are documented below for completeness.
+
+## Stage-2 drain (M2)
+
+These settings live in `src/lib/stage2-drain.ts` and `src/lib/headless.ts`. They are not currently user-configurable; the values are the result of "what makes sense for a small-to-medium KB and a single contributor."
+
+| Setting | Default | Where applied | Behavior |
+|---|---|---|---|
+| `drainBound` | 5 entries | `drainStage2Queue` | Maximum number of queue entries processed per `SessionStart` invocation. Remaining entries are deferred to the next session. Keeps a long backlog from blocking a quick session start, even though the hook is async. |
+| `maxAttempts` | 3 attempts | `drainStage2Queue` | A queue entry that fails (parse error, schema mismatch, timeout, non-zero exit) is rotated to the back of the queue with `attempts` incremented. After the third failure the session log is marked `stage_2_status: skipped` and the entry is removed from the queue. |
+| `stage2Timeout` | 60,000 ms | `runHeadlessClaude` | Per-entry wall-clock deadline for the spawned `claude -p` subprocess. A timeout counts as a failed attempt for retry purposes. |
+| `lockTtl` | 30 minutes | `acquireLock` | If a `state.json` lock is older than its TTL it is treated as stale and reclaimed. Prevents a crashed drain from blocking subsequent runs forever. |
+
+## Stage-2 drain lock
+
+`.ai/.kb-builder/state.json` carries `{ schema_version: 1, lock?: { name, pid, acquired_at, ttl_ms }, last_nudged_at? }`. The lock guards against two concurrent `SessionStart` events draining the same queue. Fields:
+
+| Field | Purpose |
+|---|---|
+| `name` | Always `"stage2-drain"` for the drain. Curator (M3) will use its own name. |
+| `pid` | The OS pid of the process holding the lock. Mostly informational; the lock is released by name+pid match. |
+| `acquired_at` | ISO 8601 timestamp. Compared against `ttl_ms` to decide whether a lock is stale. |
+| `ttl_ms` | Lock TTL in milliseconds. 1,800,000 (30 minutes) by default. |
+
+## Stage-2 log files
+
+Each drain invocation writes one stream-json file per processed entry under `.ai/knowledge-base/_logs/stage-2/`:
+
+```
+.ai/knowledge-base/_logs/stage-2/<session-id>__YYYYMMDDTHHMMSSZ.jsonl
+```
+
+The path is recorded in the session log's `stage_2_log` field. Logs are gitignored by default. See [Troubleshooting > Reading the stage-2 log](../troubleshooting/reading-stage-2-logs.md).
+
+## Frontmatter changes on stage-2 completion
+
+When the drain succeeds for an entry, the session log's frontmatter is updated in place:
+
+```yaml
+stage_2_status: done
+stage_2_completed_at: 2026-05-11T10:00:00.000Z
+stage_2_error: null
+stage_2_log: _logs/stage-2/<session-id>__<timestamp>.jsonl
+topics: [pii, gdpr, drupal, di]
+proposals:
+  practice: [...candidate objects...]
+  map: [...candidate objects...]
+```
+
+On failure, only `stage_2_status` (`failed` or `skipped`), `stage_2_completed_at` (set only when `skipped`), `stage_2_error`, and `stage_2_log` are updated; `proposals` is left empty.
+
+## Future settings (planned for M3)
+
+`.ai/knowledge-base/.config.json` (committed) plus `~/.config/@e0ipso/ai-knowledge-base/config.json` (per-user override). Will surface: `drainBound`, `maxAttempts`, `stage2Timeout`, `lockTtl`, INDEX token budget, curation threshold, gitleaks ruleset path. Project settings win.

--- a/docs/troubleshooting/index.md
+++ b/docs/troubleshooting/index.md
@@ -1,17 +1,16 @@
 ---
 title: Troubleshooting
 nav_order: 7
-has_children: false
+has_children: true
 permalink: /troubleshooting/
 ---
 
 # Troubleshooting
 
-_Filled in progressively as failure modes are encountered in M1–M4._
+Pages:
 
-Topics:
+- [Reading stage-2 logs](reading-stage-2-logs.md) — interpreting the stream-json traces under `_logs/stage-2/`.
+- Reading curator logs — _coming in M3._
+- Common issues — _coming progressively in M3–M5._
 
-- Reading `_logs/stage-2/` and `_logs/curator/` (stream-json traces).
-- Common issues — gitleaks blocking a commit, stale `INDEX.md`, two concurrent curate runs, missing `derived_from` references.
-
-For now, see [PRD §9](https://github.com/e0ipso/ai-knowledge-base/blob/main/PRD.md#9-failure-modes-the-user-sees) for the canonical list of failure modes and recovery steps.
+For the canonical list of failure modes and recovery steps, see [PRD §9](https://github.com/e0ipso/ai-knowledge-base/blob/main/PRD.md#9-failure-modes-the-user-sees).

--- a/docs/troubleshooting/reading-stage-2-logs.md
+++ b/docs/troubleshooting/reading-stage-2-logs.md
@@ -1,0 +1,71 @@
+---
+title: Reading stage-2 logs
+parent: Troubleshooting
+nav_order: 1
+---
+
+# Reading the stage-2 log
+
+When stage-2 produces something unexpected, the full LLM trace is under `.ai/knowledge-base/_logs/stage-2/`. Files are JSONL — one JSON event per line — written by `claude -p --output-format stream-json --verbose`.
+
+## Finding the relevant log
+
+Each session log records its log path in the `stage_2_log` frontmatter field:
+
+```yaml
+stage_2_status: done
+stage_2_completed_at: 2026-05-11T10:00:00.000Z
+stage_2_log: _logs/stage-2/abc123__20260511T100000Z.jsonl
+```
+
+The path is relative to `.ai/knowledge-base/`.
+
+## Anatomy of a stream-json log
+
+A typical log has these lines, in order:
+
+| Line | Purpose | Notes |
+|---|---|---|
+| `{"type": "system", "subtype": "init", ...}` | Records the session id and the model the spawned `claude -p` actually used. | Use this to confirm which model produced the output. |
+| `{"type": "assistant", "message": {"content": [...]}}` (zero or more) | Each intermediate assistant turn. The extractor is single-pass, so usually only one or two of these. | The `content` is an array of blocks; text blocks have `{"type": "text", "text": "..."}`. |
+| `{"type": "user", "message": {"content": [...]}}` (occasional) | Only present if the prompt or stdin triggered a follow-up. | The extractor prompt is designed to produce a single response, so this is usually absent. |
+| `{"type": "result", "subtype": "success" \| "error", "is_error": bool, "result": "..."}` | The final message. The drain reads `result` as JSON and validates it against the stage-2 schema. | If `is_error: true`, the drain treats the run as failed regardless of content. |
+
+## Common failure patterns
+
+### "claude subprocess produced no final result message"
+
+The log has no `type: result` line. Causes:
+
+- The spawned `claude` was killed before completing — usually a timeout (default 60 s). Check the wall-clock timestamps of the first and last events.
+- A non-zero exit code from the CLI. Run `claude --version` and verify your auth is still valid.
+
+Recovery: the entry stays in the queue with `attempts` incremented and retries on the next session start. Three failures in a row mark the session log as `skipped`.
+
+### "stage-2 output did not match schema: …"
+
+The drain parsed the final `result` text as JSON but Zod rejected it. The most common cause is the model emitting extra prose before/after the JSON or skipping a required field (`tags`, `confidence`).
+
+Recovery options:
+
+1. Inspect the offending `result` text in the log. If the model is consistently producing the wrong shape, the prompt may need tuning — see [Editing the stage-2 prompt](../customization/stage-2-prompt.md).
+2. If it's a one-off, just let the drain retry on the next session.
+
+### "failed to parse final result as JSON"
+
+The `result` text isn't parseable JSON — the model emitted prose only. Same recovery as a schema mismatch.
+
+### A session log is marked `skipped`
+
+The drain exhausted 3 attempts and gave up. The session log is preserved (you can still read the redacted transcript), but it will never produce proposals via the drain. To force a re-extraction:
+
+1. Manually flip the session log's frontmatter: `stage_2_status: pending`, clear `stage_2_error`.
+2. Re-add it to `.ai/knowledge-base/_sessions/.queue.json` (or use the M3 `/kb:propose-from-session` slash command once that ships).
+
+## Log retention
+
+Logs grow without bound. v1.5 will ship `ai-knowledge-base logs prune --older-than <duration>`. For now, the directory is gitignored, so the only consequence is local disk usage — feel free to delete old subdirectories manually.
+
+## Privacy note
+
+The stream-json log contains the **redacted** transcript slice (the same content that goes into `_sessions/<id>.md`). Secrets that gitleaks caught in stage 1 are also redacted here. Secrets gitleaks missed could appear in the log — treat `_logs/` with the same care as `_sessions/`. Both are gitignored by default.

--- a/src/adapters/claude.ts
+++ b/src/adapters/claude.ts
@@ -1,5 +1,7 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
+import type { ZodSchema } from 'zod';
+import { runHeadlessClaude, type RunHeadlessOptions } from '../lib/headless.js';
 import { parseTranscriptJsonl } from '../lib/transcript.js';
 import type {
   Adapter,
@@ -94,12 +96,16 @@ export class ClaudeAdapter implements Adapter {
   }
 
   async runHeadless<T>(
-    _promptBody: string,
-    _stdin: string,
-    _schema: import('zod').ZodSchema<T>,
-    _opts?: HeadlessOpts,
+    promptBody: string,
+    stdin: string,
+    schema: ZodSchema<T>,
+    opts?: HeadlessOpts,
   ): Promise<T> {
-    throw new Error('runHeadless() is implemented in M2');
+    const runOpts: RunHeadlessOptions = {};
+    if (opts?.timeoutMs !== undefined) runOpts.timeoutMs = opts.timeoutMs;
+    if (opts?.allowedTools !== undefined) runOpts.allowedTools = opts.allowedTools;
+    if (opts?.logFile !== undefined) runOpts.logFile = opts.logFile;
+    return runHeadlessClaude(promptBody, stdin, schema, runOpts);
   }
 
   renderSlashCommand(spec: SlashCommandSpec): string {

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -78,6 +78,11 @@ export async function runInit(opts: InitOptions): Promise<void> {
       { event: 'Stop', scriptPath: '.claude/hooks/kb-capture.mjs' },
       { event: 'SessionEnd', scriptPath: '.claude/hooks/kb-capture.mjs' },
       { event: 'PreCompact', scriptPath: '.claude/hooks/kb-capture.mjs' },
+      {
+        event: 'SessionStart',
+        scriptPath: '.claude/hooks/kb-stage2-drain.mjs',
+        async: true,
+      },
     ]);
   }
 

--- a/src/hooks/kb-stage2-drain.ts
+++ b/src/hooks/kb-stage2-drain.ts
@@ -1,0 +1,103 @@
+/**
+ * SessionStart hook (async).
+ *
+ * Drains the stage-2 queue without blocking session start. For each queued
+ * entry it spawns `claude -p --output-format stream-json --verbose`, parses
+ * the final result, validates against the Zod schema, and updates the
+ * session log frontmatter.
+ *
+ * Configured in `.claude/settings.json` with `"async": true` so its stdout
+ * does not flow back into the parent session.
+ */
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { runHeadlessClaude } from '../lib/headless.js';
+import { findRepoRoot, packageTemplatesDir, repoPaths } from '../lib/paths.js';
+import { drainStage2Queue, type Stage2Runner } from '../lib/stage2-drain.js';
+
+const PACKAGE_TAG = '[ai-knowledge-base]';
+
+async function main(): Promise<void> {
+  // Recursion guard: the drain itself spawns `claude -p`, which fires
+  // SessionStart again inside the child. KB_BUILDER_INTERNAL=1 is set on
+  // every child by runHeadlessClaude.
+  if (process.env['KB_BUILDER_INTERNAL'] === '1') return;
+
+  const raw = await readStdin();
+  let input: { cwd?: unknown } = {};
+  if (raw.trim().length > 0) {
+    try {
+      input = JSON.parse(raw) as { cwd?: unknown };
+    } catch {
+      input = {};
+    }
+  }
+  const startCwd =
+    typeof input.cwd === 'string' && input.cwd.length > 0 ? input.cwd : process.cwd();
+  const root = findRepoRoot(startCwd);
+  const paths = repoPaths(root);
+  if (!existsSync(paths.installedVersionFile)) return;
+
+  const promptTemplate = loadStage2Prompt(root);
+  if (!promptTemplate) {
+    process.stderr.write(`${PACKAGE_TAG} stage-2 prompt template not found; skipping drain\n`);
+    return;
+  }
+
+  const runner: Stage2Runner = async (prompt, stdin, schema, opts) =>
+    runHeadlessClaude(prompt, stdin, schema, opts);
+
+  try {
+    const summary = await drainStage2Queue({
+      sessionsDir: paths.sessionsDir,
+      logsDir: paths.logsDir,
+      stateFile: join(paths.builderDir, 'state.json'),
+      promptTemplate,
+      runner,
+    });
+    if (summary.status === 'locked') {
+      // Another drain is in flight; nothing to do.
+      return;
+    }
+    // Async hook stdout is not injected into the parent session, so log to
+    // stderr only on failures the user should know about.
+    const failed = summary.processed.filter((p) => p.status === 'failed' || p.status === 'skipped');
+    if (failed.length > 0) {
+      process.stderr.write(
+        `${PACKAGE_TAG} stage-2 drain: ${failed.length} session(s) failed or skipped; see _logs/stage-2/\n`,
+      );
+    }
+  } catch (err) {
+    process.stderr.write(
+      `${PACKAGE_TAG} stage-2 drain error: ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+  }
+}
+
+function loadStage2Prompt(repoRoot: string): string | null {
+  // Prefer the per-repo override written by `init`; fall back to the
+  // template bundled with the npm package.
+  const override = join(repoRoot, '.ai/.kb-builder/prompts/stage-2-extract.md');
+  if (existsSync(override)) return readFileSync(override, 'utf8');
+  const bundled = join(packageTemplatesDir(), 'prompts/stage-2-extract.md');
+  if (existsSync(bundled)) return readFileSync(bundled, 'utf8');
+  return null;
+}
+
+function readStdin(): Promise<string> {
+  return new Promise((resolve) => {
+    if (process.stdin.isTTY) {
+      resolve('');
+      return;
+    }
+    let data = '';
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', (chunk: string) => {
+      data += chunk;
+    });
+    process.stdin.on('end', () => resolve(data));
+    process.stdin.on('error', () => resolve(''));
+  });
+}
+
+void main().catch(() => process.exit(0));

--- a/src/lib/headless.ts
+++ b/src/lib/headless.ts
@@ -1,0 +1,185 @@
+import { execa } from 'execa';
+import { createWriteStream, mkdirSync } from 'node:fs';
+import { dirname } from 'node:path';
+import { Readable } from 'node:stream';
+import split2 from 'split2';
+import type { ZodSchema } from 'zod';
+
+export const DEFAULT_TIMEOUT_MS = 60_000;
+
+export interface RunHeadlessOptions {
+  timeoutMs?: number;
+  allowedTools?: string[];
+  logFile?: string;
+  env?: NodeJS.ProcessEnv;
+  /** Test seam: substitute the underlying spawn. */
+  spawn?: SpawnFn;
+}
+
+export interface SpawnResult {
+  stdout: Readable;
+  result: Promise<{
+    exitCode: number | undefined;
+    failed: boolean;
+    timedOut: boolean;
+  }>;
+}
+
+export interface SpawnContext {
+  args: string[];
+  stdin: string;
+  env: NodeJS.ProcessEnv;
+  timeoutMs: number;
+}
+
+export type SpawnFn = (command: string, ctx: SpawnContext) => SpawnResult;
+
+interface StreamJsonMessage {
+  type?: string;
+  subtype?: string;
+  result?: string;
+  is_error?: boolean;
+  [key: string]: unknown;
+}
+
+const defaultSpawn: SpawnFn = (command, ctx) => {
+  const proc = execa(command, ctx.args, {
+    input: ctx.stdin,
+    env: ctx.env,
+    timeout: ctx.timeoutMs,
+    stdin: 'pipe',
+    stdout: 'pipe',
+    reject: false,
+  });
+  const stdout = proc.stdout as Readable;
+  const result = proc.then((r) => ({
+    exitCode: typeof r.exitCode === 'number' ? r.exitCode : undefined,
+    failed: r.failed === true,
+    timedOut: r.timedOut === true,
+  }));
+  return { stdout, result };
+};
+
+/**
+ * Invokes `claude -p` with stream-json verbose output. Each line of stdout is
+ * a JSON event; we mirror them into `logFile` (if given) as they arrive and
+ * search for the final `type: result` event. Its `result` text is parsed as
+ * JSON and validated against `schema`.
+ *
+ * The recursion guard env var (`KB_BUILDER_INTERNAL=1`) is always set on the
+ * child so that capture/drain hooks fired from the spawned process exit
+ * silently.
+ */
+export async function runHeadlessClaude<T>(
+  promptBody: string,
+  stdin: string,
+  schema: ZodSchema<T>,
+  opts: RunHeadlessOptions = {},
+): Promise<T> {
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const allowedTools = opts.allowedTools ?? [];
+  const args = [
+    '-p',
+    promptBody,
+    '--allowedTools',
+    allowedTools.join(','),
+    '--output-format',
+    'stream-json',
+    '--verbose',
+  ];
+  const env: NodeJS.ProcessEnv = {
+    ...(opts.env ?? process.env),
+    KB_BUILDER_INTERNAL: '1',
+  };
+  const spawn = opts.spawn ?? defaultSpawn;
+
+  let logStream: ReturnType<typeof createWriteStream> | null = null;
+  if (opts.logFile) {
+    mkdirSync(dirname(opts.logFile), { recursive: true });
+    logStream = createWriteStream(opts.logFile, { encoding: 'utf8', flags: 'a' });
+  }
+
+  const messages: StreamJsonMessage[] = [];
+  const { stdout, result: resultPromise } = spawn('claude', {
+    args,
+    stdin,
+    env,
+    timeoutMs,
+  });
+
+  const splitter = stdout.pipe(split2());
+  splitter.on('data', (line: string) => {
+    const trimmed = line.trim();
+    if (trimmed.length === 0) return;
+    if (logStream) logStream.write(`${trimmed}\n`);
+    try {
+      messages.push(JSON.parse(trimmed) as StreamJsonMessage);
+    } catch {
+      // Non-JSON line; ignore.
+    }
+  });
+  const streamDone = new Promise<void>((resolve, reject) => {
+    splitter.once('end', () => resolve());
+    splitter.once('error', (err) => reject(err));
+  });
+
+  let runResult;
+  try {
+    const [r] = await Promise.all([resultPromise, streamDone]);
+    runResult = r;
+  } finally {
+    if (logStream) {
+      await new Promise<void>((resolve) => logStream!.end(resolve));
+    }
+  }
+
+  if (runResult.timedOut) {
+    throw new Error(`claude subprocess timed out after ${timeoutMs}ms`);
+  }
+  if (runResult.failed || (runResult.exitCode !== undefined && runResult.exitCode !== 0)) {
+    throw new Error(
+      `claude subprocess failed (exit code ${String(runResult.exitCode ?? 'unknown')})`,
+    );
+  }
+
+  const finalResult = findFinalResult(messages);
+  if (finalResult === null) {
+    throw new Error('claude subprocess produced no final result message');
+  }
+
+  let parsedJson: unknown;
+  try {
+    parsedJson = JSON.parse(extractJsonBlock(finalResult));
+  } catch (err) {
+    throw new Error(
+      `failed to parse final result as JSON: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  const validated = schema.safeParse(parsedJson);
+  if (!validated.success) {
+    throw new Error(`stage-2 output did not match schema: ${validated.error.message}`);
+  }
+  return validated.data;
+}
+
+function findFinalResult(messages: StreamJsonMessage[]): string | null {
+  for (let i = messages.length - 1; i >= 0; i -= 1) {
+    const m = messages[i];
+    if (m && m.type === 'result') {
+      if (m.is_error === true) return null;
+      if (typeof m.result === 'string') return m.result;
+    }
+  }
+  return null;
+}
+
+/**
+ * Tolerates models that wrap their JSON in ```json fences or include
+ * preamble/trailing whitespace. Falls back to the raw string.
+ */
+function extractJsonBlock(text: string): string {
+  const fence = text.match(/```(?:json)?\s*([\s\S]*?)```/);
+  if (fence && fence[1]) return fence[1].trim();
+  return text.trim();
+}

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -57,3 +57,43 @@ export const DedupCacheFileSchema = z.object({
 });
 
 export type DedupCacheFile = z.infer<typeof DedupCacheFileSchema>;
+
+export const ConfidenceSchema = z.enum(['low', 'medium', 'high']);
+export type Confidence = z.infer<typeof ConfidenceSchema>;
+
+export const Stage2CandidateSchema = z.object({
+  kind: z.enum(['practice', 'map']),
+  tags: z.array(z.string()),
+  title: z.string(),
+  summary: z.string(),
+  body: z.string(),
+  confidence: ConfidenceSchema,
+  supports_existing_node: z.string().nullable(),
+  contradicts_existing_node: z.string().nullable(),
+});
+
+export type Stage2Candidate = z.infer<typeof Stage2CandidateSchema>;
+
+export const Stage2OutputSchema = z.object({
+  practice: z.array(Stage2CandidateSchema),
+  map: z.array(Stage2CandidateSchema),
+});
+
+export type Stage2Output = z.infer<typeof Stage2OutputSchema>;
+
+export const StateLockSchema = z.object({
+  name: z.string(),
+  pid: z.number().int(),
+  acquired_at: z.string(),
+  ttl_ms: z.number().int().positive(),
+});
+
+export type StateLock = z.infer<typeof StateLockSchema>;
+
+export const StateFileSchema = z.object({
+  schema_version: z.literal(1),
+  lock: StateLockSchema.nullable().optional(),
+  last_nudged_at: z.string().nullable().optional(),
+});
+
+export type StateFile = z.infer<typeof StateFileSchema>;

--- a/src/lib/stage2-drain.ts
+++ b/src/lib/stage2-drain.ts
@@ -1,0 +1,295 @@
+import matter from 'gray-matter';
+import { existsSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import type { ZodSchema } from 'zod';
+import { Stage2OutputSchema, type Stage2Output, type QueueEntry } from './schemas.js';
+import { appendToQueue, readQueue } from './queue.js';
+import { acquireLock, releaseLock } from './state.js';
+
+export const DEFAULT_MAX_ENTRIES = 5;
+export const DEFAULT_MAX_ATTEMPTS = 3;
+export const DEFAULT_TIMEOUT_MS = 60_000;
+export const STAGE2_LOCK_NAME = 'stage2-drain';
+
+export type Stage2Runner = <T>(
+  promptBody: string,
+  stdin: string,
+  schema: ZodSchema<T>,
+  opts: { timeoutMs: number; allowedTools?: string[]; logFile?: string },
+) => Promise<T>;
+
+export interface DrainContext {
+  sessionsDir: string;
+  logsDir: string;
+  stateFile: string;
+  promptTemplate: string;
+  runner: Stage2Runner;
+  now?: () => Date;
+  maxEntries?: number;
+  maxAttempts?: number;
+  timeoutMs?: number;
+  pid?: number;
+}
+
+export type DrainEntryStatus = 'done' | 'failed' | 'skipped' | 'missing-log';
+
+export interface DrainEntryResult {
+  sessionId: string;
+  status: DrainEntryStatus;
+  attempts: number;
+  error?: string;
+  logFile?: string;
+}
+
+export interface DrainSummary {
+  status: 'locked' | 'completed';
+  processed: DrainEntryResult[];
+  remaining: number;
+  reason?: string;
+}
+
+const TRANSCRIPT_PLACEHOLDER = '[TRANSCRIPT PLACEHOLDER — substituted at runtime]';
+
+/**
+ * Drains the stage-2 queue. Acquires a lock on `state.json`, iterates up to
+ * `maxEntries` queue items, invokes the runner for each, and updates the
+ * session log frontmatter with the outcome. Persistent failures (≥ maxAttempts)
+ * mark the session log as `skipped` and remove the entry from the queue.
+ */
+export async function drainStage2Queue(ctx: DrainContext): Promise<DrainSummary> {
+  const now = ctx.now ?? (() => new Date());
+  const queueFile = join(ctx.sessionsDir, '.queue.json');
+  const maxEntries = ctx.maxEntries ?? DEFAULT_MAX_ENTRIES;
+  const maxAttempts = ctx.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
+  const timeoutMs = ctx.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const pid = ctx.pid ?? process.pid;
+
+  const lockHeld = acquireLock(ctx.stateFile, {
+    name: STAGE2_LOCK_NAME,
+    pid,
+    now: now(),
+  });
+  if (!lockHeld) {
+    return { status: 'locked', processed: [], remaining: readQueue(queueFile).entries.length };
+  }
+
+  const processed: DrainEntryResult[] = [];
+  try {
+    for (let i = 0; i < maxEntries; i += 1) {
+      const queue = readQueue(queueFile);
+      if (queue.entries.length === 0) break;
+      const entry = queue.entries[0]!;
+      const result = await processEntry({
+        entry,
+        sessionsDir: ctx.sessionsDir,
+        logsDir: ctx.logsDir,
+        promptTemplate: ctx.promptTemplate,
+        runner: ctx.runner,
+        now,
+        timeoutMs,
+        maxAttempts,
+      });
+      processed.push(result);
+
+      if (
+        result.status === 'done' ||
+        result.status === 'skipped' ||
+        result.status === 'missing-log'
+      ) {
+        removeFromQueueHead(queueFile, entry.session_id);
+      } else {
+        // Failed but more attempts left: bump attempts and rotate to the back.
+        bumpAndRotate(queueFile, entry.session_id, result.attempts);
+      }
+    }
+  } finally {
+    releaseLock(ctx.stateFile, STAGE2_LOCK_NAME, pid);
+  }
+
+  const remaining = readQueue(queueFile).entries.length;
+  return { status: 'completed', processed, remaining };
+}
+
+interface ProcessEntryArgs {
+  entry: QueueEntry;
+  sessionsDir: string;
+  logsDir: string;
+  promptTemplate: string;
+  runner: Stage2Runner;
+  now: () => Date;
+  timeoutMs: number;
+  maxAttempts: number;
+}
+
+async function processEntry(args: ProcessEntryArgs): Promise<DrainEntryResult> {
+  const { entry, sessionsDir, logsDir, promptTemplate, runner, now, timeoutMs, maxAttempts } = args;
+  const sessionLogPath = join(sessionsDir, entry.session_log);
+  if (!existsSync(sessionLogPath)) {
+    return {
+      sessionId: entry.session_id,
+      status: 'missing-log',
+      attempts: entry.attempts,
+      error: `session log not found: ${entry.session_log}`,
+    };
+  }
+
+  const parsed = matter(readFileSync(sessionLogPath, 'utf8'));
+  const transcript = extractStage1Transcript(parsed.content);
+  const prompt = buildStage2Prompt(promptTemplate, transcript);
+  const attemptIndex = entry.attempts + 1;
+  const startedAt = now();
+  const logFile = stage2LogPath(logsDir, entry.session_id, startedAt);
+
+  try {
+    const out = await runner(prompt, '', Stage2OutputSchema, {
+      timeoutMs,
+      allowedTools: [],
+      logFile,
+    });
+    writeSessionLogFrontmatter(sessionLogPath, parsed, {
+      stage_2_status: 'done',
+      stage_2_completed_at: now().toISOString(),
+      stage_2_error: null,
+      stage_2_log: relativeLogPath(sessionsDir, logFile),
+      topics: collectTopics(out),
+      proposals: { practice: out.practice, map: out.map },
+    });
+    return {
+      sessionId: entry.session_id,
+      status: 'done',
+      attempts: attemptIndex,
+      logFile,
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    const exhausted = attemptIndex >= maxAttempts;
+    writeSessionLogFrontmatter(sessionLogPath, parsed, {
+      stage_2_status: exhausted ? 'skipped' : 'failed',
+      stage_2_completed_at: exhausted ? now().toISOString() : null,
+      stage_2_error: message,
+      stage_2_log: relativeLogPath(sessionsDir, logFile),
+    });
+    return {
+      sessionId: entry.session_id,
+      status: exhausted ? 'skipped' : 'failed',
+      attempts: attemptIndex,
+      error: message,
+      logFile,
+    };
+  }
+}
+
+function extractStage1Transcript(body: string): string {
+  const startMatch = body.match(/## Stage 1: redacted transcript slice\s*\n+/);
+  if (!startMatch || startMatch.index === undefined) return body.trim();
+  const start = startMatch.index + startMatch[0].length;
+  const rest = body.slice(start);
+  const endMatch = rest.match(/\n## Stage 2:/);
+  if (!endMatch) return rest.trim();
+  return rest.slice(0, endMatch.index).trim();
+}
+
+function buildStage2Prompt(template: string, transcript: string): string {
+  if (template.includes(TRANSCRIPT_PLACEHOLDER)) {
+    return template.replace(TRANSCRIPT_PLACEHOLDER, transcript);
+  }
+  return `${template.trimEnd()}\n\n${transcript}\n`;
+}
+
+function stage2LogPath(logsDir: string, sessionId: string, when: Date): string {
+  const stamp = isoToCompactStamp(when);
+  const safe = sessionId.replace(/[^a-z0-9-]/gi, '').slice(0, 24) || 'session';
+  return join(logsDir, 'stage-2', `${safe}__${stamp}.jsonl`);
+}
+
+function isoToCompactStamp(d: Date): string {
+  const pad = (n: number) => n.toString().padStart(2, '0');
+  return (
+    `${d.getUTCFullYear()}${pad(d.getUTCMonth() + 1)}${pad(d.getUTCDate())}` +
+    `T${pad(d.getUTCHours())}${pad(d.getUTCMinutes())}${pad(d.getUTCSeconds())}Z`
+  );
+}
+
+function relativeLogPath(sessionsDir: string, logFile: string): string {
+  // Store paths relative to the knowledge-base root for cross-machine portability.
+  // sessionsDir = .ai/knowledge-base/_sessions; the kb root is its parent.
+  const kbRoot = join(sessionsDir, '..');
+  const rel = logFile.startsWith(kbRoot)
+    ? logFile.slice(kbRoot.length).replace(/^[\\/]/, '')
+    : logFile;
+  return rel;
+}
+
+function collectTopics(out: Stage2Output): string[] {
+  const all = new Set<string>();
+  for (const c of out.practice) for (const t of c.tags) all.add(t);
+  for (const c of out.map) for (const t of c.tags) all.add(t);
+  return [...all];
+}
+
+interface FrontmatterPatch {
+  stage_2_status: 'done' | 'failed' | 'skipped';
+  stage_2_completed_at: string | null;
+  stage_2_error: string | null;
+  stage_2_log: string | null;
+  topics?: string[];
+  proposals?: { practice: unknown[]; map: unknown[] };
+}
+
+function writeSessionLogFrontmatter(
+  file: string,
+  parsed: matter.GrayMatterFile<string>,
+  patch: FrontmatterPatch,
+): void {
+  const data = { ...(parsed.data as Record<string, unknown>) };
+  data['stage_2_status'] = patch.stage_2_status;
+  data['stage_2_completed_at'] = patch.stage_2_completed_at;
+  data['stage_2_error'] = patch.stage_2_error;
+  data['stage_2_log'] = patch.stage_2_log;
+  if (patch.topics) data['topics'] = patch.topics;
+  if (patch.proposals) data['proposals'] = patch.proposals;
+  const body = updateStage2Body(parsed.content, patch);
+  const serialized = matter.stringify(body, data);
+  writeFileSync(file, serialized);
+}
+
+function updateStage2Body(content: string, patch: FrontmatterPatch): string {
+  if (patch.stage_2_status !== 'done') return content;
+  // Replace the "(populated by stage-2 worker)" placeholder with a brief
+  // summary so a human browsing the session log can see what the extractor
+  // produced without opening the stream-json log.
+  return content.replace(
+    /\(populated by stage-2 worker\)/,
+    `_Extraction complete — see proposals in frontmatter._`,
+  );
+}
+
+function removeFromQueueHead(queueFile: string, sessionId: string): void {
+  const queue = readQueue(queueFile);
+  const next = {
+    schema_version: 1 as const,
+    entries: queue.entries.filter((e) => e.session_id !== sessionId),
+  };
+  atomicWriteJson(queueFile, next);
+}
+
+function bumpAndRotate(queueFile: string, sessionId: string, attempts: number): void {
+  const queue = readQueue(queueFile);
+  const matchIdx = queue.entries.findIndex((e) => e.session_id === sessionId);
+  if (matchIdx < 0) return;
+  const [entry] = queue.entries.splice(matchIdx, 1);
+  if (!entry) return;
+  const updated: QueueEntry = { ...entry, attempts };
+  queue.entries.push(updated);
+  atomicWriteJson(queueFile, queue);
+}
+
+function atomicWriteJson(file: string, data: unknown): void {
+  const tmp = `${file}.tmp`;
+  writeFileSync(tmp, `${JSON.stringify(data, null, 2)}\n`);
+  renameSync(tmp, file);
+}
+
+// Re-export for callers that want to append directly (e.g. tests / future
+// /kb:propose-from-session command).
+export { appendToQueue };

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -1,0 +1,67 @@
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
+import { dirname } from 'node:path';
+import { StateFileSchema, type StateFile, type StateLock } from './schemas.js';
+
+export const DEFAULT_LOCK_TTL_MS = 30 * 60 * 1000;
+
+export function readState(file: string): StateFile {
+  if (!existsSync(file)) return { schema_version: 1 };
+  try {
+    const raw = JSON.parse(readFileSync(file, 'utf8')) as unknown;
+    const parsed = StateFileSchema.safeParse(raw);
+    if (parsed.success) return parsed.data;
+    return { schema_version: 1 };
+  } catch {
+    return { schema_version: 1 };
+  }
+}
+
+export function writeState(file: string, state: StateFile): void {
+  mkdirSync(dirname(file), { recursive: true });
+  const tmp = `${file}.tmp`;
+  writeFileSync(tmp, `${JSON.stringify(state, null, 2)}\n`);
+  renameSync(tmp, file);
+}
+
+export interface LockOptions {
+  name: string;
+  pid: number;
+  now: Date;
+  ttlMs?: number;
+}
+
+/**
+ * Attempts to acquire the named lock. Returns true if the caller now holds
+ * the lock, false if another live process holds it. A lock whose age exceeds
+ * its TTL is treated as stale and overwritten.
+ */
+export function acquireLock(file: string, opts: LockOptions): boolean {
+  const state = readState(file);
+  const existing = state.lock ?? null;
+  const ttlMs = opts.ttlMs ?? DEFAULT_LOCK_TTL_MS;
+  const nowMs = opts.now.getTime();
+  if (existing) {
+    const acquiredMs = Date.parse(existing.acquired_at);
+    const age = Number.isFinite(acquiredMs) ? nowMs - acquiredMs : Number.POSITIVE_INFINITY;
+    const expired = age > existing.ttl_ms;
+    if (!expired && existing.pid !== opts.pid) {
+      return false;
+    }
+  }
+  const lock: StateLock = {
+    name: opts.name,
+    pid: opts.pid,
+    acquired_at: opts.now.toISOString(),
+    ttl_ms: ttlMs,
+  };
+  writeState(file, { ...state, lock });
+  return true;
+}
+
+export function releaseLock(file: string, name: string, pid: number): void {
+  const state = readState(file);
+  if (!state.lock) return;
+  if (state.lock.name !== name || state.lock.pid !== pid) return;
+  const next: StateFile = { ...state, lock: null };
+  writeState(file, next);
+}

--- a/tests/hooks/kb-stage2-drain.test.ts
+++ b/tests/hooks/kb-stage2-drain.test.ts
@@ -1,0 +1,173 @@
+import matter from 'gray-matter';
+import { execFile } from 'node:child_process';
+import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { renderSessionLog } from '../../src/lib/session-log.js';
+import { cleanSandbox, makeSandbox, runCli } from '../helpers.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, '../..');
+const hookPath = join(repoRoot, 'dist/hooks/kb-stage2-drain.mjs');
+
+interface SpawnResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+function runHook(cwd: string, input: object, env: NodeJS.ProcessEnv = {}): Promise<SpawnResult> {
+  return new Promise((resolveFn) => {
+    const proc = execFile(
+      'node',
+      [hookPath],
+      { cwd, env: { ...process.env, NO_COLOR: '1', ...env } },
+      (err, stdout, stderr) => {
+        const code =
+          err && typeof (err as { code?: unknown }).code === 'number'
+            ? ((err as { code: number }).code as number)
+            : err
+              ? 1
+              : 0;
+        resolveFn({ stdout: stdout.toString(), stderr: stderr.toString(), exitCode: code });
+      },
+    );
+    proc.stdin?.write(JSON.stringify(input));
+    proc.stdin?.end();
+  });
+}
+
+function seedSession(sandbox: string, sessionId: string): string {
+  const sessionsDir = join(sandbox, '.ai/knowledge-base/_sessions');
+  mkdirSync(sessionsDir, { recursive: true });
+  const filename = `${sessionId}.md`;
+  writeFileSync(
+    join(sessionsDir, filename),
+    renderSessionLog({
+      sessionId,
+      capturedBy: 'stop',
+      capturedAt: '2026-05-11T10:00:00Z',
+      transcriptHash: 'sha256:abc',
+      gitleaksStatus: 'clean',
+      body: '[USER]: use bravo_pii.cache for PII\n[AGENT]: ok',
+    }),
+  );
+  writeFileSync(
+    join(sessionsDir, '.queue.json'),
+    JSON.stringify(
+      {
+        schema_version: 1,
+        entries: [
+          {
+            session_id: sessionId,
+            session_log: filename,
+            captured_by: 'stop',
+            captured_at: '2026-05-11T10:00:00Z',
+            attempts: 0,
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+  );
+  return filename;
+}
+
+function writeFakeClaude(sandbox: string, resultJson: string): string {
+  const binDir = join(sandbox, 'fake-bin');
+  mkdirSync(binDir, { recursive: true });
+  const fakeClaude = join(binDir, 'claude');
+  const stream = [
+    JSON.stringify({ type: 'system', subtype: 'init' }),
+    JSON.stringify({
+      type: 'result',
+      subtype: 'success',
+      is_error: false,
+      result: resultJson,
+    }),
+  ].join('\n');
+  // POSIX shell shim: print canned stream-json and exit 0 regardless of args.
+  writeFileSync(fakeClaude, `#!/bin/sh\ncat <<'EOF'\n${stream}\nEOF\n`);
+  chmodSync(fakeClaude, 0o755);
+  return binDir;
+}
+
+describe('kb-stage2-drain hook (spawned)', () => {
+  let sandbox: string;
+  beforeEach(async () => {
+    sandbox = makeSandbox();
+    const { execFile: ef } = await import('node:child_process');
+    await new Promise<void>((res, rej) =>
+      ef('git', ['init', '-q'], { cwd: sandbox }, (err) => (err ? rej(err) : res())),
+    );
+    await runCli(sandbox, ['init', '--assistants', 'claude']);
+  });
+  afterEach(() => cleanSandbox(sandbox));
+
+  it('compiled hook bundle exists at dist/hooks/kb-stage2-drain.mjs', () => {
+    expect(existsSync(hookPath)).toBe(true);
+  });
+
+  it('exits silently with KB_BUILDER_INTERNAL=1 (recursion guard)', async () => {
+    seedSession(sandbox, 'guarded');
+    const result = await runHook(sandbox, { cwd: sandbox }, { KB_BUILDER_INTERNAL: '1' });
+    expect(result.exitCode).toBe(0);
+    const queue = JSON.parse(
+      readFileSync(join(sandbox, '.ai/knowledge-base/_sessions/.queue.json'), 'utf8'),
+    );
+    expect(queue.entries).toHaveLength(1);
+  });
+
+  it('drains a queued entry using a stubbed claude binary on PATH', async () => {
+    if (process.platform === 'win32') return;
+    const file = seedSession(sandbox, 'drained');
+    const result = JSON.stringify({
+      practice: [
+        {
+          kind: 'practice',
+          tags: ['pii'],
+          title: 'Use bravo_pii.cache',
+          summary: 'Use the project PII cache backend',
+          body: 'Encrypts at rest.',
+          confidence: 'high',
+          supports_existing_node: null,
+          contradicts_existing_node: null,
+        },
+      ],
+      map: [],
+    });
+    const fakeBin = writeFakeClaude(sandbox, result);
+
+    const hookResult = await runHook(
+      sandbox,
+      { cwd: sandbox },
+      { PATH: `${fakeBin}:${process.env['PATH'] ?? ''}` },
+    );
+    expect(hookResult.exitCode).toBe(0);
+
+    const after = matter(readFileSync(join(sandbox, '.ai/knowledge-base/_sessions', file), 'utf8'));
+    expect(after.data['stage_2_status']).toBe('done');
+    const proposals = after.data['proposals'] as { practice: unknown[]; map: unknown[] };
+    expect(proposals.practice).toHaveLength(1);
+
+    const queueAfter = JSON.parse(
+      readFileSync(join(sandbox, '.ai/knowledge-base/_sessions/.queue.json'), 'utf8'),
+    );
+    expect(queueAfter.entries).toHaveLength(0);
+
+    const logFile = after.data['stage_2_log'] as string;
+    expect(existsSync(join(sandbox, '.ai/knowledge-base', logFile))).toBe(true);
+  });
+
+  it('exits 0 when the repo has no installed-version marker', async () => {
+    const empty = makeSandbox();
+    try {
+      const result = await runHook(empty, { cwd: empty });
+      expect(result.exitCode).toBe(0);
+    } finally {
+      cleanSandbox(empty);
+    }
+  });
+});

--- a/tests/init.test.ts
+++ b/tests/init.test.ts
@@ -38,6 +38,7 @@ describe('init', () => {
       '.claude/settings.json',
       '.claude/commands/kb-bootstrap.md',
       '.claude/hooks/kb-capture.mjs',
+      '.claude/hooks/kb-stage2-drain.mjs',
       '.ai/.kb-builder/installed-version',
       '.ai/.kb-builder/prompts/stage-2-extract.md',
       '.ai/.kb-builder/prompts/curator.md',
@@ -117,6 +118,22 @@ describe('init', () => {
         `KB_BUILDER_HOOK=${event} node .claude/hooks/kb-capture.mjs`,
       );
     }
+  });
+
+  it('registers SessionStart drain hook with async: true', async () => {
+    await runCli(sandbox, ['init', '--assistants', 'claude']);
+    const settings = JSON.parse(readFileSync(join(sandbox, '.claude/settings.json'), 'utf8')) as {
+      hooks?: Record<
+        string,
+        Array<{ hooks: Array<{ type: string; command: string; async?: boolean }> }>
+      >;
+    };
+    const entries = settings.hooks?.['SessionStart'];
+    expect(entries, 'expected SessionStart hook entry').toBeDefined();
+    expect(entries?.[0]?.hooks[0]?.command).toBe(
+      'KB_BUILDER_HOOK=SessionStart node .claude/hooks/kb-stage2-drain.mjs',
+    );
+    expect(entries?.[0]?.hooks[0]?.async).toBe(true);
   });
 
   it('ships the rename — no references to the old `kb-builder` binary in copied prompts', async () => {

--- a/tests/lib/headless.test.ts
+++ b/tests/lib/headless.test.ts
@@ -1,0 +1,146 @@
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Readable } from 'node:stream';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import { runHeadlessClaude, type SpawnContext, type SpawnFn } from '../../src/lib/headless.js';
+
+function makeSpawn(
+  lines: string[],
+  opts: { exitCode?: number; timedOut?: boolean } = {},
+): {
+  spawn: SpawnFn;
+  captured: { ctx?: SpawnContext };
+} {
+  const captured: { ctx?: SpawnContext } = {};
+  const spawn: SpawnFn = (_command, ctx) => {
+    captured.ctx = ctx;
+    const stdout = Readable.from(lines.map((l) => `${l}\n`));
+    const result = Promise.resolve({
+      exitCode: opts.exitCode ?? 0,
+      failed: opts.exitCode !== undefined && opts.exitCode !== 0,
+      timedOut: opts.timedOut === true,
+    });
+    return { stdout, result };
+  };
+  return { spawn, captured };
+}
+
+const Schema = z.object({ ok: z.boolean(), n: z.number() });
+
+describe('runHeadlessClaude', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'kb-headless-'));
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  it('parses the final result message and validates against the schema', async () => {
+    const { spawn } = makeSpawn([
+      JSON.stringify({ type: 'system', subtype: 'init' }),
+      JSON.stringify({ type: 'assistant', message: { content: 'thinking' } }),
+      JSON.stringify({
+        type: 'result',
+        subtype: 'success',
+        is_error: false,
+        result: JSON.stringify({ ok: true, n: 42 }),
+      }),
+    ]);
+    const out = await runHeadlessClaude('prompt body', 'stdin payload', Schema, { spawn });
+    expect(out).toEqual({ ok: true, n: 42 });
+  });
+
+  it('extracts JSON when the result is wrapped in a fenced code block', async () => {
+    const { spawn } = makeSpawn([
+      JSON.stringify({
+        type: 'result',
+        is_error: false,
+        result: '```json\n{"ok": true, "n": 7}\n```',
+      }),
+    ]);
+    const out = await runHeadlessClaude('prompt', '', Schema, { spawn });
+    expect(out).toEqual({ ok: true, n: 7 });
+  });
+
+  it('writes the raw stream to logFile when provided', async () => {
+    const { spawn } = makeSpawn([
+      JSON.stringify({ type: 'system', subtype: 'init' }),
+      JSON.stringify({
+        type: 'result',
+        is_error: false,
+        result: JSON.stringify({ ok: true, n: 1 }),
+      }),
+    ]);
+    const logFile = join(dir, 'logs', 'stage-2', 'a.jsonl');
+    await runHeadlessClaude('prompt', '', Schema, { spawn, logFile });
+    const lines = readFileSync(logFile, 'utf8').trim().split('\n');
+    expect(lines).toHaveLength(2);
+    expect(JSON.parse(lines[0]!).type).toBe('system');
+    expect(JSON.parse(lines[1]!).type).toBe('result');
+  });
+
+  it('forces KB_BUILDER_INTERNAL=1 in the child env and passes -p arguments', async () => {
+    const { spawn, captured } = makeSpawn([
+      JSON.stringify({
+        type: 'result',
+        is_error: false,
+        result: JSON.stringify({ ok: true, n: 1 }),
+      }),
+    ]);
+    await runHeadlessClaude('hello prompt', 'stdin', Schema, {
+      spawn,
+      allowedTools: ['Read'],
+      env: { FOO: 'bar' },
+    });
+    expect(captured.ctx?.env['KB_BUILDER_INTERNAL']).toBe('1');
+    expect(captured.ctx?.env['FOO']).toBe('bar');
+    expect(captured.ctx?.args).toEqual([
+      '-p',
+      'hello prompt',
+      '--allowedTools',
+      'Read',
+      '--output-format',
+      'stream-json',
+      '--verbose',
+    ]);
+    expect(captured.ctx?.stdin).toBe('stdin');
+  });
+
+  it('throws when the subprocess returns a non-zero exit code', async () => {
+    const { spawn } = makeSpawn([], { exitCode: 1 });
+    await expect(runHeadlessClaude('p', '', Schema, { spawn })).rejects.toThrow(/exit code/);
+  });
+
+  it('throws when the subprocess times out', async () => {
+    const { spawn } = makeSpawn([], { timedOut: true });
+    await expect(runHeadlessClaude('p', '', Schema, { spawn })).rejects.toThrow(/timed out/);
+  });
+
+  it('throws when no final result message is present', async () => {
+    const { spawn } = makeSpawn([
+      JSON.stringify({ type: 'assistant', message: { content: 'hi' } }),
+    ]);
+    await expect(runHeadlessClaude('p', '', Schema, { spawn })).rejects.toThrow(
+      /no final result message/,
+    );
+  });
+
+  it('throws when the result message is flagged as an error', async () => {
+    const { spawn } = makeSpawn([
+      JSON.stringify({ type: 'result', is_error: true, result: 'oops' }),
+    ]);
+    await expect(runHeadlessClaude('p', '', Schema, { spawn })).rejects.toThrow();
+  });
+
+  it('throws when result JSON does not match the schema', async () => {
+    const { spawn } = makeSpawn([
+      JSON.stringify({
+        type: 'result',
+        is_error: false,
+        result: JSON.stringify({ ok: 'yes please' }),
+      }),
+    ]);
+    await expect(runHeadlessClaude('p', '', Schema, { spawn })).rejects.toThrow(/schema/);
+  });
+});

--- a/tests/lib/stage2-drain.test.ts
+++ b/tests/lib/stage2-drain.test.ts
@@ -1,0 +1,287 @@
+import matter from 'gray-matter';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { appendToQueue, readQueue } from '../../src/lib/queue.js';
+import { renderSessionLog } from '../../src/lib/session-log.js';
+import {
+  drainStage2Queue,
+  STAGE2_LOCK_NAME,
+  type Stage2Runner,
+} from '../../src/lib/stage2-drain.js';
+import { acquireLock, readState } from '../../src/lib/state.js';
+
+interface Harness {
+  root: string;
+  sessionsDir: string;
+  logsDir: string;
+  stateFile: string;
+  queueFile: string;
+}
+
+function makeHarness(): Harness {
+  const root = mkdtempSync(join(tmpdir(), 'kb-drain-'));
+  const sessionsDir = join(root, '.ai/knowledge-base/_sessions');
+  const logsDir = join(root, '.ai/knowledge-base/_logs');
+  const stateFile = join(root, '.ai/.kb-builder/state.json');
+  mkdirSync(sessionsDir, { recursive: true });
+  mkdirSync(logsDir, { recursive: true });
+  mkdirSync(dirname(stateFile), { recursive: true });
+  return { root, sessionsDir, logsDir, stateFile, queueFile: join(sessionsDir, '.queue.json') };
+}
+
+function seedSession(harness: Harness, sessionId: string, transcript: string): string {
+  const filename = `session-${sessionId}.md`;
+  const body = renderSessionLog({
+    sessionId,
+    capturedBy: 'stop',
+    capturedAt: '2026-05-11T10:00:00Z',
+    transcriptHash: `sha256:${sessionId}`,
+    gitleaksStatus: 'clean',
+    body: transcript,
+  });
+  writeFileSync(join(harness.sessionsDir, filename), body);
+  appendToQueue(harness.queueFile, {
+    session_id: sessionId,
+    session_log: filename,
+    captured_by: 'stop',
+    captured_at: '2026-05-11T10:00:00Z',
+    attempts: 0,
+  });
+  return filename;
+}
+
+const PROMPT_TEMPLATE =
+  'Extract knowledge from the following transcript.\n\n[TRANSCRIPT PLACEHOLDER — substituted at runtime]';
+
+function successRunner(): Stage2Runner {
+  return async () => ({
+    practice: [
+      {
+        kind: 'practice',
+        tags: ['di'],
+        title: 'Use DI',
+        summary: 'Inject services in constructors',
+        body: 'Constructor injection is the convention.',
+        confidence: 'high',
+        supports_existing_node: null,
+        contradicts_existing_node: null,
+      },
+    ],
+    map: [
+      {
+        kind: 'map',
+        tags: ['module'],
+        title: 'bravo_insider module',
+        summary: 'Personalized section module',
+        body: 'Lives at modules/custom/bravo_insider.',
+        confidence: 'high',
+        supports_existing_node: null,
+        contradicts_existing_node: null,
+      },
+    ],
+  });
+}
+
+function failingRunner(message: string): Stage2Runner {
+  return async () => {
+    throw new Error(message);
+  };
+}
+
+describe('drainStage2Queue', () => {
+  let harness: Harness;
+  beforeEach(() => {
+    harness = makeHarness();
+  });
+  afterEach(() => rmSync(harness.root, { recursive: true, force: true }));
+
+  it('processes a queued session log on success and updates frontmatter', async () => {
+    const file = seedSession(harness, 's1', '[USER]: use bravo_pii.cache for PII\n[AGENT]: ok');
+
+    const summary = await drainStage2Queue({
+      sessionsDir: harness.sessionsDir,
+      logsDir: harness.logsDir,
+      stateFile: harness.stateFile,
+      promptTemplate: PROMPT_TEMPLATE,
+      runner: successRunner(),
+    });
+
+    expect(summary.status).toBe('completed');
+    expect(summary.processed[0]?.status).toBe('done');
+    expect(summary.remaining).toBe(0);
+
+    const after = matter(readFileSync(join(harness.sessionsDir, file), 'utf8'));
+    expect(after.data['stage_2_status']).toBe('done');
+    expect(after.data['stage_2_log']).toMatch(/_logs\/stage-2\//);
+    const proposals = after.data['proposals'] as { practice: unknown[]; map: unknown[] };
+    expect(proposals.practice).toHaveLength(1);
+    expect(proposals.map).toHaveLength(1);
+    expect(after.data['topics']).toEqual(expect.arrayContaining(['di', 'module']));
+    expect(readQueue(harness.queueFile).entries).toHaveLength(0);
+  });
+
+  it('substitutes the transcript into the prompt template before invoking the runner', async () => {
+    seedSession(harness, 's-sub', 'TRANSCRIPT-BODY-MARKER');
+    let receivedPrompt = '';
+    const runner: Stage2Runner = async (prompt, _stdin, _schema, _opts) => {
+      receivedPrompt = prompt;
+      return { practice: [], map: [] };
+    };
+
+    await drainStage2Queue({
+      sessionsDir: harness.sessionsDir,
+      logsDir: harness.logsDir,
+      stateFile: harness.stateFile,
+      promptTemplate: PROMPT_TEMPLATE,
+      runner,
+    });
+
+    expect(receivedPrompt).toContain('TRANSCRIPT-BODY-MARKER');
+    expect(receivedPrompt).not.toContain('[TRANSCRIPT PLACEHOLDER');
+  });
+
+  it('returns status=locked when another process holds the lock', async () => {
+    seedSession(harness, 's2', '[USER]: hi');
+    acquireLock(harness.stateFile, {
+      name: STAGE2_LOCK_NAME,
+      pid: 999_999,
+      now: new Date('2026-05-11T10:00:00Z'),
+    });
+
+    const summary = await drainStage2Queue({
+      sessionsDir: harness.sessionsDir,
+      logsDir: harness.logsDir,
+      stateFile: harness.stateFile,
+      promptTemplate: PROMPT_TEMPLATE,
+      runner: successRunner(),
+      pid: 12345,
+    });
+
+    expect(summary.status).toBe('locked');
+    expect(readQueue(harness.queueFile).entries).toHaveLength(1);
+  });
+
+  it('respects maxEntries and leaves remaining entries on the queue', async () => {
+    for (const id of ['a', 'b', 'c', 'd']) {
+      seedSession(harness, id, `[USER]: hi-${id}`);
+    }
+    const summary = await drainStage2Queue({
+      sessionsDir: harness.sessionsDir,
+      logsDir: harness.logsDir,
+      stateFile: harness.stateFile,
+      promptTemplate: PROMPT_TEMPLATE,
+      runner: successRunner(),
+      maxEntries: 2,
+    });
+    expect(summary.processed).toHaveLength(2);
+    expect(summary.remaining).toBe(2);
+  });
+
+  it('retries a failure (attempts<max) and rotates the entry to the back of the queue', async () => {
+    seedSession(harness, 'first', '[USER]: hi-first');
+    seedSession(harness, 'second', '[USER]: hi-second');
+
+    let calls = 0;
+    const runner: Stage2Runner = async () => {
+      calls += 1;
+      if (calls === 1) throw new Error('parse error');
+      return { practice: [], map: [] };
+    };
+
+    const summary = await drainStage2Queue({
+      sessionsDir: harness.sessionsDir,
+      logsDir: harness.logsDir,
+      stateFile: harness.stateFile,
+      promptTemplate: PROMPT_TEMPLATE,
+      runner,
+      maxEntries: 2,
+    });
+    expect(summary.processed[0]?.status).toBe('failed');
+    expect(summary.processed[1]?.status).toBe('done');
+    const queueAfter = readQueue(harness.queueFile);
+    expect(queueAfter.entries).toHaveLength(1);
+    expect(queueAfter.entries[0]?.session_id).toBe('first');
+    expect(queueAfter.entries[0]?.attempts).toBe(1);
+  });
+
+  it('marks a session log as skipped after the max-attempts threshold', async () => {
+    const file = seedSession(harness, 'doomed', '[USER]: hi-doomed');
+    // Pre-set attempts to 2 so the first failure here hits the cap.
+    const existing = readQueue(harness.queueFile);
+    existing.entries[0]!.attempts = 2;
+    writeFileSync(harness.queueFile, JSON.stringify(existing, null, 2));
+
+    const summary = await drainStage2Queue({
+      sessionsDir: harness.sessionsDir,
+      logsDir: harness.logsDir,
+      stateFile: harness.stateFile,
+      promptTemplate: PROMPT_TEMPLATE,
+      runner: failingRunner('schema mismatch'),
+      maxAttempts: 3,
+    });
+
+    expect(summary.processed[0]?.status).toBe('skipped');
+    expect(readQueue(harness.queueFile).entries).toHaveLength(0);
+    const after = matter(readFileSync(join(harness.sessionsDir, file), 'utf8'));
+    expect(after.data['stage_2_status']).toBe('skipped');
+    expect(after.data['stage_2_error']).toContain('schema mismatch');
+  });
+
+  it('handles a queue entry whose session log is missing on disk', async () => {
+    appendToQueue(harness.queueFile, {
+      session_id: 'ghost',
+      session_log: 'does-not-exist.md',
+      captured_by: 'stop',
+      captured_at: '2026-05-11T10:00:00Z',
+      attempts: 0,
+    });
+    const summary = await drainStage2Queue({
+      sessionsDir: harness.sessionsDir,
+      logsDir: harness.logsDir,
+      stateFile: harness.stateFile,
+      promptTemplate: PROMPT_TEMPLATE,
+      runner: successRunner(),
+    });
+    expect(summary.processed[0]?.status).toBe('missing-log');
+    expect(readQueue(harness.queueFile).entries).toHaveLength(0);
+  });
+
+  it('releases the lock after completion', async () => {
+    seedSession(harness, 's3', '[USER]: hi');
+    await drainStage2Queue({
+      sessionsDir: harness.sessionsDir,
+      logsDir: harness.logsDir,
+      stateFile: harness.stateFile,
+      promptTemplate: PROMPT_TEMPLATE,
+      runner: successRunner(),
+    });
+    expect(readState(harness.stateFile).lock ?? null).toBeNull();
+  });
+
+  it('releases the lock even if a runner throws an unexpected error', async () => {
+    seedSession(harness, 's4', '[USER]: hi');
+    await drainStage2Queue({
+      sessionsDir: harness.sessionsDir,
+      logsDir: harness.logsDir,
+      stateFile: harness.stateFile,
+      promptTemplate: PROMPT_TEMPLATE,
+      runner: failingRunner('boom'),
+    });
+    expect(readState(harness.stateFile).lock ?? null).toBeNull();
+  });
+
+  it('does nothing and reports remaining=0 when the queue is empty', async () => {
+    const summary = await drainStage2Queue({
+      sessionsDir: harness.sessionsDir,
+      logsDir: harness.logsDir,
+      stateFile: harness.stateFile,
+      promptTemplate: PROMPT_TEMPLATE,
+      runner: successRunner(),
+    });
+    expect(summary.processed).toHaveLength(0);
+    expect(summary.remaining).toBe(0);
+    expect(existsSync(harness.logsDir)).toBe(true);
+  });
+});

--- a/tests/lib/state.test.ts
+++ b/tests/lib/state.test.ts
@@ -1,0 +1,73 @@
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { acquireLock, readState, releaseLock, writeState } from '../../src/lib/state.js';
+
+describe('state.json lock', () => {
+  let dir: string;
+  let file: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'kb-state-'));
+    file = join(dir, '.kb-builder', 'state.json');
+  });
+
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  it('returns schema_version stub when file is missing', () => {
+    expect(readState(file)).toEqual({ schema_version: 1 });
+  });
+
+  it('acquires a fresh lock and writes it to disk', () => {
+    const now = new Date('2026-05-11T10:00:00Z');
+    expect(acquireLock(file, { name: 'stage2-drain', pid: 1234, now })).toBe(true);
+    const onDisk = JSON.parse(readFileSync(file, 'utf8'));
+    expect(onDisk.schema_version).toBe(1);
+    expect(onDisk.lock.name).toBe('stage2-drain');
+    expect(onDisk.lock.pid).toBe(1234);
+    expect(onDisk.lock.acquired_at).toBe('2026-05-11T10:00:00.000Z');
+  });
+
+  it('rejects acquisition by a different live pid', () => {
+    const t0 = new Date('2026-05-11T10:00:00Z');
+    expect(acquireLock(file, { name: 'stage2-drain', pid: 1234, now: t0 })).toBe(true);
+    expect(
+      acquireLock(file, {
+        name: 'stage2-drain',
+        pid: 9999,
+        now: new Date('2026-05-11T10:01:00Z'),
+      }),
+    ).toBe(false);
+  });
+
+  it('treats a lock older than its ttl as stale and overwrites it', () => {
+    const t0 = new Date('2026-05-11T10:00:00Z');
+    acquireLock(file, { name: 'stage2-drain', pid: 1234, now: t0, ttlMs: 60_000 });
+    const later = new Date('2026-05-11T10:05:00Z');
+    expect(acquireLock(file, { name: 'stage2-drain', pid: 5555, now: later, ttlMs: 60_000 })).toBe(
+      true,
+    );
+    expect(readState(file).lock?.pid).toBe(5555);
+  });
+
+  it('releases only when name and pid match', () => {
+    const now = new Date('2026-05-11T10:00:00Z');
+    acquireLock(file, { name: 'stage2-drain', pid: 1234, now });
+    releaseLock(file, 'curator', 1234);
+    expect(readState(file).lock?.pid).toBe(1234);
+    releaseLock(file, 'stage2-drain', 1234);
+    expect(readState(file).lock).toBeNull();
+  });
+
+  it('preserves last_nudged_at across lock cycles', () => {
+    writeState(file, {
+      schema_version: 1,
+      last_nudged_at: '2026-05-11T09:00:00Z',
+    });
+    const now = new Date('2026-05-11T10:00:00Z');
+    acquireLock(file, { name: 'stage2-drain', pid: 1234, now });
+    releaseLock(file, 'stage2-drain', 1234);
+    expect(readState(file).last_nudged_at).toBe('2026-05-11T09:00:00Z');
+  });
+});

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -17,7 +17,10 @@ export default defineConfig([
     // Hooks ship as compiled, self-contained .mjs files. We use the
     // .mjs extension so they run as ESM in consumer repos regardless
     // of the consumer's package.json `type` field.
-    entry: { 'kb-capture': 'src/hooks/kb-capture.ts' },
+    entry: {
+      'kb-capture': 'src/hooks/kb-capture.ts',
+      'kb-stage2-drain': 'src/hooks/kb-stage2-drain.ts',
+    },
     outDir: 'dist/hooks',
     format: ['esm'],
     target: 'node22',


### PR DESCRIPTION
Ships Phase M2 per IMPLEMENTATION.md §12.

## Summary

- `ClaudeAdapter.runHeadless` invokes `claude -p --output-format stream-json --verbose`, mirrors the stream into `_logs/stage-2/`, and validates the final result against a Zod schema. Injectable spawn for hermetic tests.
- `kb-stage2-drain.mjs` runs on `SessionStart` with `async: true`. Acquires a PID + 30-minute TTL lock in `.ai/.kb-builder/state.json`, drains up to 5 queue entries per invocation, three-strikes-then-skip on failure, per-entry 60s timeout.
- `KB_BUILDER_INTERNAL=1` is forced on every spawned child so capture/drain hooks short-circuit inside the subprocess.
- `init` registers the new hook with `"async": true`.
- 30 new tests (stream-json parsing, lock TTL, drain retry/rotation, spawned hook against a POSIX `claude` shim). Final: 75 passing + 1 skipped. Typecheck/lint/format clean.

## Docs

- `docs/customization/stage-2-prompt.md` — prompt-tuning guide
- `docs/reference/settings.md` — drain bounds, timeouts, lock TTL
- `docs/troubleshooting/reading-stage-2-logs.md` — stream-json trace interpretation
- `docs/reference/hook-events.md` — stage-2 drain section added

## Test plan

- [x] `npm test` — 75 passing + 1 skipped (gitleaks gate)
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] Spawned-hook smoke test with a fake `claude` shim on PATH


---
_Generated by [Claude Code](https://claude.ai/code/session_01AUUeZeKvuqa3dcmjx9QTJb)_