### PR TITLE
feat(M3): curate pipeline + manual-add

### DIFF
--- a/docs/customization/curator-prompt.md
+++ b/docs/customization/curator-prompt.md
@@ -1,0 +1,78 @@
+---
+title: Editing the curator prompt
+parent: Customization
+nav_order: 2
+---
+
+# Editing the curator prompt
+
+The curator decides what happens to every stage-2 candidate that lands in the queue: add, modify, contradict, or drop. After the stage-2 extractor, this is the second most important quality lever in the pipeline.
+
+## Where the prompt lives
+
+| Location | Used by | When edited |
+|---|---|---|
+| `src/templates-source/prompts/curator.md` | The package itself | Edit here if you maintain `@e0ipso/ai-knowledge-base` |
+| `.ai/.kb-builder/prompts/curator.md` | The curator subprocess at runtime | Edit here in a consumer repo to override the prompt locally |
+
+`ai-knowledge-base init` copies the shipped template into `.ai/.kb-builder/prompts/`. The `ai-knowledge-base curate` command prefers the local copy if it exists.
+
+## Version comment
+
+The first comment block in `curator.md` is the prompt version (`Version: N`). Bump it whenever you change behavior; the curator log records the prompt content under the run id so historic decisions remain auditable.
+
+## What the prompt receives
+
+At runtime, the `[BATCH PLACEHOLDER]` token is replaced by a JSON payload of the form:
+
+```json
+{
+  "index_summary": "<current INDEX.md contents>",
+  "existing_nodes": [
+    { "id": "...", "title": "...", "kind": "practice", "tags": ["..."], "summary": "...", "body": "..." }
+  ],
+  "batch": [
+    {
+      "session_id": "...",
+      "captured_at": "...",
+      "derived_from": "session-<id>.md",
+      "practice_candidates": [{ /* Stage2Candidate */ }],
+      "map_candidates": [{ /* Stage2Candidate */ }]
+    }
+  ]
+}
+```
+
+`existing_nodes` only contains the nodes referenced by `supports_existing_node` or `contradicts_existing_node` in the batch. The full INDEX is provided as a fallback so the curator can spot near-duplicates the stage-2 extractor didn't link.
+
+## What the prompt must produce
+
+A single JSON array (the curator's final result message). Each element is one `CuratorAction`:
+
+```json
+{
+  "action": "add | modify | contradict | drop",
+  "candidate_origin": "<session_id>:<practice|map>:<index>",
+  "target_node_id": "<id-or-null>",
+  "proposed_node": { /* full node frontmatter + body, or null for drop */ },
+  "rationale": "1–3 sentence justification",
+  "suggested_resolution": null
+}
+```
+
+The curator MUST always emit `suggested_resolution: null`, even on contradictions — the reviewer chooses, not the model.
+
+## What to verify after a change
+
+1. Re-run `npm test` — the curate library tests assert add/modify/contradict routing into the correct `_proposed/<bucket>/` folder and that contradictions never auto-resolve.
+2. Re-run against `tests/fixtures/transcripts/bravo-insider/expected.md`'s curator follow-up checks. The four key cases — analytics-dispatcher contradict, cache-tags add-with-relates-to, schema.org add, DI drop-or-modify — exercise the prompt's hardest decisions.
+3. Inspect `.ai/knowledge-base/_logs/curator/<run-id>__<timestamp>.jsonl` from a real run: confirm the model emits a single JSON array as the final result, with no preamble.
+
+## Anti-patterns the prompt avoids
+
+- Modifications that just rephrase existing content (drop instead).
+- Additions when a near-duplicate exists (convert to modification).
+- Auto-resolving contradictions (suggested_resolution must stay null).
+- Crossing the practice/map boundary.
+
+When the curator's output looks wrong, the prompt is almost always the right place to fix it before reaching for code changes.

--- a/docs/customization/index.md
+++ b/docs/customization/index.md
@@ -10,7 +10,7 @@ permalink: /customization/
 Pages:
 
 - [Editing the stage-2 prompt](stage-2-prompt.md) — tune the capture extractor for your project's vocabulary.
-- Editing the curator prompt — _coming in M3._
+- [Editing the curator prompt](curator-prompt.md) — control how stage-2 candidates become proposals.
 - Editing the bootstrap-incremental prompt — _coming in M3.5._
 
 Prompts are copied to `.ai/.kb-builder/prompts/` during `init` so you can override locally; hooks pick up the local copy if present and fall back to the bundled template. Reference settings live under [Reference > Settings](../reference/settings.md).

--- a/docs/getting-started/first-capture.md
+++ b/docs/getting-started/first-capture.md
@@ -6,14 +6,79 @@ nav_order: 2
 
 # First capture → curate
 
-_Coming in M3._
+A walkthrough of one full cycle through the pipeline: capture → drain → curate → review → consume.
 
-The capture pipeline (M1), stage-2 extractor (M2), and curator (M3) ship in subsequent phases. Once they're available, this page walks through:
+## 1. Run a Claude Code session that teaches something
 
-1. Running an AI session that produces a captured transcript.
-2. Reading the captured `.ai/knowledge-base/_sessions/<id>.md`.
-3. Running `/kb:curate` to produce reviewable proposals.
-4. Accepting / rejecting proposals as a git commit.
-5. Starting a new session and seeing the new knowledge in the injected index.
+After `ai-knowledge-base init --assistants claude`, open a Claude Code session in the repo and have an exchange where you correct the agent or introduce project-specific context — for example, "no, in this project we use the X service, not Y." End the session normally (`Stop`, `SessionEnd`, or by triggering `PreCompact`).
 
-For now, see [Implementation phases](https://github.com/e0ipso/ai-knowledge-base/blob/main/IMPLEMENTATION.md#12-implementation-phases).
+Under the hood, the capture hook synchronously:
+
+- Dedupes by transcript SHA-256 (5-minute window).
+- Runs gitleaks redaction on the transcript slice.
+- Writes a session log to `.ai/knowledge-base/_sessions/<timestamp>-<slug>.md` with `stage_2_status: pending`.
+- Appends a queue entry to `_sessions/.queue.json`.
+
+You can verify it produced something with `ai-knowledge-base status`.
+
+## 2. Start another session — the stage-2 drain runs in the background
+
+The next time you open a Claude Code session, the async `kb-stage2-drain` hook fires. It spawns `claude -p` per queue entry, extracts practice and map candidates from each transcript, and writes them into the session log frontmatter as `proposals.{practice,map}`. The session log's `stage_2_status` flips to `done`. Status reflects this immediately.
+
+## 3. Run `/kb:curate`
+
+In any session, type `/kb:curate`. The slash command body delegates to:
+
+```sh
+ai-knowledge-base curate
+```
+
+The curator:
+
+- Acquires the `.ai/.kb-builder/state.json` lock (`name: curator`, 30-min TTL).
+- Batches every `stage_2_status: done` session log that has not been curated yet.
+- Spawns `claude -p` per batch with the curator prompt.
+- Writes proposals into `.ai/knowledge-base/_proposed/{additions,modifications,contradictions}/`.
+- Regenerates `INDEX.md` and `GRAPH.md` from the current `nodes/` tree.
+
+Contradiction proposals always carry `suggested_resolution: null` — the curator never auto-resolves.
+
+## 4. Review the proposals
+
+```sh
+ai-knowledge-base proposals review
+```
+
+For each proposal:
+
+- **Addition / modification:** accept (move into `nodes/<kind>/`), reject (delete), or skip.
+- **Contradiction:** pick a resolution first (`supersede`, `keep_both`, `reject`), then accept or skip. Choosing `supersede` updates the target node with `valid_until` and `superseded_by` automatically.
+
+The reviewer's commit then carries both the new node files and the regenerated `INDEX.md` / `GRAPH.md`.
+
+## 5. The next session sees the new knowledge
+
+On the next `SessionStart`, the consume hook (M4) reads `INDEX.md` and injects it into the session context. The agent now knows about the practice or map node you just added.
+
+## Capturing knowledge manually
+
+If you notice missing knowledge between sessions, capture it directly without waiting for a session that happens to teach it. Two equivalent paths:
+
+```sh
+ai-knowledge-base node add
+```
+
+…or, in a session:
+
+```
+/kb:add
+```
+
+Both land in `_proposed/additions/<kind>-<slug>.md` with `proposal.rationale: "manual"`, so they show up alongside curator-produced proposals during `proposals review`.
+
+## Where the logs go
+
+Stage-2 traces: `.ai/knowledge-base/_logs/stage-2/<session-id>__<timestamp>.jsonl`.
+Curator traces: `.ai/knowledge-base/_logs/curator/<run-id>__<timestamp>.jsonl`.
+
+Both directories are gitignored by default. See [Troubleshooting](../troubleshooting/) for how to read them when something goes wrong.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -48,13 +48,57 @@ ai-knowledge-base status
 
 Print a summary of pending work — queue depth, pending session logs, pending proposals, current node counts.
 
+## `curate`
+
+```sh
+ai-knowledge-base curate [--batch-size <n>] [--token-budget <n>] [--timeout <ms>]
+```
+
+Run the curator non-interactively over every session log with `stage_2_status: done` that has not yet been curated. The command:
+
+1. Acquires the curator lock on `.ai/.kb-builder/state.json` (`name: curator`, PID + 30-minute TTL). If another curate run holds the lock, exits with `locked` and no work done.
+2. Batches pending session logs by count (`--batch-size`, default 10) and an estimated token budget (`--token-budget`, default 50000).
+3. Spawns one `claude -p` subprocess per batch with the curator prompt, streaming JSON output to `.ai/knowledge-base/_logs/curator/<ulid>__<timestamp>.jsonl`.
+4. Writes one proposal per non-drop action under `.ai/knowledge-base/_proposed/{additions,modifications,contradictions}/`.
+5. Regenerates `INDEX.md` and `GRAPH.md` from the current `nodes/` tree (deterministic, no LLM).
+6. Marks each session log with `curator_processed_at` and `curator_run_id` so it is not re-curated next run.
+
+Contradiction proposals always carry `suggested_resolution: null` — the curator never auto-resolves; the reviewer chooses one of `supersede`, `keep_both`, or `reject` during `proposals review`.
+
+Flags:
+
+- `--batch-size <n>` — maximum session logs per curator batch. Default `10`.
+- `--token-budget <n>` — approximate per-batch input token budget. Default `50000` (~4 chars per token).
+- `--timeout <ms>` — per-batch subprocess timeout. Default `120000`.
+
+## `node add`
+
+```sh
+ai-knowledge-base node add
+```
+
+Interactive CLI for capturing a single node manually. Uses `@inquirer/prompts` to collect `kind`, `title`, `summary`, `tags`, `relates_to`, `confidence`, and `body`. The result lands in `.ai/knowledge-base/_proposed/additions/<kind>-<slug>.md` with `proposal.kind: addition` and `proposal.rationale: "manual"`, never directly in `nodes/`.
+
+After writing the proposal, INDEX and GRAPH are regenerated so the index doesn't drift while a manual proposal sits awaiting review.
+
+The same path is available in-session as the `/kb:add` slash command.
+
+## `proposals review`
+
+```sh
+ai-knowledge-base proposals review [--list]
+```
+
+Interactive TUI that walks every pending proposal under `_proposed/`. For additions and modifications, the reviewer accepts (moves the file into `nodes/<kind>/` and strips the `proposal` block) or rejects (deletes the proposal). For contradictions, the reviewer must first pick a `suggested_resolution` — `supersede`, `keep_both`, or `reject` — then accept. When the resolution is `supersede`, the target node is updated with `valid_until` and `superseded_by` automatically.
+
+Flags:
+
+- `--list` — print the pending proposals and exit. Useful for CI or scripting.
+
 ## Commands available in later phases
 
 | Command | Phase |
 |---|---|
-| `node add` | M3 |
-| `curate` | M3 |
-| `proposals review` | M3 |
 | `bootstrap-incremental` | M3.5 |
 | `index rebuild` | M4 / M5 |
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -8,8 +8,8 @@ permalink: /reference/
 # Reference
 
 - [CLI commands](cli.md) — every `ai-knowledge-base` subcommand.
+- [Slash commands](slash-commands.md) — `/kb:curate`, `/kb:add`, `/kb:bootstrap`.
 - [Hook events](hook-events.md) — the four registered Claude Code events (capture + stage-2 drain).
 - [Settings](settings.md) — defaults for the stage-2 drain (bounds, timeouts, lock TTL).
-- Slash commands — _coming in M3._
 - Frontmatter schemas — _coming in M4._
 - Failure modes — _coming progressively._

--- a/docs/reference/slash-commands.md
+++ b/docs/reference/slash-commands.md
@@ -1,0 +1,36 @@
+---
+title: Slash commands
+parent: Reference
+nav_order: 4
+---
+
+# Slash commands
+
+`init --assistants claude` copies these slash command bodies into `.claude/commands/`. They are invoked from inside a Claude Code session by typing `/kb:<name>`.
+
+## `/kb:curate`
+
+Wraps the `ai-knowledge-base curate` CLI. The slash command body instructs the agent to:
+
+1. Run `ai-knowledge-base curate` in the repo root.
+2. Report the resulting summary line (proposals written, drops, batches, run id).
+3. Recommend `ai-knowledge-base proposals review` as the next step.
+
+The curator subprocess uses `claude -p` internally; recursion is blocked by the `KB_BUILDER_INTERNAL=1` env var.
+
+## `/kb:add`
+
+In-session companion to `ai-knowledge-base node add`. Asks the user for the seven fields needed for a node (kind, title, summary, tags, body, relates_to, confidence), assembles valid proposal frontmatter, and writes the file directly under `.ai/knowledge-base/_proposed/additions/`. No `claude -p` subprocess — the slash command runs in the user's existing session.
+
+Both `/kb:add` and `ai-knowledge-base node add` write proposals carrying `proposal.kind: addition` and `proposal.rationale: "manual"`, so manual additions are distinguishable in review.
+
+## `/kb:bootstrap`
+
+Ships in M3.5. First-time agent-driven bootstrap from existing markdown documentation.
+
+## Coming in later phases
+
+| Slash command | Phase |
+|---|---|
+| `/kb:show <topic-or-slug>` | M5 |
+| `/kb:propose-from-session` | M5 |

--- a/docs/troubleshooting/index.md
+++ b/docs/troubleshooting/index.md
@@ -10,7 +10,7 @@ permalink: /troubleshooting/
 Pages:
 
 - [Reading stage-2 logs](reading-stage-2-logs.md) — interpreting the stream-json traces under `_logs/stage-2/`.
-- Reading curator logs — _coming in M3._
+- [Reading curator logs](reading-curator-logs.md) — interpreting the stream-json traces under `_logs/curator/`.
 - Common issues — _coming progressively in M3–M5._
 
 For the canonical list of failure modes and recovery steps, see [PRD §9](https://github.com/e0ipso/ai-knowledge-base/blob/main/PRD.md#9-failure-modes-the-user-sees).

--- a/docs/troubleshooting/reading-curator-logs.md
+++ b/docs/troubleshooting/reading-curator-logs.md
@@ -1,0 +1,43 @@
+---
+title: Reading _logs/curator/
+parent: Troubleshooting
+nav_order: 2
+---
+
+# Reading `_logs/curator/`
+
+Every `ai-knowledge-base curate` invocation writes a stream-json trace to `.ai/knowledge-base/_logs/curator/<run-id>__<timestamp>.jsonl`. The run id is a ULID generated at the start of the run; the timestamp is wall-clock UTC compact form.
+
+These logs are gitignored by default — they belong to the contributor's machine.
+
+## Anatomy of the log
+
+Each line is one JSON event from the spawned `claude -p` subprocess. The interesting types are:
+
+| `type` | What it tells you |
+|---|---|
+| `assistant` | Streamed reasoning / commentary from the curator |
+| `tool_use` | A `Read` call against an existing node (the curator's only allowed tool) |
+| `tool_result` | Output of the `Read` call |
+| `result` | The final message. `result` field is the JSON array of CuratorActions |
+
+The drain validates the `result` event's content against `CuratorOutputSchema`. If validation fails, the curator surfaces the schema error and exits non-zero; the proposals for that batch are not written.
+
+## When the curator misbehaves
+
+1. **Empty proposals folder after `curate` reports `proposalsWritten: N > 0`.** Check the log for a final `result` event with `is_error: true`. The drain treats any `is_error` final result as a parse failure.
+
+2. **Curator produced fenced JSON.** `runHeadlessClaude` tolerates ` ```json ... ``` ` wrappers around the final result. If the model wraps the JSON in extra commentary, the parse step strips the fence; if no fence is present but there's preamble, the parser falls back to the raw string and validation will fail. Inspect the log's final `result.result` field directly.
+
+3. **Same proposal appears twice in different batches.** Cross-batch dedup keeps the higher-confidence action per `proposed_node.id`. If you see duplicates that survived dedup, both had different ids — check whether the slugification was inconsistent in the curator's output (case, hyphen runs, accents).
+
+4. **Curator auto-resolved a contradiction.** The persistence layer always writes `suggested_resolution: null`, regardless of what the model emitted. Confirm by reading the proposal file's frontmatter. If a non-null value appears, the prompt or the persistence path has regressed.
+
+## Re-running a single batch
+
+There is no first-class "re-run batch N" command in v1. Instead:
+
+1. Manually clear the `curator_processed_at` and `curator_run_id` fields from the affected session log frontmatter (use any text editor).
+2. Re-run `ai-knowledge-base curate`. The session log will be picked up again and re-curated.
+
+The original log under `_logs/curator/` is left in place — its filename includes the original run id, so old and new logs do not collide.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,9 @@
 import { Command } from 'commander';
+import { runCurateCommand } from './commands/curate.js';
 import { runDoctor } from './commands/doctor.js';
 import { runInit } from './commands/init.js';
+import { runNodeAdd } from './commands/node-add.js';
+import { runProposalsReview } from './commands/proposals-review.js';
 import { runStatus } from './commands/status.js';
 import { log } from './lib/log.js';
 import { packageVersion } from './lib/version.js';
@@ -46,6 +49,51 @@ async function main(): Promise<void> {
       const doctorOpts: { verbose?: boolean } = {};
       if (opts.verbose) doctorOpts.verbose = true;
       const code = await runDoctor(doctorOpts);
+      process.exit(code);
+    });
+
+  program
+    .command('curate')
+    .description('Run the curator non-interactively over pending session logs.')
+    .option('--batch-size <n>', 'sessions per curator batch (default 10)', (v) => parseInt(v, 10))
+    .option('--token-budget <n>', 'approx token budget per batch (default 50000)', (v) =>
+      parseInt(v, 10),
+    )
+    .option('--timeout <ms>', 'per-batch subprocess timeout (default 120000)', (v) =>
+      parseInt(v, 10),
+    )
+    .action(async (opts: { batchSize?: number; tokenBudget?: number; timeout?: number }) => {
+      const curateOpts: { batchSize?: number; tokenBudget?: number; timeoutMs?: number } = {};
+      if (typeof opts.batchSize === 'number' && !Number.isNaN(opts.batchSize))
+        curateOpts.batchSize = opts.batchSize;
+      if (typeof opts.tokenBudget === 'number' && !Number.isNaN(opts.tokenBudget))
+        curateOpts.tokenBudget = opts.tokenBudget;
+      if (typeof opts.timeout === 'number' && !Number.isNaN(opts.timeout))
+        curateOpts.timeoutMs = opts.timeout;
+      const code = await runCurateCommand(curateOpts);
+      process.exit(code);
+    });
+
+  const nodeGroup = program.command('node').description('Manage knowledge-base nodes.');
+  nodeGroup
+    .command('add')
+    .description('Interactively draft a new node; writes a proposal under _proposed/additions/.')
+    .action(async () => {
+      const code = await runNodeAdd();
+      process.exit(code);
+    });
+
+  const proposalsGroup = program
+    .command('proposals')
+    .description('Inspect and review pending proposals.');
+  proposalsGroup
+    .command('review')
+    .description('Interactively accept, reject, or set the resolution of pending proposals.')
+    .option('--list', 'just list the proposals without prompting', false)
+    .action(async (opts: { list?: boolean }) => {
+      const reviewOpts: { list?: boolean } = {};
+      if (opts.list) reviewOpts.list = true;
+      const code = await runProposalsReview(reviewOpts);
       process.exit(code);
     });
 

--- a/src/commands/curate.ts
+++ b/src/commands/curate.ts
@@ -1,0 +1,76 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { ClaudeAdapter } from '../adapters/claude.js';
+import { runCurate, type CuratorRunner } from '../lib/curate.js';
+import { log } from '../lib/log.js';
+import { findRepoRoot, packageTemplatesDir, repoPaths } from '../lib/paths.js';
+
+export interface CurateCommandOptions {
+  batchSize?: number;
+  tokenBudget?: number;
+  timeoutMs?: number;
+}
+
+export async function runCurateCommand(opts: CurateCommandOptions = {}): Promise<number> {
+  const root = findRepoRoot();
+  const paths = repoPaths(root);
+
+  if (!existsSync(paths.installedVersionFile)) {
+    log.error(
+      'ai-knowledge-base is not initialized in this repo. Run `ai-knowledge-base init --assistants claude`.',
+    );
+    return 1;
+  }
+
+  const promptTemplate = loadCuratorPrompt(paths.builderDir);
+  if (!promptTemplate) {
+    log.error('Curator prompt template not found.');
+    return 1;
+  }
+
+  const adapter = new ClaudeAdapter();
+  const runner: CuratorRunner = (prompt, stdin, schema, runnerOpts) =>
+    adapter.runHeadless(prompt, stdin, schema, runnerOpts);
+
+  log.info('Curating pending session logs…');
+  const baseOpts = {
+    kbDir: paths.kbDir,
+    sessionsDir: paths.sessionsDir,
+    nodesDir: paths.nodesDir,
+    proposedDir: paths.proposedDir,
+    logsDir: paths.logsDir,
+    stateFile: join(paths.builderDir, 'state.json'),
+    promptTemplate,
+    runner,
+  };
+  const result = await runCurate({
+    ...baseOpts,
+    ...(opts.batchSize !== undefined ? { batchSize: opts.batchSize } : {}),
+    ...(opts.tokenBudget !== undefined ? { tokenBudget: opts.tokenBudget } : {}),
+    ...(opts.timeoutMs !== undefined ? { timeoutMs: opts.timeoutMs } : {}),
+  });
+
+  switch (result.status) {
+    case 'locked':
+      log.warn(`Curator is locked: ${result.reason ?? 'another run holds the lock'}.`);
+      return 0;
+    case 'no-pending':
+      log.success('No pending session logs. INDEX and GRAPH regenerated.');
+      return 0;
+    case 'completed':
+      log.success(
+        `Curator finished: ${result.proposalsWritten} proposal(s), ${result.drops} drop(s) over ${result.batches} batch(es).`,
+      );
+      log.plain(`Run id: ${result.runId ?? '(unknown)'}`);
+      log.plain('Review the proposals with `ai-knowledge-base proposals review`.');
+      return 0;
+  }
+}
+
+function loadCuratorPrompt(builderDir: string): string | null {
+  const local = join(builderDir, 'prompts', 'curator.md');
+  if (existsSync(local)) return readFileSync(local, 'utf8');
+  const fallback = join(packageTemplatesDir(), 'prompts', 'curator.md');
+  if (existsSync(fallback)) return readFileSync(fallback, 'utf8');
+  return null;
+}

--- a/src/commands/node-add.ts
+++ b/src/commands/node-add.ts
@@ -1,0 +1,159 @@
+import { existsSync } from 'node:fs';
+import { input, select } from '@inquirer/prompts';
+import { generateGraph, generateIndex, writeGraph, writeIndex } from '../lib/index-gen.js';
+import { log } from '../lib/log.js';
+import {
+  deriveNodeId,
+  ensureUniqueId,
+  proposalFilename,
+  readAllNodes,
+  writeProposalFile,
+} from '../lib/nodes.js';
+import { findRepoRoot, repoPaths } from '../lib/paths.js';
+import type { Confidence, NodeKind, ProposalFrontmatter } from '../lib/schemas.js';
+
+export interface NodeAddOptions {
+  yes?: boolean;
+  // Test seam: supply answers programmatically instead of prompting.
+  preset?: {
+    kind: NodeKind;
+    title: string;
+    summary: string;
+    tags: string;
+    body: string;
+    relatesTo?: string;
+    confidence?: Confidence;
+  };
+  now?: Date;
+}
+
+export async function runNodeAdd(opts: NodeAddOptions = {}): Promise<number> {
+  const root = findRepoRoot();
+  const paths = repoPaths(root);
+  if (!existsSync(paths.installedVersionFile)) {
+    log.error(
+      'ai-knowledge-base is not initialized in this repo. Run `ai-knowledge-base init --assistants claude`.',
+    );
+    return 1;
+  }
+
+  const answers = opts.preset ? opts.preset : await promptForNode();
+
+  const kind = answers.kind;
+  const title = answers.title.trim();
+  if (!title) {
+    log.error('Title is required.');
+    return 1;
+  }
+  const summary = answers.summary.trim();
+  if (!summary) {
+    log.error('Summary is required.');
+    return 1;
+  }
+  const body = answers.body.trim() || `# ${title}\n\n${summary}\n`;
+  const tags = parseList(answers.tags);
+  const relatesTo = parseList(answers.relatesTo ?? '');
+  const confidence: Confidence = answers.confidence ?? 'high';
+
+  const existingIds = new Set(readAllNodes(paths.nodesDir).map((n) => n.frontmatter.id));
+  const id = ensureUniqueId(existingIds, deriveNodeId(kind, title));
+  const now = (opts.now ?? new Date()).toISOString();
+
+  const frontmatter: ProposalFrontmatter = {
+    schema_version: 1,
+    id,
+    title,
+    kind,
+    tags,
+    valid_from: now,
+    valid_until: null,
+    updated: now,
+    supersedes: null,
+    superseded_by: null,
+    derived_from: [],
+    relates_to: relatesTo,
+    depends_on: [],
+    confidence,
+    summary,
+    proposal: {
+      kind: 'addition',
+      source_sessions: [],
+      target_node: null,
+      rationale: 'manual',
+      suggested_resolution: null,
+      curator_log: null,
+    },
+  };
+
+  const filename = proposalFilename(kind, id);
+  const filePath = writeProposalFile({
+    proposedDir: paths.proposedDir,
+    proposalKind: 'additions',
+    filename,
+    frontmatter,
+    body,
+  });
+
+  // INDEX/GRAPH reflect committed nodes, not proposals — but the curator
+  // step is what wires that up. Regenerate here for consistency with the
+  // curate command (which regenerates on every run); this also exercises the
+  // generator path so manual `node add` doesn't silently leave a stale index.
+  const index = generateIndex(paths.nodesDir, { now: new Date(now) });
+  writeIndex(`${paths.kbDir}/INDEX.md`, index);
+  const graph = generateGraph(paths.nodesDir, { now: new Date(now) });
+  writeGraph(`${paths.kbDir}/GRAPH.md`, graph);
+
+  log.success(`Wrote proposal: ${filePath}`);
+  log.plain('Review with `ai-knowledge-base proposals review`.');
+  return 0;
+}
+
+async function promptForNode(): Promise<{
+  kind: NodeKind;
+  title: string;
+  summary: string;
+  tags: string;
+  body: string;
+  relatesTo: string;
+  confidence: Confidence;
+}> {
+  const kind = (await select({
+    message: 'Node kind',
+    choices: [
+      { name: 'practice — how we build things', value: 'practice' },
+      { name: 'map — what exists in the project', value: 'map' },
+    ],
+  })) as NodeKind;
+  const title = await input({
+    message: 'Title (short, ≤ 80 chars)',
+    validate: (v) => v.trim().length > 0 || 'Required',
+  });
+  const summary = await input({
+    message: 'Summary (≤ 140 chars)',
+    validate: (v) => v.trim().length > 0 || 'Required',
+  });
+  const tags = await input({ message: 'Tags (comma-separated, optional)' });
+  const relatesTo = await input({
+    message: 'relates_to (comma-separated node ids, optional)',
+  });
+  const confidence = (await select({
+    message: 'Confidence',
+    choices: [
+      { name: 'high', value: 'high' },
+      { name: 'medium', value: 'medium' },
+      { name: 'low', value: 'low' },
+    ],
+    default: 'high',
+  })) as Confidence;
+  const body = await input({
+    message: 'Body markdown (one line; for longer content, edit the proposal after writing)',
+  });
+  return { kind, title, summary, tags, body, relatesTo, confidence };
+}
+
+function parseList(s: string): string[] {
+  return s
+    .split(',')
+    .map((x) => x.trim())
+    .filter(Boolean);
+}

--- a/src/commands/proposals-review.ts
+++ b/src/commands/proposals-review.ts
@@ -1,0 +1,230 @@
+import { mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs';
+import { basename, join } from 'node:path';
+import matter from 'gray-matter';
+import { confirm, select } from '@inquirer/prompts';
+import { log } from '../lib/log.js';
+import { listProposalFiles, readProposalFile } from '../lib/nodes.js';
+import { findRepoRoot, repoPaths } from '../lib/paths.js';
+import { ProposalFrontmatterSchema, type ProposalFrontmatter } from '../lib/schemas.js';
+
+export interface ProposalsReviewOptions {
+  /** When true, do not prompt — just print a summary and return. */
+  list?: boolean;
+  /** Test seam: pre-recorded actions per proposal (in order). */
+  actions?: ReviewAction[];
+}
+
+export type ReviewAction =
+  | { type: 'accept' }
+  | { type: 'reject' }
+  | { type: 'set_resolution'; value: 'supersede' | 'keep_both' | 'reject' }
+  | { type: 'skip' };
+
+interface DiscoveredProposal {
+  path: string;
+  bucket: 'additions' | 'modifications' | 'contradictions';
+  frontmatter: ProposalFrontmatter;
+  body: string;
+}
+
+export async function runProposalsReview(opts: ProposalsReviewOptions = {}): Promise<number> {
+  const root = findRepoRoot();
+  const paths = repoPaths(root);
+
+  const discovered = discoverProposals(paths.proposedDir);
+  if (discovered.length === 0) {
+    log.success('No proposals awaiting review.');
+    return 0;
+  }
+
+  if (opts.list) {
+    printSummary(discovered);
+    return 0;
+  }
+
+  log.plain(`Reviewing ${discovered.length} proposal(s).`);
+  const actions = opts.actions ?? [];
+  let actionIdx = 0;
+  let accepted = 0;
+  let rejected = 0;
+  let skipped = 0;
+
+  for (const proposal of discovered) {
+    printProposalHeader(proposal);
+    const action: ReviewAction =
+      actionIdx < actions.length ? actions[actionIdx++]! : await promptForAction(proposal);
+
+    if (action.type === 'skip') {
+      skipped += 1;
+      continue;
+    }
+    if (action.type === 'reject') {
+      rmSync(proposal.path);
+      rejected += 1;
+      log.warn(`Rejected ${basename(proposal.path)}`);
+      continue;
+    }
+    if (action.type === 'set_resolution') {
+      writeBack(proposal, { suggested_resolution: action.value });
+      log.info(`Set suggested_resolution=${action.value} on ${basename(proposal.path)}`);
+      const next: ReviewAction =
+        actionIdx < actions.length
+          ? actions[actionIdx++]!
+          : (await confirm({ message: 'Accept this proposal now?', default: true }))
+            ? { type: 'accept' }
+            : { type: 'skip' };
+      if (next.type === 'accept') {
+        accepted += promote(proposal, paths.nodesDir) ? 1 : 0;
+      } else {
+        skipped += 1;
+      }
+      continue;
+    }
+    // accept
+    accepted += promote(proposal, paths.nodesDir) ? 1 : 0;
+  }
+
+  log.plain('');
+  log.success(`Done. accepted=${accepted} rejected=${rejected} skipped=${skipped}`);
+  if (accepted > 0) {
+    log.plain(
+      'Run `ai-knowledge-base curate` (or restart Claude Code) to refresh INDEX/GRAPH after acceptance.',
+    );
+  }
+  return 0;
+}
+
+function discoverProposals(proposedDir: string): DiscoveredProposal[] {
+  const out: DiscoveredProposal[] = [];
+  const grouped = listProposalFiles(proposedDir);
+  const buckets: Array<['additions' | 'modifications' | 'contradictions', string[]]> = [
+    ['additions', grouped.additions],
+    ['modifications', grouped.modifications],
+    ['contradictions', grouped.contradictions],
+  ];
+  for (const [bucket, files] of buckets) {
+    for (const file of files) {
+      const parsed = readProposalFile(file);
+      if (!parsed) continue;
+      out.push({ path: file, bucket, frontmatter: parsed.frontmatter, body: parsed.body });
+    }
+  }
+  return out;
+}
+
+function printSummary(discovered: DiscoveredProposal[]): void {
+  for (const p of discovered) {
+    log.plain(`[${p.bucket}] ${p.frontmatter.id} — ${p.frontmatter.title}`);
+  }
+}
+
+function printProposalHeader(p: DiscoveredProposal): void {
+  log.plain('');
+  log.plain('────────────────────────────────────────────────────────');
+  log.plain(`[${p.bucket}] ${p.frontmatter.id}`);
+  log.plain(`title:        ${p.frontmatter.title}`);
+  log.plain(`kind:         ${p.frontmatter.kind}`);
+  log.plain(`confidence:   ${p.frontmatter.confidence}`);
+  log.plain(`tags:         ${p.frontmatter.tags.join(', ') || '(none)'}`);
+  log.plain(`rationale:    ${p.frontmatter.proposal.rationale}`);
+  if (p.frontmatter.proposal.target_node) {
+    log.plain(`target_node:  ${p.frontmatter.proposal.target_node}`);
+  }
+  if (p.bucket === 'contradictions') {
+    log.plain(
+      `suggested_resolution: ${p.frontmatter.proposal.suggested_resolution ?? '(unset — choose one)'}`,
+    );
+  }
+  log.plain(`file:         ${p.path}`);
+  log.plain('────────────────────────────────────────────────────────');
+}
+
+async function promptForAction(p: DiscoveredProposal): Promise<ReviewAction> {
+  if (p.bucket === 'contradictions') {
+    const value = (await select({
+      message: 'Action',
+      choices: [
+        { name: 'set resolution → supersede', value: 'supersede' },
+        { name: 'set resolution → keep_both', value: 'keep_both' },
+        { name: 'set resolution → reject', value: 'reject' },
+        { name: 'reject proposal (delete)', value: '__reject__' },
+        { name: 'skip', value: '__skip__' },
+      ],
+    })) as string;
+    if (value === '__reject__') return { type: 'reject' };
+    if (value === '__skip__') return { type: 'skip' };
+    return { type: 'set_resolution', value: value as 'supersede' | 'keep_both' | 'reject' };
+  }
+  const choice = (await select({
+    message: 'Action',
+    choices: [
+      { name: 'accept (move into nodes/)', value: 'accept' },
+      { name: 'reject (delete)', value: 'reject' },
+      { name: 'skip', value: 'skip' },
+    ],
+  })) as 'accept' | 'reject' | 'skip';
+  return { type: choice } as ReviewAction;
+}
+
+function writeBack(
+  proposal: DiscoveredProposal,
+  patch: Partial<ProposalFrontmatter['proposal']>,
+): void {
+  const next: ProposalFrontmatter = {
+    ...proposal.frontmatter,
+    proposal: { ...proposal.frontmatter.proposal, ...patch },
+  };
+  const validated = ProposalFrontmatterSchema.parse(next);
+  const serialized = matter.stringify(proposal.body.trimEnd() + '\n', validated);
+  writeFileSync(proposal.path, serialized);
+  proposal.frontmatter = validated;
+}
+
+/**
+ * Promote a proposal into nodes/. For additions, strip the `proposal` block
+ * and move into `nodes/<kind>/`. For modifications and contradictions we do
+ * the same — the reviewer's resolution choice (for contradictions) has
+ * already been recorded in the frontmatter, and follow-up node mutations
+ * (e.g. setting valid_until on the contradicted node when the resolution is
+ * `supersede`) happen here.
+ */
+function promote(proposal: DiscoveredProposal, nodesDir: string): boolean {
+  const fm = proposal.frontmatter;
+  const kindDir = join(nodesDir, fm.kind);
+  mkdirSync(kindDir, { recursive: true });
+  const destFile = join(kindDir, `${fm.id}.md`);
+
+  const { proposal: _ignored, ...nodeFm } = fm;
+  void _ignored;
+  const nodeContent = matter.stringify(proposal.body.trimEnd() + '\n', nodeFm);
+  writeFileSync(destFile, nodeContent);
+
+  if (proposal.bucket === 'contradictions' && fm.proposal.suggested_resolution === 'supersede') {
+    applySupersede(proposal, nodesDir);
+  }
+  rmSync(proposal.path);
+  log.success(`Accepted ${basename(proposal.path)} → ${destFile}`);
+  return true;
+}
+
+function applySupersede(proposal: DiscoveredProposal, nodesDir: string): void {
+  const targetId = proposal.frontmatter.proposal.target_node;
+  if (!targetId) return;
+  const targetFile = join(nodesDir, proposal.frontmatter.kind, `${targetId}.md`);
+  let existing: string | null = null;
+  try {
+    existing = readFileSync(targetFile, 'utf8');
+  } catch {
+    log.warn(`Target node not found for supersede: ${targetFile}`);
+    return;
+  }
+  const parsed = matter(existing);
+  const data = { ...(parsed.data as Record<string, unknown>) };
+  const now = new Date().toISOString();
+  data['valid_until'] = now;
+  data['superseded_by'] = proposal.frontmatter.id;
+  data['updated'] = now;
+  const next = matter.stringify(parsed.content, data);
+  writeFileSync(targetFile + '.tmp', next);
+  renameSync(targetFile + '.tmp', targetFile);
+}

--- a/src/lib/curate.ts
+++ b/src/lib/curate.ts
@@ -1,0 +1,483 @@
+import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import matter from 'gray-matter';
+import type { ZodSchema } from 'zod';
+import { generateGraph, generateIndex, writeGraph, writeIndex } from './index-gen.js';
+import {
+  deriveNodeId,
+  ensureUniqueId,
+  proposalFilename,
+  readAllNodes,
+  writeProposalFile,
+} from './nodes.js';
+import {
+  CuratorOutputSchema,
+  type CuratorAction,
+  type CuratorOutput,
+  type NodeKind,
+  type ProposalFrontmatter,
+  SessionLogFrontmatterSchema,
+  Stage2CandidateSchema,
+  type Stage2Candidate,
+} from './schemas.js';
+import { acquireLock, releaseLock } from './state.js';
+import { ulid } from './ulid.js';
+
+export const CURATOR_LOCK_NAME = 'curator';
+export const DEFAULT_BATCH_SIZE = 10;
+export const DEFAULT_TOKEN_BUDGET = 50_000;
+export const DEFAULT_TIMEOUT_MS = 120_000;
+const CHARS_PER_TOKEN = 4;
+
+export type CuratorRunner = <T>(
+  promptBody: string,
+  stdin: string,
+  schema: ZodSchema<T>,
+  opts: { timeoutMs: number; allowedTools?: string[]; logFile?: string },
+) => Promise<T>;
+
+export interface CurateContext {
+  kbDir: string;
+  sessionsDir: string;
+  nodesDir: string;
+  proposedDir: string;
+  logsDir: string;
+  stateFile: string;
+  promptTemplate: string;
+  runner: CuratorRunner;
+  batchSize?: number;
+  tokenBudget?: number;
+  timeoutMs?: number;
+  now?: () => Date;
+  pid?: number;
+  /** Test seam: override ULID. */
+  runId?: string;
+}
+
+export interface CurateResult {
+  status: 'completed' | 'locked' | 'no-pending';
+  runId?: string;
+  batches: number;
+  candidates: number;
+  proposalsWritten: number;
+  drops: number;
+  pendingSessions: number;
+  reason?: string;
+}
+
+interface PendingSession {
+  filename: string;
+  filePath: string;
+  sessionId: string;
+  capturedAt: string;
+  topics: string[];
+  practiceCandidates: Stage2Candidate[];
+  mapCandidates: Stage2Candidate[];
+}
+
+interface SessionMatterData {
+  proposals?: { practice?: unknown; map?: unknown };
+  curator_processed_at?: unknown;
+}
+
+/**
+ * Reads `_sessions/` and returns every log with `stage_2_status: done` that
+ * has not yet been processed by curate. Used by both the curate command and
+ * `ai-knowledge-base status` (eventually) for reporting.
+ */
+export function listPendingSessions(sessionsDir: string): PendingSession[] {
+  if (!existsSync(sessionsDir)) return [];
+  const out: PendingSession[] = [];
+  for (const name of readdirSync(sessionsDir)) {
+    if (!name.endsWith('.md')) continue;
+    const filePath = join(sessionsDir, name);
+    const parsed = matter(readFileSync(filePath, 'utf8'));
+    const fmCheck = SessionLogFrontmatterSchema.safeParse(parsed.data);
+    if (!fmCheck.success) continue;
+    const fm = fmCheck.data;
+    if (fm.stage_2_status !== 'done') continue;
+    const data = parsed.data as SessionMatterData;
+    if (typeof data.curator_processed_at === 'string') continue;
+    const practice = parseCandidateArray(data.proposals?.practice);
+    const map = parseCandidateArray(data.proposals?.map);
+    out.push({
+      filename: name,
+      filePath,
+      sessionId: fm.session_id,
+      capturedAt: fm.captured_at,
+      topics: fm.topics,
+      practiceCandidates: practice,
+      mapCandidates: map,
+    });
+  }
+  out.sort((a, b) => a.capturedAt.localeCompare(b.capturedAt));
+  return out;
+}
+
+function parseCandidateArray(value: unknown): Stage2Candidate[] {
+  if (!Array.isArray(value)) return [];
+  const out: Stage2Candidate[] = [];
+  for (const entry of value) {
+    const parsed = Stage2CandidateSchema.safeParse(entry);
+    if (parsed.success) out.push(parsed.data);
+  }
+  return out;
+}
+
+const BATCH_PLACEHOLDER = '[BATCH PLACEHOLDER — substituted at runtime]';
+
+/**
+ * Splits pending sessions into batches sized by both count (`batchSize`,
+ * default 10) and an estimated token budget (`tokenBudget`, default 50K).
+ */
+export function batchSessions(
+  sessions: PendingSession[],
+  batchSize: number,
+  tokenBudget: number,
+): PendingSession[][] {
+  const batches: PendingSession[][] = [];
+  let current: PendingSession[] = [];
+  let currentTokens = 0;
+  for (const s of sessions) {
+    const cost = estimateSessionTokens(s);
+    const wouldExceed = current.length >= batchSize || currentTokens + cost > tokenBudget;
+    if (wouldExceed && current.length > 0) {
+      batches.push(current);
+      current = [];
+      currentTokens = 0;
+    }
+    current.push(s);
+    currentTokens += cost;
+  }
+  if (current.length > 0) batches.push(current);
+  return batches;
+}
+
+function estimateSessionTokens(s: PendingSession): number {
+  let chars = 0;
+  for (const c of s.practiceCandidates) chars += c.body.length + c.summary.length;
+  for (const c of s.mapCandidates) chars += c.body.length + c.summary.length;
+  return Math.max(1, Math.ceil(chars / CHARS_PER_TOKEN));
+}
+
+/**
+ * Builds the JSON payload that the curator subprocess receives on stdin.
+ * Includes the existing nodes the batch references plus the candidates.
+ */
+export interface CuratorBatchPayload {
+  index_summary: string;
+  existing_nodes: Array<{
+    id: string;
+    title: string;
+    kind: string;
+    tags: string[];
+    summary: string;
+    body: string;
+  }>;
+  batch: Array<{
+    session_id: string;
+    captured_at: string;
+    derived_from: string;
+    practice_candidates: Stage2Candidate[];
+    map_candidates: Stage2Candidate[];
+  }>;
+}
+
+export function buildBatchPayload(
+  batch: PendingSession[],
+  kbDir: string,
+  nodesDir: string,
+): CuratorBatchPayload {
+  const referenced = new Set<string>();
+  for (const s of batch) {
+    for (const c of [...s.practiceCandidates, ...s.mapCandidates]) {
+      if (c.supports_existing_node) referenced.add(c.supports_existing_node);
+      if (c.contradicts_existing_node) referenced.add(c.contradicts_existing_node);
+    }
+  }
+
+  const existingNodes: CuratorBatchPayload['existing_nodes'] = [];
+  if (referenced.size > 0) {
+    for (const node of readAllNodes(nodesDir)) {
+      if (!referenced.has(node.frontmatter.id)) continue;
+      existingNodes.push({
+        id: node.frontmatter.id,
+        title: node.frontmatter.title,
+        kind: node.frontmatter.kind,
+        tags: node.frontmatter.tags,
+        summary: node.frontmatter.summary,
+        body: node.body.trim(),
+      });
+    }
+  }
+
+  const indexFile = join(kbDir, 'INDEX.md');
+  const indexSummary = existsSync(indexFile) ? readFileSync(indexFile, 'utf8') : '';
+
+  return {
+    index_summary: indexSummary,
+    existing_nodes: existingNodes,
+    batch: batch.map((s) => ({
+      session_id: s.sessionId,
+      captured_at: s.capturedAt,
+      derived_from: s.filename,
+      practice_candidates: s.practiceCandidates,
+      map_candidates: s.mapCandidates,
+    })),
+  };
+}
+
+function buildBatchPrompt(template: string, payload: CuratorBatchPayload): string {
+  const json = JSON.stringify(payload, null, 2);
+  if (template.includes(BATCH_PLACEHOLDER)) {
+    return template.replace(BATCH_PLACEHOLDER, json);
+  }
+  return `${template.trimEnd()}\n\n${json}\n`;
+}
+
+/**
+ * Runs one curate invocation across all pending sessions. Acquires the
+ * `curator` lock on `state.json`, iterates the batched stage-2 outputs, asks
+ * the runner for actions, materializes proposals on disk, and regenerates
+ * INDEX/GRAPH from the (unchanged) nodes/ tree. Returns a summary.
+ */
+export async function runCurate(ctx: CurateContext): Promise<CurateResult> {
+  const now = ctx.now ?? (() => new Date());
+  const pid = ctx.pid ?? process.pid;
+  const batchSize = ctx.batchSize ?? DEFAULT_BATCH_SIZE;
+  const tokenBudget = ctx.tokenBudget ?? DEFAULT_TOKEN_BUDGET;
+  const timeoutMs = ctx.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  const pending = listPendingSessions(ctx.sessionsDir);
+  if (pending.length === 0) {
+    // Always regenerate INDEX/GRAPH so a manual `node add` followed by an
+    // empty curate run still refreshes the index.
+    regenerateIndexAndGraph(ctx, now());
+    return {
+      status: 'no-pending',
+      batches: 0,
+      candidates: 0,
+      proposalsWritten: 0,
+      drops: 0,
+      pendingSessions: 0,
+    };
+  }
+
+  const acquired = acquireLock(ctx.stateFile, {
+    name: CURATOR_LOCK_NAME,
+    pid,
+    now: now(),
+  });
+  if (!acquired) {
+    return {
+      status: 'locked',
+      batches: 0,
+      candidates: 0,
+      proposalsWritten: 0,
+      drops: 0,
+      pendingSessions: pending.length,
+      reason: 'another curate run holds the lock',
+    };
+  }
+
+  const runId = ctx.runId ?? ulid(now());
+  const startStamp = compactStamp(now());
+  const logFile = join(ctx.logsDir, 'curator', `${runId}__${startStamp}.jsonl`);
+  mkdirSync(join(ctx.logsDir, 'curator'), { recursive: true });
+
+  const batches = batchSessions(pending, batchSize, tokenBudget);
+  const allActions: CuratorAction[] = [];
+
+  try {
+    for (const batch of batches) {
+      const payload = buildBatchPayload(batch, ctx.kbDir, ctx.nodesDir);
+      const prompt = buildBatchPrompt(ctx.promptTemplate, payload);
+      const actions: CuratorOutput = await ctx.runner(prompt, '', CuratorOutputSchema, {
+        timeoutMs,
+        allowedTools: ['Read'],
+        logFile,
+      });
+      allActions.push(...actions);
+    }
+
+    const merged = dedupActions(allActions);
+    const existingIds = new Set(readAllNodes(ctx.nodesDir).map((n) => n.frontmatter.id));
+    const seenSlugs = new Set<string>();
+    let proposalsWritten = 0;
+    let drops = 0;
+
+    for (const action of merged) {
+      if (action.action === 'drop' || !action.proposed_node) {
+        drops += 1;
+        continue;
+      }
+      const written = persistAction(action, {
+        proposedDir: ctx.proposedDir,
+        existingIds,
+        seenSlugs,
+        runLogPath: relativeToKb(ctx.kbDir, logFile),
+        now: now(),
+      });
+      if (written) proposalsWritten += 1;
+    }
+
+    markSessionsProcessed(pending, runId, now());
+    regenerateIndexAndGraph(ctx, now());
+
+    return {
+      status: 'completed',
+      runId,
+      batches: batches.length,
+      candidates: pending.reduce(
+        (sum, s) => sum + s.practiceCandidates.length + s.mapCandidates.length,
+        0,
+      ),
+      proposalsWritten,
+      drops,
+      pendingSessions: pending.length,
+    };
+  } finally {
+    releaseLock(ctx.stateFile, CURATOR_LOCK_NAME, pid);
+  }
+}
+
+interface PersistContext {
+  proposedDir: string;
+  existingIds: Set<string>;
+  seenSlugs: Set<string>;
+  runLogPath: string;
+  now: Date;
+}
+
+function persistAction(action: CuratorAction, ctx: PersistContext): boolean {
+  const proposedNode = action.proposed_node;
+  if (!proposedNode) return false;
+  const folder = proposalFolderFor(action.action);
+  const kind: NodeKind = proposedNode.kind;
+  const id = ensureUniqueId(
+    new Set([...ctx.existingIds, ...ctx.seenSlugs]),
+    proposedNode.id || deriveNodeId(kind, proposedNode.title),
+  );
+  ctx.seenSlugs.add(id);
+  const filename = proposalFilename(kind, id);
+
+  const frontmatter: ProposalFrontmatter = {
+    schema_version: 1,
+    id,
+    title: proposedNode.title,
+    kind,
+    tags: proposedNode.tags,
+    valid_from: proposedNode.valid_from,
+    valid_until: proposedNode.valid_until ?? null,
+    updated: ctx.now.toISOString(),
+    supersedes: proposedNode.supersedes ?? null,
+    superseded_by: proposedNode.superseded_by ?? null,
+    derived_from: proposedNode.derived_from,
+    relates_to: proposedNode.relates_to,
+    depends_on: [],
+    confidence: proposedNode.confidence,
+    summary: proposedNode.summary,
+    proposal: {
+      kind: proposalKindFor(action.action),
+      source_sessions: parseSourceSessions(action.candidate_origin),
+      target_node: action.target_node_id ?? null,
+      rationale: action.rationale,
+      // The curator must not auto-resolve contradictions; we always write null
+      // here regardless of what the model emitted in `suggested_resolution`.
+      suggested_resolution: null,
+      curator_log: ctx.runLogPath,
+    },
+  };
+
+  writeProposalFile({
+    proposedDir: ctx.proposedDir,
+    proposalKind: folder,
+    filename,
+    frontmatter,
+    body: proposedNode.body,
+  });
+  return true;
+}
+
+function proposalFolderFor(
+  action: CuratorAction['action'],
+): 'additions' | 'modifications' | 'contradictions' {
+  if (action === 'modify') return 'modifications';
+  if (action === 'contradict') return 'contradictions';
+  return 'additions';
+}
+
+function proposalKindFor(
+  action: CuratorAction['action'],
+): 'addition' | 'modification' | 'contradiction' {
+  if (action === 'modify') return 'modification';
+  if (action === 'contradict') return 'contradiction';
+  return 'addition';
+}
+
+function parseSourceSessions(origin: string): string[] {
+  // candidate_origin = "<session_id>:<practice|map>:<index>"
+  const [sessionId] = origin.split(':');
+  return sessionId ? [sessionId] : [];
+}
+
+/**
+ * Cross-batch dedup: two actions targeting the same proposed_node.id collapse
+ * into one. Higher-confidence wins; rationale is preserved from the winner,
+ * source_sessions union via candidate_origin parsing.
+ */
+export function dedupActions(actions: CuratorAction[]): CuratorAction[] {
+  const byKey = new Map<string, CuratorAction>();
+  for (const action of actions) {
+    if (action.action === 'drop' || !action.proposed_node) {
+      byKey.set(`drop:${action.candidate_origin}`, action);
+      continue;
+    }
+    const id = action.proposed_node.id;
+    const existing = byKey.get(id);
+    if (!existing || rankConfidence(action) > rankConfidence(existing)) {
+      byKey.set(id, action);
+    }
+  }
+  return [...byKey.values()];
+}
+
+function rankConfidence(action: CuratorAction): number {
+  const node = action.proposed_node;
+  if (!node) return 0;
+  return node.confidence === 'high' ? 3 : node.confidence === 'medium' ? 2 : 1;
+}
+
+function markSessionsProcessed(sessions: PendingSession[], runId: string, now: Date): void {
+  for (const s of sessions) {
+    const parsed = matter(readFileSync(s.filePath, 'utf8'));
+    const data = { ...(parsed.data as Record<string, unknown>) };
+    data['curator_processed_at'] = now.toISOString();
+    data['curator_run_id'] = runId;
+    const serialized = matter.stringify(parsed.content, data);
+    writeFileSync(s.filePath, serialized);
+  }
+}
+
+function regenerateIndexAndGraph(ctx: CurateContext, now: Date): void {
+  mkdirSync(ctx.kbDir, { recursive: true });
+  const index = generateIndex(ctx.nodesDir, { now });
+  writeIndex(join(ctx.kbDir, 'INDEX.md'), index);
+  const graph = generateGraph(ctx.nodesDir, { now });
+  writeGraph(join(ctx.kbDir, 'GRAPH.md'), graph);
+}
+
+function relativeToKb(kbDir: string, file: string): string {
+  if (file.startsWith(kbDir)) {
+    return file.slice(kbDir.length).replace(/^[\\/]/, '');
+  }
+  return file;
+}
+
+function compactStamp(d: Date): string {
+  const pad = (n: number) => n.toString().padStart(2, '0');
+  return (
+    `${d.getUTCFullYear()}${pad(d.getUTCMonth() + 1)}${pad(d.getUTCDate())}` +
+    `T${pad(d.getUTCHours())}${pad(d.getUTCMinutes())}${pad(d.getUTCSeconds())}Z`
+  );
+}

--- a/src/lib/index-gen.ts
+++ b/src/lib/index-gen.ts
@@ -1,0 +1,219 @@
+import { writeFileSync } from 'node:fs';
+import matter from 'gray-matter';
+import { computeNodesHash, readAllNodes, type NodeFile } from './nodes.js';
+import { GraphFrontmatterSchema, IndexFrontmatterSchema, type NodeFrontmatter } from './schemas.js';
+
+export const DEFAULT_BUDGET_TOKENS = 2000;
+export const MIN_PER_KIND = 5;
+export const RECENT_SUPERSEDED_LIMIT = 5;
+const CHARS_PER_TOKEN = 4;
+
+export interface GenerateOptions {
+  budgetTokens?: number;
+  now?: Date;
+}
+
+export interface GeneratedIndex {
+  content: string;
+  nodesHash: string;
+  nodeCount: number;
+  hiddenByBudget: number;
+}
+
+export interface GeneratedGraph {
+  content: string;
+  nodesHash: string;
+  nodeCount: number;
+}
+
+/**
+ * Rough token estimate. We currently use the documented 4-chars-per-token
+ * fallback from IMPLEMENTATION.md §9; @anthropic-ai/tokenizer can be wired
+ * in later without a schema change.
+ */
+function estimateTokens(text: string): number {
+  return Math.ceil(text.length / CHARS_PER_TOKEN);
+}
+
+function isValid(fm: NodeFrontmatter): boolean {
+  return fm.valid_until === null;
+}
+
+function partition(nodes: NodeFile[]): { valid: NodeFile[]; superseded: NodeFile[] } {
+  const valid: NodeFile[] = [];
+  const superseded: NodeFile[] = [];
+  for (const n of nodes) {
+    if (isValid(n.frontmatter)) valid.push(n);
+    else superseded.push(n);
+  }
+  return { valid, superseded };
+}
+
+function sortByUpdatedDesc(a: NodeFile, b: NodeFile): number {
+  if (a.frontmatter.updated === b.frontmatter.updated) {
+    return a.frontmatter.id.localeCompare(b.frontmatter.id);
+  }
+  return a.frontmatter.updated < b.frontmatter.updated ? 1 : -1;
+}
+
+function relPathFromKb(node: NodeFile): string {
+  // node.path looks like .../knowledge-base/nodes/<kind>/<slug>.md.
+  const marker = '/nodes/';
+  const idx = node.path.lastIndexOf(marker);
+  if (idx < 0) return node.path;
+  return `nodes/${node.path.slice(idx + marker.length)}`;
+}
+
+function renderBullet(n: NodeFile): string {
+  const tags = n.frontmatter.tags.length > 0 ? ` (tags: ${n.frontmatter.tags.join(', ')})` : '';
+  return `- **${n.frontmatter.title}** — ${n.frontmatter.summary} [\`${relPathFromKb(n)}\`]${tags}`;
+}
+
+/**
+ * Render INDEX.md from the current state of `nodesDir`. Deterministic, no LLM.
+ * Implements the token-budgeted layout in IMPLEMENTATION.md §8.
+ */
+export function generateIndex(nodesDir: string, opts: GenerateOptions = {}): GeneratedIndex {
+  const budget = opts.budgetTokens ?? DEFAULT_BUDGET_TOKENS;
+  const now = opts.now ?? new Date();
+  const nodes = readAllNodes(nodesDir);
+  const { valid, superseded } = partition(nodes);
+  const validByKind: Record<'practice' | 'map', NodeFile[]> = { practice: [], map: [] };
+  for (const n of valid) validByKind[n.frontmatter.kind].push(n);
+  validByKind.practice.sort(sortByUpdatedDesc);
+  validByKind.map.sort(sortByUpdatedDesc);
+  superseded.sort(sortByUpdatedDesc);
+
+  const hash = computeNodesHash(nodesDir);
+  const nodeCount = nodes.length;
+  const validCount = valid.length;
+  const supersededCount = superseded.length;
+
+  const header = `# KB Index\n\n_${nodeCount} nodes • ${validCount} currently valid • ${supersededCount} superseded • last updated ${now.toISOString()}_\n`;
+
+  // Greedy budgeting: render all bullets, then trim oldest within each kind
+  // (preserving at least MIN_PER_KIND) until we fit the budget. Hidden count
+  // becomes a footer line.
+  const sections: Array<{ heading: string; bullets: NodeFile[] }> = [
+    { heading: '## Practice (how we build)', bullets: validByKind.practice.slice() },
+    { heading: '## Map (what exists)', bullets: validByKind.map.slice() },
+  ];
+
+  const recentSuperseded = superseded.slice(0, RECENT_SUPERSEDED_LIMIT);
+  let hidden = 0;
+  let body = renderBody(header, sections, recentSuperseded, hidden);
+  while (estimateTokens(body) > budget) {
+    const trimmed = trimOldest(sections);
+    if (!trimmed) break;
+    hidden += 1;
+    body = renderBody(header, sections, recentSuperseded, hidden);
+  }
+
+  const fm = IndexFrontmatterSchema.parse({
+    schema_version: 1,
+    generated_at: now.toISOString(),
+    nodes_hash: `sha256:${hash}`,
+    node_count: nodeCount,
+    budget_tokens: budget,
+  });
+  const content = matter.stringify(body, fm);
+  return { content, nodesHash: hash, nodeCount, hiddenByBudget: hidden };
+}
+
+function trimOldest(sections: Array<{ heading: string; bullets: NodeFile[] }>): boolean {
+  // Pick the section with the largest bullet count above MIN_PER_KIND and
+  // drop its oldest entry (the tail after sort-desc).
+  let target: { heading: string; bullets: NodeFile[] } | null = null;
+  for (const s of sections) {
+    if (s.bullets.length <= MIN_PER_KIND) continue;
+    if (!target || s.bullets.length > target.bullets.length) target = s;
+  }
+  if (!target) return false;
+  target.bullets.pop();
+  return true;
+}
+
+function renderBody(
+  header: string,
+  sections: Array<{ heading: string; bullets: NodeFile[] }>,
+  recentSuperseded: NodeFile[],
+  hidden: number,
+): string {
+  const parts: string[] = [header];
+  for (const s of sections) {
+    parts.push('');
+    parts.push(s.heading);
+    if (s.bullets.length === 0) {
+      parts.push('_None yet._');
+    } else {
+      for (const b of s.bullets) parts.push(renderBullet(b));
+    }
+  }
+  if (recentSuperseded.length > 0) {
+    parts.push('');
+    parts.push('## Recently superseded');
+    for (const n of recentSuperseded) {
+      const successor = n.frontmatter.superseded_by
+        ? ` (superseded by ${n.frontmatter.superseded_by})`
+        : '';
+      parts.push(`- **${n.frontmatter.title}**${successor} [\`${relPathFromKb(n)}\`]`);
+    }
+  }
+  if (hidden > 0) {
+    parts.push('');
+    parts.push(`_${hidden} additional nodes hidden by token budget — see GRAPH.md_`);
+  }
+  return parts.join('\n');
+}
+
+/**
+ * Render GRAPH.md — full unfiltered edge listing. Deterministic.
+ */
+export function generateGraph(nodesDir: string, opts: GenerateOptions = {}): GeneratedGraph {
+  const now = opts.now ?? new Date();
+  const nodes = readAllNodes(nodesDir);
+  nodes.sort((a, b) => a.frontmatter.id.localeCompare(b.frontmatter.id));
+  const hash = computeNodesHash(nodesDir);
+
+  const lines: string[] = [`# KB Graph`, ''];
+  if (nodes.length === 0) {
+    lines.push('_No nodes yet._');
+  } else {
+    lines.push(`Total nodes: ${nodes.length}`);
+    lines.push('');
+    for (const n of nodes) {
+      const fm = n.frontmatter;
+      const status = fm.valid_until === null ? 'valid' : 'superseded';
+      lines.push(`## ${fm.id}`);
+      lines.push('');
+      lines.push(`- **kind:** ${fm.kind}`);
+      lines.push(`- **status:** ${status}`);
+      lines.push(`- **title:** ${fm.title}`);
+      if (fm.tags.length > 0) lines.push(`- **tags:** ${fm.tags.join(', ')}`);
+      if (fm.relates_to.length > 0) lines.push(`- **relates_to:** ${fm.relates_to.join(', ')}`);
+      if (fm.depends_on.length > 0) lines.push(`- **depends_on:** ${fm.depends_on.join(', ')}`);
+      if (fm.supersedes) lines.push(`- **supersedes:** ${fm.supersedes}`);
+      if (fm.superseded_by) lines.push(`- **superseded_by:** ${fm.superseded_by}`);
+      if (fm.derived_from.length > 0)
+        lines.push(`- **derived_from:** ${fm.derived_from.join(', ')}`);
+      lines.push('');
+    }
+  }
+
+  const fm = GraphFrontmatterSchema.parse({
+    schema_version: 1,
+    generated_at: now.toISOString(),
+    nodes_hash: `sha256:${hash}`,
+    node_count: nodes.length,
+  });
+  const content = matter.stringify(lines.join('\n'), fm);
+  return { content, nodesHash: hash, nodeCount: nodes.length };
+}
+
+export function writeIndex(file: string, generated: GeneratedIndex): void {
+  writeFileSync(file, generated.content);
+}
+
+export function writeGraph(file: string, generated: GeneratedGraph): void {
+  writeFileSync(file, generated.content);
+}

--- a/src/lib/nodes.ts
+++ b/src/lib/nodes.ts
@@ -1,0 +1,165 @@
+import { createHash } from 'node:crypto';
+import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
+import { join, posix, relative, sep } from 'node:path';
+import matter from 'gray-matter';
+import {
+  NodeFrontmatterSchema,
+  ProposalFrontmatterSchema,
+  type NodeFrontmatter,
+  type NodeKind,
+  type ProposalFrontmatter,
+} from './schemas.js';
+
+export interface NodeFile {
+  path: string;
+  filename: string;
+  frontmatter: NodeFrontmatter;
+  body: string;
+}
+
+const KINDS: NodeKind[] = ['practice', 'map'];
+
+export function readAllNodes(nodesDir: string): NodeFile[] {
+  const out: NodeFile[] = [];
+  for (const kind of KINDS) {
+    const dir = join(nodesDir, kind);
+    if (!existsSync(dir)) continue;
+    for (const name of readdirSync(dir)) {
+      if (!name.endsWith('.md')) continue;
+      const filePath = join(dir, name);
+      const raw = readFileSync(filePath, 'utf8');
+      const parsed = matter(raw);
+      const result = NodeFrontmatterSchema.safeParse(parsed.data);
+      if (!result.success) continue;
+      out.push({
+        path: filePath,
+        filename: name,
+        frontmatter: result.data,
+        body: parsed.content,
+      });
+    }
+  }
+  return out;
+}
+
+export function findNodeById(nodesDir: string, id: string): NodeFile | null {
+  for (const node of readAllNodes(nodesDir)) {
+    if (node.frontmatter.id === id) return node;
+  }
+  return null;
+}
+
+/**
+ * Deterministic content hash over the nodes/ directory per IMPLEMENTATION.md §8.1.
+ *
+ *   1. Walk all `.md` files under nodes/ recursively.
+ *   2. For each file, sha256(file contents).
+ *   3. Build "<relative-path-from-nodes-dir>\t<sha256-hex>" strings.
+ *   4. Sort lexicographically.
+ *   5. Join with newlines.
+ *   6. sha256(joined), hex-encoded.
+ */
+export function computeNodesHash(nodesDir: string): string {
+  const entries: string[] = [];
+  if (existsSync(nodesDir)) {
+    walkMarkdown(nodesDir, nodesDir, entries);
+  }
+  entries.sort();
+  return createHash('sha256').update(entries.join('\n'), 'utf8').digest('hex');
+}
+
+function walkMarkdown(rootDir: string, currentDir: string, out: string[]): void {
+  for (const name of readdirSync(currentDir, { withFileTypes: true })) {
+    const fullPath = join(currentDir, name.name);
+    if (name.isDirectory()) {
+      walkMarkdown(rootDir, fullPath, out);
+      continue;
+    }
+    if (!name.name.endsWith('.md')) continue;
+    const rel = relative(rootDir, fullPath).split(sep).join(posix.sep);
+    const sha = createHash('sha256').update(readFileSync(fullPath)).digest('hex');
+    out.push(`${rel}\t${sha}`);
+  }
+}
+
+/**
+ * Slugify a string for use as a node id segment. Keeps lowercase ascii and
+ * dashes; collapses other runs to a single dash. Trims leading/trailing
+ * dashes. Returns "untitled" for empty input.
+ */
+export function slugify(input: string): string {
+  const slug = input
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return slug || 'untitled';
+}
+
+export function deriveNodeId(kind: NodeKind, title: string): string {
+  return `${kind}-${slugify(title)}`;
+}
+
+export function proposalFilename(kind: NodeKind, slugOrId: string): string {
+  const slug = slugOrId.startsWith(`${kind}-`) ? slugOrId : `${kind}-${slugify(slugOrId)}`;
+  return `${slug}.md`;
+}
+
+export function ensureUniqueId(existingIds: Set<string>, candidate: string): string {
+  if (!existingIds.has(candidate)) return candidate;
+  for (let i = 2; i < 100; i += 1) {
+    const next = `${candidate}-${i}`;
+    if (!existingIds.has(next)) return next;
+  }
+  // Fall back to a short hash discriminator.
+  const disc = createHash('sha256').update(`${candidate}-${Date.now()}`).digest('hex').slice(0, 6);
+  return `${candidate}-${disc}`;
+}
+
+export interface WriteProposalArgs {
+  proposedDir: string;
+  proposalKind: 'additions' | 'modifications' | 'contradictions';
+  filename: string;
+  frontmatter: ProposalFrontmatter;
+  body: string;
+}
+
+export function writeProposalFile(args: WriteProposalArgs): string {
+  const validated = ProposalFrontmatterSchema.parse(args.frontmatter);
+  const targetDir = join(args.proposedDir, args.proposalKind);
+  mkdirSync(targetDir, { recursive: true });
+  const filePath = join(targetDir, args.filename);
+  const out = matter.stringify(args.body.trimEnd() + '\n', validated);
+  writeFileSync(filePath, out);
+  return filePath;
+}
+
+export function listProposalFiles(proposedDir: string): {
+  additions: string[];
+  modifications: string[];
+  contradictions: string[];
+} {
+  return {
+    additions: listMd(join(proposedDir, 'additions')),
+    modifications: listMd(join(proposedDir, 'modifications')),
+    contradictions: listMd(join(proposedDir, 'contradictions')),
+  };
+}
+
+function listMd(dir: string): string[] {
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir)
+    .filter((n) => n.endsWith('.md'))
+    .map((n) => join(dir, n))
+    .sort();
+}
+
+export function readProposalFile(file: string): {
+  frontmatter: ProposalFrontmatter;
+  body: string;
+} | null {
+  if (!existsSync(file)) return null;
+  const parsed = matter(readFileSync(file, 'utf8'));
+  const result = ProposalFrontmatterSchema.safeParse(parsed.data);
+  if (!result.success) return null;
+  return { frontmatter: result.data, body: parsed.content };
+}

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -97,3 +97,95 @@ export const StateFileSchema = z.object({
 });
 
 export type StateFile = z.infer<typeof StateFileSchema>;
+
+export const NodeKindSchema = z.enum(['practice', 'map']);
+export type NodeKind = z.infer<typeof NodeKindSchema>;
+
+export const NodeFrontmatterSchema = z.object({
+  schema_version: z.literal(1),
+  id: z.string(),
+  title: z.string(),
+  kind: NodeKindSchema,
+  tags: z.array(z.string()),
+  valid_from: z.string(),
+  valid_until: z.string().nullable(),
+  updated: z.string(),
+  supersedes: z.string().nullable(),
+  superseded_by: z.string().nullable(),
+  derived_from: z.array(z.string()),
+  relates_to: z.array(z.string()),
+  depends_on: z.array(z.string()),
+  confidence: ConfidenceSchema,
+  summary: z.string(),
+});
+export type NodeFrontmatter = z.infer<typeof NodeFrontmatterSchema>;
+
+export const ProposalKindSchema = z.enum(['addition', 'modification', 'contradiction']);
+export type ProposalKind = z.infer<typeof ProposalKindSchema>;
+
+export const ProposalBlockSchema = z.object({
+  kind: ProposalKindSchema,
+  source_sessions: z.array(z.string()),
+  target_node: z.string().nullable(),
+  rationale: z.string(),
+  suggested_resolution: z.enum(['supersede', 'keep_both', 'reject']).nullable(),
+  curator_log: z.string().nullable(),
+});
+export type ProposalBlock = z.infer<typeof ProposalBlockSchema>;
+
+export const ProposalFrontmatterSchema = NodeFrontmatterSchema.extend({
+  proposal: ProposalBlockSchema,
+});
+export type ProposalFrontmatter = z.infer<typeof ProposalFrontmatterSchema>;
+
+/**
+ * Curator output schema: one entry per stage-2 candidate. Drops omit
+ * `proposed_node`; add/modify/contradict include it (without `proposal`
+ * block — the curator wrapper builds that).
+ */
+export const CuratorProposedNodeSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  kind: NodeKindSchema,
+  tags: z.array(z.string()),
+  summary: z.string(),
+  body: z.string(),
+  confidence: ConfidenceSchema,
+  derived_from: z.array(z.string()),
+  relates_to: z.array(z.string()),
+  supersedes: z.string().nullable(),
+  valid_from: z.string(),
+  valid_until: z.string().nullable(),
+  superseded_by: z.string().nullable(),
+});
+export type CuratorProposedNode = z.infer<typeof CuratorProposedNodeSchema>;
+
+export const CuratorActionSchema = z.object({
+  action: z.enum(['add', 'modify', 'contradict', 'drop']),
+  candidate_origin: z.string(),
+  target_node_id: z.string().nullable(),
+  proposed_node: CuratorProposedNodeSchema.nullable(),
+  rationale: z.string(),
+  suggested_resolution: z.enum(['supersede', 'keep_both', 'reject']).nullable(),
+});
+export type CuratorAction = z.infer<typeof CuratorActionSchema>;
+
+export const CuratorOutputSchema = z.array(CuratorActionSchema);
+export type CuratorOutput = z.infer<typeof CuratorOutputSchema>;
+
+export const IndexFrontmatterSchema = z.object({
+  schema_version: z.literal(1),
+  generated_at: z.string(),
+  nodes_hash: z.string(),
+  node_count: z.number().int().nonnegative(),
+  budget_tokens: z.number().int().positive(),
+});
+export type IndexFrontmatter = z.infer<typeof IndexFrontmatterSchema>;
+
+export const GraphFrontmatterSchema = z.object({
+  schema_version: z.literal(1),
+  generated_at: z.string(),
+  nodes_hash: z.string(),
+  node_count: z.number().int().nonnegative(),
+});
+export type GraphFrontmatter = z.infer<typeof GraphFrontmatterSchema>;

--- a/src/lib/ulid.ts
+++ b/src/lib/ulid.ts
@@ -1,0 +1,37 @@
+import { randomBytes } from 'node:crypto';
+
+const ENCODING = '0123456789ABCDEFGHJKMNPQRSTVWXYZ';
+const TIME_LEN = 10;
+const RANDOM_LEN = 16;
+
+/**
+ * Generates a Crockford Base32 ULID (26 characters). The first 10 chars
+ * encode milliseconds since the Unix epoch; the remaining 16 are
+ * cryptographic randomness. Lexicographic order matches time order.
+ */
+export function ulid(now: Date = new Date()): string {
+  const ms = now.getTime();
+  const time = encodeTime(ms);
+  const random = encodeRandom();
+  return `${time}${random}`;
+}
+
+function encodeTime(ms: number): string {
+  let value = ms;
+  const out: string[] = new Array<string>(TIME_LEN);
+  for (let i = TIME_LEN - 1; i >= 0; i -= 1) {
+    const mod = value % 32;
+    out[i] = ENCODING[mod]!;
+    value = (value - mod) / 32;
+  }
+  return out.join('');
+}
+
+function encodeRandom(): string {
+  const bytes = randomBytes(RANDOM_LEN);
+  const out: string[] = new Array<string>(RANDOM_LEN);
+  for (let i = 0; i < RANDOM_LEN; i += 1) {
+    out[i] = ENCODING[bytes[i]! % 32]!;
+  }
+  return out.join('');
+}

--- a/src/templates-source/claude/commands/kb-add.md
+++ b/src/templates-source/claude/commands/kb-add.md
@@ -1,0 +1,70 @@
+---
+description: Capture a knowledge-base node manually from the current session. Writes to _proposed/additions/ for human review.
+---
+
+<!--
+  Version: 1
+  Slash command body for `/kb:add`. Runs in the user's existing session
+  (no `claude -p` subprocess). The agent writes a proposal file directly
+  using the Write tool.
+-->
+
+# /kb:add
+
+Capture a single piece of knowledge that the user wants to record in the project KB. The output is a *proposal* under `.ai/knowledge-base/_proposed/additions/`, never a direct write into `nodes/`. A human reviews it later via `ai-knowledge-base proposals review`.
+
+## What to gather from the user
+
+Ask the user concise questions and gather:
+
+1. **Kind** — `practice` (how we build things) or `map` (what exists in the project).
+2. **Title** — short imperative for practice; noun phrase for map. ≤ 80 chars.
+3. **Summary** — one sentence, ≤ 140 chars. Will appear in INDEX.md.
+4. **Tags** — comma-separated, e.g. `caching, drupal, render-array`.
+5. **Body** — full markdown body. For practice: what to do/avoid and *why*. For map: what it is, where it lives, what it does.
+6. **relates_to** *(optional)* — node ids this should link to. Useful for exceptions, siblings, extensions.
+7. **Confidence** — `high`, `medium`, or `low`. Default to `high` for manual entries; recommend `medium` when the user is uncertain.
+
+If anything is missing or ambiguous, ask — once you write the proposal, you cannot easily edit it without an extra round-trip.
+
+## What to write
+
+Create the file at `.ai/knowledge-base/_proposed/additions/<kind>-<slug>.md`. The slug is derived from the title: lowercase, ascii letters and digits only, hyphens between words. If a file with that name already exists, append a short discriminator (e.g. `-2`).
+
+Frontmatter (every field is required; null where indicated):
+
+```yaml
+---
+schema_version: 1
+id: <kind>-<slug>
+title: "<title>"
+kind: <practice|map>
+tags: [<tag1>, <tag2>, ...]
+valid_from: <now in ISO 8601 UTC, e.g. 2026-05-11T10:00:00Z>
+valid_until: null
+updated: <same as valid_from>
+supersedes: null
+superseded_by: null
+derived_from: []
+relates_to: [<id1>, <id2>, ...]   # or [] if none
+depends_on: []
+confidence: <high|medium|low>
+summary: "<summary>"
+proposal:
+  kind: addition
+  source_sessions: []
+  target_node: null
+  rationale: "manual"
+  suggested_resolution: null
+  curator_log: null
+---
+```
+
+Body: just the markdown the user gave you. Add a `# <title>` H1 at the top if the body doesn't already start with one.
+
+## Constraints
+
+- Only use the `Write` tool, and only on a single file path under `.ai/knowledge-base/_proposed/additions/`.
+- Do not modify or read any other file in the KB.
+- Do not regenerate `INDEX.md` or `GRAPH.md` — that happens on the next `ai-knowledge-base curate` run.
+- After writing, tell the user: file path, the proposal id, and remind them to run `ai-knowledge-base proposals review`.

--- a/src/templates-source/claude/commands/kb-curate.md
+++ b/src/templates-source/claude/commands/kb-curate.md
@@ -1,0 +1,33 @@
+---
+description: Curate pending session logs into proposals (additions, modifications, contradictions). Wraps the `ai-knowledge-base curate` CLI.
+---
+
+<!--
+  Version: 1
+  Slash command body that delegates to the curator CLI. The CLI shells out
+  to `claude -p` internally; this command is just a convenient launcher for
+  the user.
+-->
+
+# /kb:curate
+
+Run the curator over pending session logs and turn them into reviewable proposals.
+
+## What to do
+
+1. Run `ai-knowledge-base curate` in the project root. The command:
+   - Acquires the curator lock (`.ai/.kb-builder/state.json`, name=`curator`, PID + 30-min TTL).
+   - Batches every session log whose `stage_2_status: done` and which has not yet been curated.
+   - Spawns `claude -p` per batch with the curator prompt (no recursion: `KB_BUILDER_INTERNAL=1`).
+   - Writes proposals under `.ai/knowledge-base/_proposed/{additions,modifications,contradictions}/`.
+   - Regenerates `INDEX.md` and `GRAPH.md` from the current `nodes/` tree.
+
+2. Once it finishes, report the summary line to the user (proposals written, drops, batches, run id).
+
+3. Tell the user the next step is `ai-knowledge-base proposals review` to accept or reject the new proposals.
+
+## Constraints
+
+- Do not modify nodes/ directly. Only the human reviewer promotes proposals into the nodes/ tree.
+- If the command reports `locked`, do not retry — explain that another curate run is in progress.
+- If no session logs are pending, the command still regenerates INDEX/GRAPH; that's expected, not an error.

--- a/tests/commands/node-add.test.ts
+++ b/tests/commands/node-add.test.ts
@@ -1,0 +1,105 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import matter from 'gray-matter';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { runNodeAdd } from '../../src/commands/node-add.js';
+
+function sandbox(): string {
+  const root = mkdtempSync(join(tmpdir(), 'kb-nodeadd-'));
+  mkdirSync(join(root, '.git'), { recursive: true });
+  mkdirSync(join(root, '.ai/.kb-builder'), { recursive: true });
+  writeFileSync(
+    join(root, '.ai/.kb-builder/installed-version'),
+    JSON.stringify({
+      schema_version: 1,
+      package: '@e0ipso/ai-knowledge-base',
+      version: '0.0.0-test',
+      installed_at: '2026-05-11T10:00:00Z',
+      assistants: ['claude'],
+    }),
+  );
+  mkdirSync(join(root, '.ai/knowledge-base/nodes/practice'), { recursive: true });
+  mkdirSync(join(root, '.ai/knowledge-base/nodes/map'), { recursive: true });
+  mkdirSync(join(root, '.ai/knowledge-base/_proposed/additions'), { recursive: true });
+  return root;
+}
+
+describe('node add', () => {
+  let cwd: string;
+  let original: string;
+  beforeEach(() => {
+    original = process.cwd();
+    cwd = sandbox();
+    process.chdir(cwd);
+  });
+  afterEach(() => {
+    process.chdir(original);
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
+  it('writes a proposal file with rationale=manual and proposal.kind=addition', async () => {
+    const code = await runNodeAdd({
+      preset: {
+        kind: 'practice',
+        title: 'Use commit signing for releases',
+        summary: 'All releases must be GPG-signed',
+        tags: 'releases, gpg',
+        body: '# Use commit signing\n\nDetails.',
+      },
+      now: new Date('2026-05-11T10:00:00Z'),
+    });
+    expect(code).toBe(0);
+    const dir = join(cwd, '.ai/knowledge-base/_proposed/additions');
+    const files = readdirSync(dir);
+    expect(files).toHaveLength(1);
+    const fm = matter(readFileSync(join(dir, files[0]!), 'utf8')).data as Record<string, unknown>;
+    expect(fm['kind']).toBe('practice');
+    expect((fm['proposal'] as { kind: string; rationale: string }).rationale).toBe('manual');
+    expect((fm['proposal'] as { kind: string }).kind).toBe('addition');
+    expect(existsSync(join(cwd, '.ai/knowledge-base/INDEX.md'))).toBe(true);
+  });
+
+  it('avoids id collisions with existing nodes', async () => {
+    writeFileSync(
+      join(cwd, '.ai/knowledge-base/nodes/practice/practice-use-foo.md'),
+      matter.stringify('# Use Foo\nBody.\n', {
+        schema_version: 1,
+        id: 'practice-use-foo',
+        title: 'Use Foo',
+        kind: 'practice',
+        tags: [],
+        valid_from: '2026-01-01T00:00:00Z',
+        valid_until: null,
+        updated: '2026-01-01T00:00:00Z',
+        supersedes: null,
+        superseded_by: null,
+        derived_from: [],
+        relates_to: [],
+        depends_on: [],
+        confidence: 'high',
+        summary: 'orig',
+      }),
+    );
+    await runNodeAdd({
+      preset: {
+        kind: 'practice',
+        title: 'Use Foo',
+        summary: 'Different content',
+        tags: '',
+        body: 'New body',
+      },
+      now: new Date('2026-05-11T10:00:00Z'),
+    });
+    const files = readdirSync(join(cwd, '.ai/knowledge-base/_proposed/additions'));
+    expect(files[0]).toBe('practice-use-foo-2.md');
+  });
+});

--- a/tests/commands/proposals-review.test.ts
+++ b/tests/commands/proposals-review.test.ts
@@ -1,0 +1,170 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import matter from 'gray-matter';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { runProposalsReview } from '../../src/commands/proposals-review.js';
+import type { ProposalFrontmatter } from '../../src/lib/schemas.js';
+
+function sandbox(): string {
+  const root = mkdtempSync(join(tmpdir(), 'kb-review-'));
+  mkdirSync(join(root, '.git'), { recursive: true });
+  mkdirSync(join(root, '.ai/.kb-builder'), { recursive: true });
+  writeFileSync(
+    join(root, '.ai/.kb-builder/installed-version'),
+    JSON.stringify({
+      schema_version: 1,
+      package: '@e0ipso/ai-knowledge-base',
+      version: '0.0.0-test',
+      installed_at: '2026-05-11T10:00:00Z',
+      assistants: ['claude'],
+    }),
+  );
+  mkdirSync(join(root, '.ai/knowledge-base/nodes/practice'), { recursive: true });
+  mkdirSync(join(root, '.ai/knowledge-base/nodes/map'), { recursive: true });
+  mkdirSync(join(root, '.ai/knowledge-base/_proposed/additions'), { recursive: true });
+  mkdirSync(join(root, '.ai/knowledge-base/_proposed/modifications'), { recursive: true });
+  mkdirSync(join(root, '.ai/knowledge-base/_proposed/contradictions'), { recursive: true });
+  return root;
+}
+
+function makeProposal(
+  bucket: 'additions' | 'modifications' | 'contradictions',
+  id: string,
+  overrides: Partial<ProposalFrontmatter['proposal']> = {},
+): ProposalFrontmatter {
+  return {
+    schema_version: 1,
+    id,
+    title: id,
+    kind: 'practice',
+    tags: [],
+    valid_from: '2026-05-11T10:00:00Z',
+    valid_until: null,
+    updated: '2026-05-11T10:00:00Z',
+    supersedes: null,
+    superseded_by: null,
+    derived_from: [],
+    relates_to: [],
+    depends_on: [],
+    confidence: 'high',
+    summary: `summary for ${id}`,
+    proposal: {
+      kind:
+        bucket === 'additions'
+          ? 'addition'
+          : bucket === 'modifications'
+            ? 'modification'
+            : 'contradiction',
+      source_sessions: [],
+      target_node: null,
+      rationale: 'r',
+      suggested_resolution: null,
+      curator_log: null,
+      ...overrides,
+    },
+  };
+}
+
+function writeProposal(
+  root: string,
+  bucket: 'additions' | 'modifications' | 'contradictions',
+  fm: ProposalFrontmatter,
+  body = '# body\n\nProposal body.\n',
+): void {
+  const file = join(root, '.ai/knowledge-base/_proposed', bucket, `${fm.id}.md`);
+  writeFileSync(file, matter.stringify(body, fm));
+}
+
+describe('proposals review', () => {
+  let cwd: string;
+  let original: string;
+  beforeEach(() => {
+    original = process.cwd();
+    cwd = sandbox();
+    process.chdir(cwd);
+  });
+  afterEach(() => {
+    process.chdir(original);
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
+  it('accepts an addition: moves the proposal into nodes/<kind>/ and strips the proposal block', async () => {
+    writeProposal(cwd, 'additions', makeProposal('additions', 'practice-foo'));
+    const code = await runProposalsReview({ actions: [{ type: 'accept' }] });
+    expect(code).toBe(0);
+    expect(existsSync(join(cwd, '.ai/knowledge-base/_proposed/additions/practice-foo.md'))).toBe(
+      false,
+    );
+    const moved = join(cwd, '.ai/knowledge-base/nodes/practice/practice-foo.md');
+    expect(existsSync(moved)).toBe(true);
+    const fm = matter(readFileSync(moved, 'utf8')).data as Record<string, unknown>;
+    expect(fm['proposal']).toBeUndefined();
+    expect(fm['id']).toBe('practice-foo');
+  });
+
+  it('rejects a proposal: deletes the file without writing to nodes/', async () => {
+    writeProposal(cwd, 'additions', makeProposal('additions', 'practice-bar'));
+    await runProposalsReview({ actions: [{ type: 'reject' }] });
+    expect(existsSync(join(cwd, '.ai/knowledge-base/_proposed/additions/practice-bar.md'))).toBe(
+      false,
+    );
+    expect(readdirSync(join(cwd, '.ai/knowledge-base/nodes/practice'))).toHaveLength(0);
+  });
+
+  it('sets suggested_resolution and then accepts the contradiction', async () => {
+    // Seed an existing target node so supersede can update it.
+    const targetFm = {
+      schema_version: 1,
+      id: 'practice-old',
+      title: 'Old',
+      kind: 'practice',
+      tags: [],
+      valid_from: '2026-01-01T00:00:00Z',
+      valid_until: null,
+      updated: '2026-01-01T00:00:00Z',
+      supersedes: null,
+      superseded_by: null,
+      derived_from: [],
+      relates_to: [],
+      depends_on: [],
+      confidence: 'high',
+      summary: 'old',
+    };
+    writeFileSync(
+      join(cwd, '.ai/knowledge-base/nodes/practice/practice-old.md'),
+      matter.stringify('# Old\nBody.\n', targetFm),
+    );
+    writeProposal(
+      cwd,
+      'contradictions',
+      makeProposal('contradictions', 'practice-new', { target_node: 'practice-old' }),
+    );
+    await runProposalsReview({
+      actions: [{ type: 'set_resolution', value: 'supersede' }, { type: 'accept' }],
+    });
+    const target = matter(
+      readFileSync(join(cwd, '.ai/knowledge-base/nodes/practice/practice-old.md'), 'utf8'),
+    ).data as Record<string, unknown>;
+    expect(target['superseded_by']).toBe('practice-new');
+    expect(typeof target['valid_until']).toBe('string');
+  });
+
+  it('lists pending proposals with --list and exits 0', async () => {
+    writeProposal(cwd, 'additions', makeProposal('additions', 'practice-listed'));
+    const code = await runProposalsReview({ list: true });
+    expect(code).toBe(0);
+    // file is untouched.
+    expect(existsSync(join(cwd, '.ai/knowledge-base/_proposed/additions/practice-listed.md'))).toBe(
+      true,
+    );
+  });
+});

--- a/tests/lib/curate.test.ts
+++ b/tests/lib/curate.test.ts
@@ -1,0 +1,387 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import matter from 'gray-matter';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  CURATOR_LOCK_NAME,
+  buildBatchPayload,
+  batchSessions,
+  dedupActions,
+  listPendingSessions,
+  runCurate,
+  type CuratorRunner,
+} from '../../src/lib/curate.js';
+import type { CuratorAction, Stage2Candidate } from '../../src/lib/schemas.js';
+import { acquireLock, readState } from '../../src/lib/state.js';
+
+interface Harness {
+  root: string;
+  kbDir: string;
+  sessionsDir: string;
+  nodesDir: string;
+  proposedDir: string;
+  logsDir: string;
+  stateFile: string;
+}
+
+function makeHarness(): Harness {
+  const root = mkdtempSync(join(tmpdir(), 'kb-curate-'));
+  const kbDir = join(root, '.ai/knowledge-base');
+  const sessionsDir = join(kbDir, '_sessions');
+  const nodesDir = join(kbDir, 'nodes');
+  const proposedDir = join(kbDir, '_proposed');
+  const logsDir = join(kbDir, '_logs');
+  const stateFile = join(root, '.ai/.kb-builder/state.json');
+  mkdirSync(sessionsDir, { recursive: true });
+  mkdirSync(nodesDir, { recursive: true });
+  mkdirSync(proposedDir, { recursive: true });
+  mkdirSync(logsDir, { recursive: true });
+  mkdirSync(dirname(stateFile), { recursive: true });
+  return { root, kbDir, sessionsDir, nodesDir, proposedDir, logsDir, stateFile };
+}
+
+function seedSession(
+  harness: Harness,
+  sessionId: string,
+  practice: Stage2Candidate[],
+  map: Stage2Candidate[],
+  capturedAt = '2026-05-11T10:00:00Z',
+): string {
+  const filename = `session-${sessionId}.md`;
+  const fm = {
+    schema_version: 1,
+    session_id: sessionId,
+    captured_by: 'stop',
+    captured_at: capturedAt,
+    transcript_hash: `sha256:${sessionId}`,
+    stage_2_status: 'done',
+    stage_2_completed_at: capturedAt,
+    stage_2_error: null,
+    stage_2_log: `_logs/stage-2/${sessionId}.jsonl`,
+    gitleaks_status: 'clean',
+    topics: [],
+    proposals: { practice, map },
+  };
+  const body = matter.stringify('## Stage 2: structured summary\n', fm);
+  writeFileSync(join(harness.sessionsDir, filename), body);
+  return filename;
+}
+
+function makeCandidate(kind: 'practice' | 'map', title: string): Stage2Candidate {
+  return {
+    kind,
+    tags: ['t'],
+    title,
+    summary: `summary of ${title}`,
+    body: `body for ${title}`,
+    confidence: 'high',
+    supports_existing_node: null,
+    contradicts_existing_node: null,
+  };
+}
+
+function makeAction(
+  action: 'add' | 'modify' | 'contradict' | 'drop',
+  overrides: Partial<CuratorAction> = {},
+): CuratorAction {
+  const base: CuratorAction = {
+    action,
+    candidate_origin: 's:practice:0',
+    target_node_id: null,
+    proposed_node:
+      action === 'drop'
+        ? null
+        : {
+            id: `practice-${action}-node`,
+            title: 'Proposed title',
+            kind: 'practice',
+            tags: ['t'],
+            summary: 'Proposed summary',
+            body: '# Proposed\n\nBody.',
+            confidence: 'high',
+            derived_from: ['session-1.md'],
+            relates_to: [],
+            supersedes: null,
+            valid_from: '2026-05-11T10:00:00Z',
+            valid_until: null,
+            superseded_by: null,
+          },
+    rationale: 'because',
+    suggested_resolution: null,
+  };
+  return { ...base, ...overrides };
+}
+
+const PROMPT_TEMPLATE = 'You are the curator.\n\n[BATCH PLACEHOLDER — substituted at runtime]';
+
+describe('listPendingSessions', () => {
+  let harness: Harness;
+  beforeEach(() => (harness = makeHarness()));
+  afterEach(() => rmSync(harness.root, { recursive: true, force: true }));
+
+  it('returns only stage_2_status=done sessions that have not yet been curated', () => {
+    seedSession(harness, 'a', [makeCandidate('practice', 'A')], []);
+    // pending session — not yet stage-2 done.
+    const fm = {
+      schema_version: 1,
+      session_id: 'pending',
+      captured_by: 'stop',
+      captured_at: '2026-05-11T10:00:00Z',
+      transcript_hash: 'sha256:pending',
+      stage_2_status: 'pending',
+      stage_2_completed_at: null,
+      stage_2_error: null,
+      stage_2_log: null,
+      gitleaks_status: 'clean',
+      topics: [],
+      proposals: { practice: [], map: [] },
+    };
+    writeFileSync(join(harness.sessionsDir, 'session-pending.md'), matter.stringify('# x', fm));
+    const sessions = listPendingSessions(harness.sessionsDir);
+    expect(sessions.map((s) => s.sessionId)).toEqual(['a']);
+  });
+});
+
+describe('batchSessions', () => {
+  it('respects the per-batch session count limit', () => {
+    const sessions = Array.from({ length: 25 }, (_, i) => ({
+      filename: `s-${i}.md`,
+      filePath: `s-${i}.md`,
+      sessionId: `s-${i}`,
+      capturedAt: '2026-05-11T10:00:00Z',
+      topics: [],
+      practiceCandidates: [makeCandidate('practice', `c-${i}`)],
+      mapCandidates: [],
+    }));
+    const batches = batchSessions(sessions, 10, 1_000_000);
+    expect(batches.map((b) => b.length)).toEqual([10, 10, 5]);
+  });
+});
+
+describe('dedupActions', () => {
+  it('keeps the higher-confidence action when two propose the same id', () => {
+    const a = makeAction('add', {
+      proposed_node: {
+        id: 'practice-foo',
+        title: 'Foo',
+        kind: 'practice',
+        tags: [],
+        summary: 'low',
+        body: 'body',
+        confidence: 'low',
+        derived_from: [],
+        relates_to: [],
+        supersedes: null,
+        valid_from: '2026-05-11T10:00:00Z',
+        valid_until: null,
+        superseded_by: null,
+      },
+    });
+    const b = makeAction('add', {
+      proposed_node: {
+        id: 'practice-foo',
+        title: 'Foo',
+        kind: 'practice',
+        tags: [],
+        summary: 'high',
+        body: 'body',
+        confidence: 'high',
+        derived_from: [],
+        relates_to: [],
+        supersedes: null,
+        valid_from: '2026-05-11T10:00:00Z',
+        valid_until: null,
+        superseded_by: null,
+      },
+    });
+    const merged = dedupActions([a, b]);
+    expect(merged).toHaveLength(1);
+    expect(merged[0]?.proposed_node?.summary).toBe('high');
+  });
+});
+
+describe('runCurate', () => {
+  let harness: Harness;
+  beforeEach(() => (harness = makeHarness()));
+  afterEach(() => rmSync(harness.root, { recursive: true, force: true }));
+
+  it('writes a proposal per non-drop action and marks the session as processed', async () => {
+    seedSession(harness, 's1', [makeCandidate('practice', 'Use X')], []);
+    const runner: CuratorRunner = async () => [
+      makeAction('add', {
+        proposed_node: {
+          id: 'practice-use-x',
+          title: 'Use X',
+          kind: 'practice',
+          tags: ['x'],
+          summary: 'Use X everywhere',
+          body: '# Use X\nBody.\n',
+          confidence: 'high',
+          derived_from: ['session-s1.md'],
+          relates_to: [],
+          supersedes: null,
+          valid_from: '2026-05-11T10:00:00Z',
+          valid_until: null,
+          superseded_by: null,
+        },
+      }),
+    ];
+
+    const result = await runCurate({
+      kbDir: harness.kbDir,
+      sessionsDir: harness.sessionsDir,
+      nodesDir: harness.nodesDir,
+      proposedDir: harness.proposedDir,
+      logsDir: harness.logsDir,
+      stateFile: harness.stateFile,
+      promptTemplate: PROMPT_TEMPLATE,
+      runner,
+    });
+
+    expect(result.status).toBe('completed');
+    expect(result.proposalsWritten).toBe(1);
+    expect(existsSync(join(harness.proposedDir, 'additions', 'practice-use-x.md'))).toBe(true);
+    // INDEX/GRAPH regenerated.
+    expect(existsSync(join(harness.kbDir, 'INDEX.md'))).toBe(true);
+    expect(existsSync(join(harness.kbDir, 'GRAPH.md'))).toBe(true);
+    // Session marked as curator_processed.
+    const after = matter(readFileSync(join(harness.sessionsDir, 'session-s1.md'), 'utf8'));
+    expect(typeof (after.data as Record<string, unknown>)['curator_processed_at']).toBe('string');
+    expect(typeof (after.data as Record<string, unknown>)['curator_run_id']).toBe('string');
+  });
+
+  it('routes modifications, contradictions, and additions to the right folders', async () => {
+    seedSession(
+      harness,
+      's',
+      [
+        makeCandidate('practice', 'Add'),
+        makeCandidate('practice', 'Mod'),
+        makeCandidate('practice', 'Contradict'),
+      ],
+      [],
+    );
+    const runner: CuratorRunner = async () => [
+      makeAction('add'),
+      makeAction('modify', { target_node_id: 'practice-mod-target' }),
+      makeAction('contradict', { target_node_id: 'practice-contra-target' }),
+    ];
+    await runCurate({
+      kbDir: harness.kbDir,
+      sessionsDir: harness.sessionsDir,
+      nodesDir: harness.nodesDir,
+      proposedDir: harness.proposedDir,
+      logsDir: harness.logsDir,
+      stateFile: harness.stateFile,
+      promptTemplate: PROMPT_TEMPLATE,
+      runner,
+    });
+    expect(readdirSync(join(harness.proposedDir, 'additions'))).toHaveLength(1);
+    expect(readdirSync(join(harness.proposedDir, 'modifications'))).toHaveLength(1);
+    expect(readdirSync(join(harness.proposedDir, 'contradictions'))).toHaveLength(1);
+    // Contradiction proposal must NOT auto-pick a resolution.
+    const contradictFile = join(
+      harness.proposedDir,
+      'contradictions',
+      readdirSync(join(harness.proposedDir, 'contradictions'))[0]!,
+    );
+    const fm = matter(readFileSync(contradictFile, 'utf8')).data as {
+      proposal: { suggested_resolution: string | null };
+    };
+    expect(fm.proposal.suggested_resolution).toBeNull();
+  });
+
+  it('returns status=locked when another process holds the curator lock', async () => {
+    seedSession(harness, 's', [makeCandidate('practice', 'Hi')], []);
+    acquireLock(harness.stateFile, {
+      name: CURATOR_LOCK_NAME,
+      pid: 999_999,
+      now: new Date(),
+    });
+    const result = await runCurate({
+      kbDir: harness.kbDir,
+      sessionsDir: harness.sessionsDir,
+      nodesDir: harness.nodesDir,
+      proposedDir: harness.proposedDir,
+      logsDir: harness.logsDir,
+      stateFile: harness.stateFile,
+      promptTemplate: PROMPT_TEMPLATE,
+      runner: async () => [],
+      pid: 12345,
+    });
+    expect(result.status).toBe('locked');
+  });
+
+  it('releases the lock after completion', async () => {
+    seedSession(harness, 's', [makeCandidate('practice', 'Hi')], []);
+    await runCurate({
+      kbDir: harness.kbDir,
+      sessionsDir: harness.sessionsDir,
+      nodesDir: harness.nodesDir,
+      proposedDir: harness.proposedDir,
+      logsDir: harness.logsDir,
+      stateFile: harness.stateFile,
+      promptTemplate: PROMPT_TEMPLATE,
+      runner: async () => [],
+    });
+    expect(readState(harness.stateFile).lock ?? null).toBeNull();
+  });
+
+  it('reports no-pending and still regenerates INDEX/GRAPH when nothing is queued', async () => {
+    const result = await runCurate({
+      kbDir: harness.kbDir,
+      sessionsDir: harness.sessionsDir,
+      nodesDir: harness.nodesDir,
+      proposedDir: harness.proposedDir,
+      logsDir: harness.logsDir,
+      stateFile: harness.stateFile,
+      promptTemplate: PROMPT_TEMPLATE,
+      runner: async () => [],
+    });
+    expect(result.status).toBe('no-pending');
+    expect(existsSync(join(harness.kbDir, 'INDEX.md'))).toBe(true);
+  });
+
+  it('buildBatchPayload includes referenced existing nodes only', () => {
+    // Two existing nodes; only one is referenced by the batch.
+    mkdirSync(join(harness.nodesDir, 'practice'), { recursive: true });
+    for (const id of ['practice-x', 'practice-y']) {
+      const fm = matter.stringify(`# ${id}\nBody.\n`, {
+        schema_version: 1,
+        id,
+        title: id,
+        kind: 'practice',
+        tags: [],
+        valid_from: '2026-01-01T00:00:00Z',
+        valid_until: null,
+        updated: '2026-01-01T00:00:00Z',
+        supersedes: null,
+        superseded_by: null,
+        derived_from: [],
+        relates_to: [],
+        depends_on: [],
+        confidence: 'high',
+        summary: 's',
+      });
+      writeFileSync(join(harness.nodesDir, 'practice', `${id}.md`), fm);
+    }
+    seedSession(
+      harness,
+      's',
+      [{ ...makeCandidate('practice', 'Hi'), supports_existing_node: 'practice-x' }],
+      [],
+    );
+    const sessions = listPendingSessions(harness.sessionsDir);
+    const payload = buildBatchPayload(sessions, harness.kbDir, harness.nodesDir);
+    expect(payload.existing_nodes.map((n) => n.id)).toEqual(['practice-x']);
+  });
+});

--- a/tests/lib/index-gen.test.ts
+++ b/tests/lib/index-gen.test.ts
@@ -1,0 +1,124 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import matter from 'gray-matter';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { generateGraph, generateIndex } from '../../src/lib/index-gen.js';
+
+interface NodeSeed {
+  kind: 'practice' | 'map';
+  id: string;
+  title: string;
+  summary: string;
+  tags?: string[];
+  updated?: string;
+  valid_until?: string | null;
+  superseded_by?: string | null;
+}
+
+function seedNodes(root: string, seeds: NodeSeed[]): void {
+  for (const s of seeds) {
+    const dir = join(root, s.kind);
+    mkdirSync(dir, { recursive: true });
+    const body = `# ${s.title}\n\nBody.\n`;
+    const fm = matter.stringify(body, {
+      schema_version: 1,
+      id: s.id,
+      title: s.title,
+      kind: s.kind,
+      tags: s.tags ?? [],
+      valid_from: '2026-01-01T00:00:00Z',
+      valid_until: s.valid_until ?? null,
+      updated: s.updated ?? '2026-01-01T00:00:00Z',
+      supersedes: null,
+      superseded_by: s.superseded_by ?? null,
+      derived_from: [],
+      relates_to: [],
+      depends_on: [],
+      confidence: 'high',
+      summary: s.summary,
+    });
+    writeFileSync(join(dir, `${s.id}.md`), fm);
+  }
+}
+
+describe('generateIndex', () => {
+  let root: string;
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'kb-index-'));
+  });
+  afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+  it('renders practice and map sections sorted by updated desc', () => {
+    seedNodes(root, [
+      {
+        kind: 'practice',
+        id: 'practice-a',
+        title: 'A practice',
+        summary: 'A summary',
+        updated: '2026-04-01T00:00:00Z',
+      },
+      {
+        kind: 'practice',
+        id: 'practice-b',
+        title: 'B practice',
+        summary: 'B summary',
+        updated: '2026-05-01T00:00:00Z',
+      },
+      { kind: 'map', id: 'map-x', title: 'X map', summary: 'X summary' },
+    ]);
+    const out = generateIndex(root, { now: new Date('2026-05-11T10:00:00Z') });
+    expect(out.nodeCount).toBe(3);
+    expect(out.content).toContain('## Practice (how we build)');
+    expect(out.content).toContain('## Map (what exists)');
+    const aIdx = out.content.indexOf('A practice');
+    const bIdx = out.content.indexOf('B practice');
+    expect(bIdx).toBeGreaterThan(0);
+    expect(bIdx).toBeLessThan(aIdx);
+    expect(out.content).toMatch(/nodes_hash:\s+['"]?sha256:/);
+    expect(out.content).toMatch(/3 nodes • 3 currently valid • 0 superseded/);
+  });
+
+  it('lists superseded nodes in their own section and counts them as invalid', () => {
+    seedNodes(root, [
+      {
+        kind: 'practice',
+        id: 'practice-old',
+        title: 'Old',
+        summary: 'old summary',
+        valid_until: '2026-04-01T00:00:00Z',
+        superseded_by: 'practice-new',
+      },
+      { kind: 'practice', id: 'practice-new', title: 'New', summary: 'new summary' },
+    ]);
+    const out = generateIndex(root);
+    expect(out.content).toContain('## Recently superseded');
+    expect(out.content).toContain('superseded by practice-new');
+    expect(out.content).toMatch(/2 nodes • 1 currently valid • 1 superseded/);
+  });
+
+  it('renders an empty index gracefully when nodes/ is missing', () => {
+    const out = generateIndex(join(root, 'nope'));
+    expect(out.nodeCount).toBe(0);
+    expect(out.content).toContain('_None yet._');
+  });
+});
+
+describe('generateGraph', () => {
+  let root: string;
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'kb-graph-'));
+  });
+  afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+  it('emits a per-node block with edges and frontmatter', () => {
+    seedNodes(root, [
+      { kind: 'practice', id: 'practice-a', title: 'A', summary: 'a' },
+      { kind: 'map', id: 'map-b', title: 'B', summary: 'b' },
+    ]);
+    const out = generateGraph(root);
+    expect(out.content).toContain('## practice-a');
+    expect(out.content).toContain('## map-b');
+    expect(out.content).toContain('Total nodes: 2');
+  });
+});

--- a/tests/lib/nodes.test.ts
+++ b/tests/lib/nodes.test.ts
@@ -1,0 +1,135 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  computeNodesHash,
+  deriveNodeId,
+  ensureUniqueId,
+  proposalFilename,
+  readAllNodes,
+  slugify,
+  writeProposalFile,
+} from '../../src/lib/nodes.js';
+import type { ProposalFrontmatter } from '../../src/lib/schemas.js';
+
+function seedNode(dir: string, kind: 'practice' | 'map', id: string, body = '# body\n'): void {
+  const file = join(dir, kind, `${id}.md`);
+  mkdirSync(join(dir, kind), { recursive: true });
+  const fm = [
+    '---',
+    'schema_version: 1',
+    `id: ${id}`,
+    `title: "${id} title"`,
+    `kind: ${kind}`,
+    'tags: [a, b]',
+    'valid_from: "2026-01-01T00:00:00Z"',
+    'valid_until: null',
+    'updated: "2026-01-01T00:00:00Z"',
+    'supersedes: null',
+    'superseded_by: null',
+    'derived_from: []',
+    'relates_to: []',
+    'depends_on: []',
+    'confidence: high',
+    `summary: "summary for ${id}"`,
+    '---',
+    '',
+    body,
+  ].join('\n');
+  writeFileSync(file, fm);
+}
+
+describe('nodes helpers', () => {
+  let root: string;
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'kb-nodes-'));
+  });
+  afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+  it('reads all valid nodes and skips malformed files', () => {
+    seedNode(root, 'practice', 'practice-x');
+    seedNode(root, 'map', 'map-y');
+    // Garbage file should be ignored.
+    mkdirSync(join(root, 'practice'), { recursive: true });
+    writeFileSync(join(root, 'practice', 'broken.md'), '---\nnot: valid\n---\nbody');
+
+    const nodes = readAllNodes(root);
+    expect(nodes.map((n) => n.frontmatter.id).sort()).toEqual(['map-y', 'practice-x']);
+  });
+
+  it('computeNodesHash is deterministic and content-sensitive', () => {
+    seedNode(root, 'practice', 'practice-a', '# v1\n');
+    const h1 = computeNodesHash(root);
+    seedNode(root, 'practice', 'practice-a', '# v2\n');
+    const h2 = computeNodesHash(root);
+    seedNode(root, 'practice', 'practice-a', '# v1\n');
+    const h3 = computeNodesHash(root);
+    expect(h1).toBe(h3);
+    expect(h1).not.toBe(h2);
+    expect(h1).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('hash differs when adding a file', () => {
+    seedNode(root, 'practice', 'practice-a');
+    const before = computeNodesHash(root);
+    seedNode(root, 'map', 'map-b');
+    expect(computeNodesHash(root)).not.toBe(before);
+  });
+
+  it('slugify and deriveNodeId match the kind-slug pattern', () => {
+    expect(slugify('Bravo Insider — module!!')).toBe('bravo-insider-module');
+    expect(deriveNodeId('practice', 'Use DI in controllers')).toBe(
+      'practice-use-di-in-controllers',
+    );
+    expect(slugify('   ')).toBe('untitled');
+  });
+
+  it('ensureUniqueId appends a suffix when colliding', () => {
+    const set = new Set(['practice-foo']);
+    expect(ensureUniqueId(set, 'practice-foo')).toBe('practice-foo-2');
+    set.add('practice-foo-2');
+    expect(ensureUniqueId(set, 'practice-foo')).toBe('practice-foo-3');
+  });
+
+  it('writeProposalFile serializes valid frontmatter and round-trips', () => {
+    const proposedDir = join(root, '_proposed');
+    const fm: ProposalFrontmatter = {
+      schema_version: 1,
+      id: 'practice-write-test',
+      title: 'Write test',
+      kind: 'practice',
+      tags: ['x'],
+      valid_from: '2026-05-11T10:00:00Z',
+      valid_until: null,
+      updated: '2026-05-11T10:00:00Z',
+      supersedes: null,
+      superseded_by: null,
+      derived_from: ['session-1.md'],
+      relates_to: [],
+      depends_on: [],
+      confidence: 'high',
+      summary: 'For testing the proposal writer.',
+      proposal: {
+        kind: 'addition',
+        source_sessions: ['session-1'],
+        target_node: null,
+        rationale: 'unit test',
+        suggested_resolution: null,
+        curator_log: null,
+      },
+    };
+    const written = writeProposalFile({
+      proposedDir,
+      proposalKind: 'additions',
+      filename: proposalFilename('practice', 'practice-write-test'),
+      frontmatter: fm,
+      body: '# Write test\n\nBody.',
+    });
+    const raw = readFileSync(written, 'utf8');
+    expect(raw).toContain('id: practice-write-test');
+    expect(raw).toContain('proposal:');
+    expect(raw).toContain('rationale: unit test');
+    expect(raw).toContain('# Write test');
+  });
+});


### PR DESCRIPTION
## Summary

Ships Phase M3 — the curate pipeline and the manual-add path. After this PR, captured session logs can flow all the way through stage-2 extraction into reviewable proposals.

### Curator pipeline (`ai-knowledge-base curate`, `/kb:curate`)

- Spawns `claude -p` per batch against `templates/prompts/curator.md`, batched by count (`--batch-size`, default 10) and estimated token budget (`--token-budget`, default 50K).
- Acquires the curator lock on `.ai/.kb-builder/state.json` (`name: curator`, PID + 30-min TTL); refuses to run concurrently.
- Streams JSON output to `.ai/knowledge-base/_logs/curator/<ulid>__<timestamp>.jsonl`.
- Cross-batch dedup: two actions targeting the same `proposed_node.id` collapse, keeping the higher-confidence one.
- Writes proposals to `_proposed/{additions,modifications,contradictions}/`. **Contradictions always carry `suggested_resolution: null`** — the reviewer chooses, the curator never auto-resolves.
- Regenerates `INDEX.md` and `GRAPH.md` from the current `nodes/` tree (deterministic, no LLM, content-derived `nodes_hash`).
- Marks session logs with `curator_processed_at` and `curator_run_id` so they aren't re-curated.

### Manual-add path

- `ai-knowledge-base node add` — inquirer-driven CLI that drafts a node from manual input.
- `/kb:add` — slash command that runs in the user's existing session (no `claude -p`), bound to `Write`.
- Both land in `_proposed/additions/<kind>-<slug>.md` with `proposal.rationale: "manual"`, never directly in `nodes/`.

### Review TUI (`ai-knowledge-base proposals review`)

- Walks pending proposals one at a time, accept/reject/skip for additions and modifications.
- Contradictions require picking a resolution (`supersede`, `keep_both`, `reject`) before accept.
- Accepting with `supersede` updates the target node's `valid_until` and `superseded_by` automatically.
- `--list` prints the pending proposals and exits.

### Schemas

New Zod schemas, all `schema_version: 1`:

- `NodeFrontmatterSchema`
- `ProposalFrontmatterSchema` (NodeFrontmatter + `proposal` block)
- `CuratorActionSchema` / `CuratorOutputSchema` (curator subprocess output contract)
- `IndexFrontmatterSchema`, `GraphFrontmatterSchema`

### Docs

- Reference > CLI commands: full coverage of `curate`, `node add`, `proposals review`.
- Reference > Slash commands (new page).
- Customization > Editing the curator prompt (new page).
- Troubleshooting > Reading `_logs/curator/` (new page).
- Getting Started > First capture → curate: full walkthrough.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] `npm test` — 100 tests pass (was 75) + 1 skipped (real-gitleaks gate)
- [x] Curate library tests: routing into `additions/`/`modifications/`/`contradictions/`, contradictions never auto-resolve, locking, INDEX/GRAPH regen on no-pending
- [x] Manual node-add tests: rationale=manual, kind=addition, id collision suffixing
- [x] Proposals review tests: accept moves into `nodes/<kind>/`, reject deletes, contradiction supersede flow updates target node
- [x] INDEX/GRAPH generators tested with deterministic fixtures
- [x] `nodes_hash` shown to be content-sensitive and stable across runs

https://claude.ai/code/session_016M6GbTq6TgArUFGcZcxNUw

---
_Generated by [Claude Code](https://claude.ai/code/session_016M6GbTq6TgArUFGcZcxNUw)_