### PR TITLE
feat(M4): SessionStart consume hook + dangling derived_from doctor

### DIFF
--- a/docs/core-concepts/how-it-works.md
+++ b/docs/core-concepts/how-it-works.md
@@ -1,0 +1,122 @@
+---
+title: How it works
+parent: Core Concepts
+nav_order: 1
+---
+
+# How it works
+
+Three pipelines connect Claude Code session activity to a curated knowledge base committed in your repo. Each pipeline is independent — you can disable any one of them (by removing its hook entry) without breaking the others.
+
+## 1. Capture — turn transcripts into candidates
+
+Trigger: every time Claude Code fires `Stop`, `SessionEnd`, or `PreCompact`. Two stages.
+
+**Stage 1 (sync, ≤1 s deadline).** The `kb-capture.mjs` hook reads the transcript path from the hook input, parses out the user/assistant text, runs gitleaks redaction over it, and writes `_sessions/<YYYYMMDD-HHmm-id>.md` with `stage_2_status: pending`. The session log path is appended to `_sessions/.queue.json`. If gitleaks isn't available or crashes, capture aborts — the security guarantee outweighs availability.
+
+**Stage 2 (async, on next `SessionStart`).** The `kb-stage2-drain.mjs` hook pops up to 5 entries off the queue. For each, it spawns `claude -p` against the redacted transcript with the [stage-2 prompt](../customization/stage-2-prompt.md), streams the JSON output to `_logs/stage-2/<id>__<ts>.jsonl`, parses the final result, validates it against the Zod schema, and writes the structured `practice` and `map` candidates back into the session log's frontmatter. Failures retry (max 3 attempts) and then mark the log `stage_2_status: skipped`.
+
+End state: every successfully-processed session log carries `stage_2_status: done` plus arrays of candidate nodes in its frontmatter. Nothing has been written to `nodes/` yet — the assistant has no visibility of these candidates until they're curated.
+
+## 2. Curate — turn candidates into proposals
+
+Trigger: explicit. Either `/kb:curate` (slash command) or `ai-knowledge-base curate` (CLI). The consume hook nudges the contributor when ≥ 5 session logs are pending, throttled to once per hour, but the contributor runs the curator deliberately.
+
+`ai-knowledge-base curate`:
+
+1. Acquires the `curator` lock on `state.json`.
+2. Batches every stage-2-`done`, not-yet-curated session log by count (default 10) and approximate token budget (default 50K).
+3. Spawns one `claude -p` per batch with the [curator prompt](../customization/curator-prompt.md). The curator output is a list of `add` / `modify` / `contradict` / `drop` actions, each carrying a proposed node.
+4. Writes one proposal file per non-drop action into `_proposed/{additions,modifications,contradictions}/`. Contradictions always carry `suggested_resolution: null` — the curator never auto-resolves.
+5. Stamps each session log with `curator_processed_at` and `curator_run_id` so it isn't re-curated.
+6. Regenerates `INDEX.md` and `GRAPH.md` from the current `nodes/` (deterministic, no LLM — see [`src/lib/index-gen.ts`](https://github.com/e0ipso/ai-knowledge-base/blob/main/src/lib/index-gen.ts)).
+
+End state: proposals are on disk awaiting review. `ai-knowledge-base proposals review` walks the reviewer through each one. Accepted proposals lose their `proposal` frontmatter block and move into `nodes/<kind>/`. Rejected proposals are deleted.
+
+## 3. Consume — inject the KB at session start
+
+Trigger: every `SessionStart` event from Claude Code. Synchronous.
+
+The `kb-session-start.mjs` hook reads the current `INDEX.md`, detects staleness (by comparing the frontmatter `nodes_hash` against the live hash of `nodes/`), counts pending session logs, and emits a single JSON line on stdout that Claude Code merges into the session's context:
+
+```json
+{
+  "hookSpecificOutput": {
+    "hookEventName": "SessionStart",
+    "additionalContext": "<INDEX body + optional warnings + optional nudge>"
+  }
+}
+```
+
+When the assistant turns on, it already has the current knowledge base summary in its context. There is no MCP, no extra tool calls — the index is just there, like a `CLAUDE.md` file.
+
+End state: knowledge that was captured (and curated, and reviewed) is back in front of the assistant for the next conversation.
+
+## How the pieces hand off
+
+```
+                Stop / SessionEnd / PreCompact
+                            │
+                            ▼
+                  kb-capture.mjs (sync)
+                            │
+                            ▼
+                   _sessions/<log>.md
+                   stage_2_status: pending
+                            │
+                            ▼
+                       .queue.json
+                            │
+                            │   SessionStart
+                            ▼
+              kb-stage2-drain.mjs (async)
+                            │
+                            ▼
+                   _sessions/<log>.md
+                   stage_2_status: done
+                   proposals: { practice, map }
+                            │
+                            │   /kb:curate
+                            ▼
+                ai-knowledge-base curate
+                            │
+                            ▼
+              _proposed/{additions,modifications,contradictions}/
+                            │
+                            │   ai-knowledge-base proposals review
+                            ▼
+                      nodes/<kind>/<slug>.md
+                            │
+                            ▼
+                        INDEX.md  (regen)
+                            │
+                            │   SessionStart
+                            ▼
+              kb-session-start.mjs (sync)
+                            │
+                            ▼
+                   additionalContext  →  assistant
+```
+
+## Bootstrap pipelines
+
+There are two **optional** pipelines that seed the KB from existing markdown documentation. They share the same proposal output path as the curator:
+
+- `/kb:bootstrap` — agent-driven, in-session, for the first time you adopt the KB on a project with existing docs.
+- `ai-knowledge-base bootstrap-incremental --from <path>` — deterministic, hash-aware CLI for re-runs after docs change.
+
+See [Bootstrap](../bootstrap/) for both walkthroughs.
+
+## What is and isn't automatic
+
+| Step | Automatic? |
+|---|---|
+| Stage-1 capture (Stop/SessionEnd/PreCompact) | Yes. Hooks fire automatically; gitleaks redacts; logs are written. |
+| Stage-2 extraction | Yes. Runs on next SessionStart in the background. |
+| Curate (stage-2 candidates → proposals) | **No.** You run `/kb:curate` or the CLI deliberately. The nudge is a notification, not a trigger. |
+| Proposal review | **No.** You step through proposals interactively. |
+| INDEX/GRAPH regeneration | Yes, every time the curator runs (or `node add` finishes). |
+| Consume injection | Yes. The sync `SessionStart` hook injects INDEX on every session. |
+| Bootstrap (`/kb:bootstrap` or `bootstrap-incremental`) | **No.** Opt-in. |
+
+This split is deliberate. The expensive, judgment-heavy steps (curating, reviewing, bootstrapping) stay manual; the deterministic, cheap steps run on their own.

--- a/docs/core-concepts/index.md
+++ b/docs/core-concepts/index.md
@@ -1,15 +1,21 @@
 ---
 title: Core Concepts
 nav_order: 3
-has_children: false
+has_children: true
 permalink: /core-concepts/
 ---
 
 # Core Concepts
 
-_Filled in across M2–M4. See [PRD §2](https://github.com/e0ipso/ai-knowledge-base/blob/main/PRD.md#2-solution-overview) and [IMPLEMENTATION §1](https://github.com/e0ipso/ai-knowledge-base/blob/main/IMPLEMENTATION.md#1-architecture-overview) in the meantime._
+The knowledge base is a per-repo store of curated, contributor-reviewed knowledge extracted from your AI coding sessions. Three pipelines move content through it:
 
-Topics:
+- **Capture** (stage 1, then stage 2) — turns raw transcripts into structured candidate nodes.
+- **Curate** — turns candidates into proposals for human review; accepted proposals become canonical nodes.
+- **Consume** — injects the current knowledge base summary at session start so the assistant uses it.
 
-- How it works (capture / curate / consume pipeline).
-- The knowledge model (`practice` vs `map` nodes, validity windows, provenance).
+Pages:
+
+- [How it works](how-it-works.md) — the three pipelines and how they hand off.
+- [Knowledge model](knowledge-model.md) — `practice` vs `map` nodes, validity windows, provenance.
+
+See [PRD §2](https://github.com/e0ipso/ai-knowledge-base/blob/main/PRD.md#2-solution-overview) and [IMPLEMENTATION §1](https://github.com/e0ipso/ai-knowledge-base/blob/main/IMPLEMENTATION.md#1-architecture-overview) for the design.

--- a/docs/core-concepts/knowledge-model.md
+++ b/docs/core-concepts/knowledge-model.md
@@ -1,0 +1,94 @@
+---
+title: Knowledge model
+parent: Core Concepts
+nav_order: 2
+---
+
+# Knowledge model
+
+Every piece of curated knowledge lives in a single markdown file under `.ai/knowledge-base/nodes/<kind>/<slug>.md` with a small Zod-validated YAML frontmatter. Two kinds:
+
+## Practice nodes — _how we build_
+
+Imperative project guidance. Conventions, prohibitions, gotchas, workflow rules.
+
+```yaml
+---
+schema_version: 1
+id: practice-prefer-constructor-injection
+title: "Prefer constructor injection over service container lookups"
+kind: practice
+tags: [drupal, di, services]
+valid_from: 2026-05-10T14:30:00Z
+valid_until: null
+updated: 2026-05-10T14:30:00Z
+supersedes: null
+superseded_by: null
+derived_from:
+  - 20260510-1014-session-abc.md
+relates_to: [map-bravo-cards-module]
+depends_on: []
+confidence: high
+summary: "Inject dependencies via the constructor; avoid \Drupal::service() in module code."
+---
+
+# Prefer constructor injection over service container lookups
+
+Body explains the rule, the rationale, and when an exception is OK.
+```
+
+## Map nodes — _what exists_
+
+Named entities in this project. Modules, services, vocabulary, locations.
+
+```yaml
+---
+schema_version: 1
+id: map-bravo-cards-module
+title: "Bravo Cards module"
+kind: map
+tags: [module, bravo, personalization]
+…
+summary: "Personalized card module at modules/custom/bravo_cards/."
+---
+
+# Bravo Cards module
+
+What it is, where it lives, the major classes.
+```
+
+## Why two kinds
+
+A practice ("always do X") and a map entry ("X is our module for Y") feel similar but are useful at different moments. Practice nodes answer "what should I do?" Map nodes answer "what is this thing called?" The stage-2 prompt and the curator are calibrated to split combined content across both kinds — when a doc says "use `bravo_analytics.dispatcher` — our service for tracking events," the practice node owns "use the dispatcher" and the map node owns "what the dispatcher is."
+
+## Validity window
+
+`valid_from` and `valid_until` are ISO-8601 timestamps. A node is "valid" when `valid_until` is `null`. Superseded nodes get `valid_until` set to the supersession time and `superseded_by` set to the new node's id. The reviewer manages this automatically when accepting a contradiction proposal with `suggested_resolution: supersede`.
+
+Validity is informational, not enforced. Superseded nodes still live in `nodes/`; they're listed under "Recently superseded" at the bottom of `INDEX.md` for the most recent 5.
+
+## Provenance
+
+`derived_from` lists the source of the node. Three flavors:
+
+- A session log filename (`20260510-1014-session-abc.md`) — the node came from a captured conversation.
+- A repo-relative path (`docs/architecture/auth.md`) — the node came from existing documentation via `/kb:bootstrap` or `bootstrap-incremental`.
+- An absolute path — rare, but supported for nodes seeded from outside the repo.
+
+`ai-knowledge-base doctor --verbose` lists `derived_from` references that no longer resolve on disk. Stale references are a warning, not an error — the consume path silently ignores them; the curator treats them as "evidence not available" and proceeds.
+
+## Relations
+
+`relates_to` (loose) and `depends_on` (strict ordering) are arrays of node ids. They are not enforced — there is no foreign-key check. They feed `GRAPH.md` (the unfiltered edge listing) which the assistant can read when it wants to walk the graph. `INDEX.md` does not render them.
+
+## Confidence
+
+`low` / `medium` / `high`. The curator and bootstrap-incremental default to `medium` when the source is implicit or the doc looks aspirational; they escalate to `high` when the rule is stated explicitly with rationale and the source looks actively maintained. The reviewer can edit confidence during `proposals review` by hand-editing the proposal frontmatter before accepting it.
+
+## Schema versioning
+
+Every frontmatter shape (nodes, session logs, proposals, INDEX/GRAPH frontmatter, state files) carries `schema_version: 1`. v1 to v2 will ship a migration script under `src/lib/migrations/`. Hand-edit the schema at your own risk — `proposals review` and `doctor` both fail closed on shapes they can't validate.
+
+## Where the schemas live
+
+All Zod schemas are in [`src/lib/schemas.ts`](https://github.com/e0ipso/ai-knowledge-base/blob/main/src/lib/schemas.ts). Re-read it when you're unsure what a field allows; the source of truth is the schema, not the docs.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -38,7 +38,15 @@ What `init` writes:
 ai-knowledge-base doctor [--verbose]
 ```
 
-Verify the installation. Checks Node version, the `claude` CLI, gitleaks, the installed-version marker, the pre-commit config, and the gitignore block. Exits 0 if there are no errors (warnings are allowed). Exits 1 if any check fails.
+Verify the installation. Checks:
+
+- Node ≥ 22, `claude` CLI on PATH, gitleaks on PATH.
+- `.ai/.kb-builder/installed-version` marker.
+- `.pre-commit-config.yaml` present with a gitleaks entry.
+- `.gitignore` carries the managed ai-knowledge-base block.
+- Every `derived_from` reference under `nodes/` resolves on disk (session log filename, repo-relative path, or absolute path). Dangling references are a warning, not an error — the consume path silently ignores them. `--verbose` prints the offending references after the check summary.
+
+Exits 0 if there are no errors (warnings are allowed). Exits 1 if any check fails.
 
 ## `status`
 

--- a/docs/reference/hook-events.md
+++ b/docs/reference/hook-events.md
@@ -6,10 +6,11 @@ nav_order: 3
 
 # Hook events
 
-`init` registers two hook scripts:
+`init` registers three hook scripts:
 
 - `.claude/hooks/kb-capture.mjs` — runs on `Stop`, `SessionEnd`, and `PreCompact`. Implements **stage-1 capture**: dedup, secret-scan with redaction, write a session log, append to `.queue.json`.
 - `.claude/hooks/kb-stage2-drain.mjs` — runs on `SessionStart` with `async: true`. Drains the stage-2 queue by spawning `claude -p` for each pending session log; updates the log's frontmatter with the structured extraction output.
+- `.claude/hooks/kb-session-start.mjs` — runs on `SessionStart` synchronously. **Consume** step: injects `INDEX.md` as `additionalContext` for the session, appends a stale-INDEX warning when `nodes_hash` has drifted, and emits a one-line nudge when the curate backlog crosses the threshold (hourly throttle).
 
 ## Registered events
 
@@ -18,13 +19,14 @@ nav_order: 3
 | `Stop` | Captures after every assistant turn ends. The transcript hash changes turn-by-turn, so this produces one log per substantive checkpoint within a session. | Synchronous, ≤1 s deadline. Dedup window prevents overlap with the other two events. |
 | `SessionEnd` | Captures when the user explicitly closes or clears the session. The strongest signal that the session is done. | Same pipeline as `Stop`. |
 | `PreCompact` | Fires immediately before Claude Code compacts context. Without this, content about to be discarded would be lost. | Same pipeline as `Stop`. The 1-second deadline still applies; if you have a very long transcript and capture would exceed it, the hook exits silently rather than blocking compaction. |
-| `SessionStart` | Runs the **stage-2 drain** (M2). For each entry in `.queue.json`, spawns `claude -p --output-format stream-json --verbose` against the redacted transcript slice and writes the structured extraction back into the session log's frontmatter. | `async: true` — stdout does not flow into the parent session. Stops after `drainBound` entries (default 5), the rest are deferred to the next session. |
+| `SessionStart` (drain, async) | Runs the **stage-2 drain** (M2). For each entry in `.queue.json`, spawns `claude -p --output-format stream-json --verbose` against the redacted transcript slice and writes the structured extraction back into the session log's frontmatter. | `async: true` — stdout does not flow into the parent session. Stops after `drainBound` entries (default 5), the rest are deferred to the next session. |
+| `SessionStart` (consume, sync) | Runs the **consume** step (M4). Loads `INDEX.md`, emits it as `hookSpecificOutput.additionalContext` so the assistant sees the current KB summary at the start of every session. Appends a stale-INDEX warning when `nodes_hash` drift is detected. Appends a curate nudge when the pending-session backlog ≥ 5 (default) AND it has been ≥ 1 hour since the last nudge (`last_nudged_at` lives in `state.json`). | Synchronous, ≤1 s deadline. stdout is JSON; non-fatal errors go to stderr. |
 
-The three stage-1 events route through the same `kb-capture.mjs` script, so the only difference in the resulting session log is the `captured_by` frontmatter field (`stop`, `session_end`, or `pre_compact`). `SessionStart` is wired separately to `kb-stage2-drain.mjs`.
+The three stage-1 events route through the same `kb-capture.mjs` script, so the only difference in the resulting session log is the `captured_by` frontmatter field (`stop`, `session_end`, or `pre_compact`). `SessionStart` runs two scripts: `kb-stage2-drain.mjs` (async drain) and `kb-session-start.mjs` (sync consume injection). They are independent — failure in one does not block the other.
 
 ## Recursion guard
 
-Both hooks check `KB_BUILDER_INTERNAL=1` in their environment and exit immediately if set. The stage-2 drain (and the curator in M3) spawns `claude -p` subprocesses with this env var so that the child Claude Code instance doesn't fire its own capture or drain hooks and trigger recursive work.
+All three hooks check `KB_BUILDER_INTERNAL=1` in their environment and exit immediately if set. The stage-2 drain (M2), the curator (M3), and `bootstrap-incremental` (M3.5) all spawn `claude -p` subprocesses with this env var so that the child Claude Code instance doesn't fire its own capture, drain, or consume hooks and trigger recursive work.
 
 If you wrap the `claude` CLI in a script that spawns sessions for any reason, set `KB_BUILDER_INTERNAL=1` in those subprocesses.
 
@@ -87,7 +89,7 @@ After `init`, `.claude/settings.json` contains a block per event:
 }
 ```
 
-The same pattern repeats for `SessionEnd` and `PreCompact`. `SessionStart` carries `"async": true` so the drain does not block session startup:
+The same pattern repeats for `SessionEnd` and `PreCompact`. `SessionStart` carries two entries — the drain (async, so it does not block startup) and the consume injection (sync, since its output must reach the assistant before the first turn):
 
 ```json
 {
@@ -101,6 +103,14 @@ The same pattern repeats for `SessionEnd` and `PreCompact`. `SessionStart` carri
             "async": true
           }
         ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "KB_BUILDER_HOOK=SessionStart node .claude/hooks/kb-session-start.mjs"
+          }
+        ]
       }
     ]
   }
@@ -108,3 +118,19 @@ The same pattern repeats for `SessionEnd` and `PreCompact`. `SessionStart` carri
 ```
 
 Existing user-defined hooks in the same file are preserved on re-init.
+
+## Consume hook (`SessionStart`, sync)
+
+The consume hook is the M4 read path. Per invocation:
+
+1. **Recursion guard.** Exits immediately if `KB_BUILDER_INTERNAL=1` is set.
+2. **Resolve `INDEX.md`.** If missing, emits an "_The knowledge base is empty._" stub so the assistant still sees a coherent context. If present, parses the frontmatter and strips it before injection.
+3. **Stale detection.** Compares the frontmatter `nodes_hash` against `computeNodesHash(nodes/)`. On mismatch, appends `> KB index is stale — run \`ai-knowledge-base index rebuild\` to refresh.`
+4. **Nudge throttle.** Counts session logs with `stage_2_status: done` and no `curator_processed_at`. If the count ≥ threshold (default 5) AND `now - state.last_nudged_at ≥ 1 hour`, appends `> You have N pending session log(s). Run \`/kb:curate\` (or \`ai-knowledge-base curate\`) when ready.` and writes the new `last_nudged_at` back to `state.json`.
+5. **Emit.** Writes a single JSON line to stdout matching Claude Code's SessionStart contract:
+
+   ```json
+   {"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"<INDEX body + optional warnings>"}}
+   ```
+
+The hook has a 1-second hard deadline (same as stage-1 capture). If it overruns, the timer exits process 0 so session startup is never blocked.

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -1,7 +1,9 @@
 import { execFile } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
+import { isAbsolute, join } from 'node:path';
 import { promisify } from 'node:util';
 import { log } from '../lib/log.js';
+import { readAllNodes } from '../lib/nodes.js';
 import { findRepoRoot, repoPaths } from '../lib/paths.js';
 
 const exec = promisify(execFile);
@@ -19,7 +21,7 @@ interface NamedCheck {
   result: CheckResult;
 }
 
-export async function runDoctor(_opts: DoctorOptions): Promise<number> {
+export async function runDoctor(opts: DoctorOptions): Promise<number> {
   const root = findRepoRoot();
   const paths = repoPaths(root);
 
@@ -40,6 +42,21 @@ export async function runDoctor(_opts: DoctorOptions): Promise<number> {
     result: checkGitignore(paths.gitignoreFile),
   });
 
+  const dangling = collectDanglingDerivedFrom(root, paths.nodesDir, paths.sessionsDir);
+  checks.push({
+    name: 'derived_from references resolve',
+    result:
+      dangling.length === 0
+        ? { ok: true, detail: 'no dangling references' }
+        : {
+            ok: false,
+            level: 'warn',
+            detail: `${dangling.length} dangling reference(s)${
+              opts.verbose ? '' : ' — re-run with --verbose to list them'
+            }`,
+          },
+  });
+
   let failures = 0;
   let warnings = 0;
   for (const c of checks) {
@@ -54,6 +71,14 @@ export async function runDoctor(_opts: DoctorOptions): Promise<number> {
     }
   }
 
+  if (opts.verbose && dangling.length > 0) {
+    log.plain('');
+    log.plain('Dangling derived_from references:');
+    for (const d of dangling) {
+      log.plain(`  - ${d.nodeId}: ${d.reference}`);
+    }
+  }
+
   log.plain('');
   if (failures === 0 && warnings === 0) {
     log.success('All checks passed.');
@@ -65,6 +90,42 @@ export async function runDoctor(_opts: DoctorOptions): Promise<number> {
   }
   log.error(`${failures} error(s), ${warnings} warning(s).`);
   return 1;
+}
+
+interface DanglingRef {
+  nodeId: string;
+  reference: string;
+}
+
+/**
+ * Collects every `derived_from` entry whose target does not exist on disk.
+ * A reference resolves if any of these match:
+ *   - It is a bare filename and exists under `_sessions/`.
+ *   - It is a repo-relative path and exists when resolved against `root`.
+ *   - It is an absolute path and exists as-is.
+ */
+export function collectDanglingDerivedFrom(
+  root: string,
+  nodesDir: string,
+  sessionsDir: string,
+): DanglingRef[] {
+  if (!existsSync(nodesDir)) return [];
+  const out: DanglingRef[] = [];
+  for (const node of readAllNodes(nodesDir)) {
+    for (const ref of node.frontmatter.derived_from) {
+      if (resolvesOnDisk(ref, root, sessionsDir)) continue;
+      out.push({ nodeId: node.frontmatter.id, reference: ref });
+    }
+  }
+  return out;
+}
+
+function resolvesOnDisk(ref: string, root: string, sessionsDir: string): boolean {
+  if (ref.length === 0) return false;
+  if (isAbsolute(ref) && existsSync(ref)) return true;
+  if (existsSync(join(root, ref))) return true;
+  if (!ref.includes('/') && existsSync(join(sessionsDir, ref))) return true;
+  return false;
 }
 
 function checkNodeVersion(): CheckResult {

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -83,6 +83,7 @@ export async function runInit(opts: InitOptions): Promise<void> {
         scriptPath: '.claude/hooks/kb-stage2-drain.mjs',
         async: true,
       },
+      { event: 'SessionStart', scriptPath: '.claude/hooks/kb-session-start.mjs' },
     ]);
   }
 

--- a/src/hooks/kb-session-start.ts
+++ b/src/hooks/kb-session-start.ts
@@ -1,0 +1,85 @@
+/**
+ * SessionStart hook (sync).
+ *
+ * Injects the current `INDEX.md` body as additionalContext, optionally
+ * appends a stale-INDEX warning, and optionally appends a curate nudge
+ * when the pending-session backlog exceeds the threshold (hourly throttle).
+ *
+ * Output format: a JSON object on stdout matching Claude Code's
+ * `hookSpecificOutput.additionalContext` convention. Configured in
+ * `.claude/settings.json` without `async: true` so stdout actually flows
+ * back into the parent session.
+ */
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { buildSessionStartContext } from '../lib/session-start.js';
+import { findRepoRoot, repoPaths } from '../lib/paths.js';
+
+const PACKAGE_TAG = '[ai-knowledge-base]';
+const HARD_DEADLINE_MS = 1000;
+
+async function main(): Promise<void> {
+  // Recursion guard: stage-2 drain spawns `claude -p` which itself fires
+  // SessionStart. The drain runner sets KB_BUILDER_INTERNAL=1 on every
+  // child so this hook exits silently in that case.
+  if (process.env['KB_BUILDER_INTERNAL'] === '1') return;
+
+  // Hard wall-clock deadline so a slow filesystem can't block session
+  // start. unref() so the timer does not pin the event loop.
+  const deadline = setTimeout(() => process.exit(0), HARD_DEADLINE_MS);
+  deadline.unref();
+
+  const raw = await readStdin();
+  let input: { cwd?: unknown } = {};
+  if (raw.trim().length > 0) {
+    try {
+      input = JSON.parse(raw) as { cwd?: unknown };
+    } catch {
+      input = {};
+    }
+  }
+  const startCwd =
+    typeof input.cwd === 'string' && input.cwd.length > 0 ? input.cwd : process.cwd();
+  const root = findRepoRoot(startCwd);
+  const paths = repoPaths(root);
+  if (!existsSync(paths.installedVersionFile)) return;
+
+  try {
+    const result = buildSessionStartContext({
+      kbDir: paths.kbDir,
+      nodesDir: paths.nodesDir,
+      sessionsDir: paths.sessionsDir,
+      stateFile: join(paths.builderDir, 'state.json'),
+    });
+    process.stdout.write(
+      `${JSON.stringify({
+        hookSpecificOutput: {
+          hookEventName: 'SessionStart',
+          additionalContext: result.additionalContext,
+        },
+      })}\n`,
+    );
+  } catch (err) {
+    process.stderr.write(
+      `${PACKAGE_TAG} session-start error: ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+  }
+}
+
+function readStdin(): Promise<string> {
+  return new Promise((resolve) => {
+    if (process.stdin.isTTY) {
+      resolve('');
+      return;
+    }
+    let data = '';
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', (chunk: string) => {
+      data += chunk;
+    });
+    process.stdin.on('end', () => resolve(data));
+    process.stdin.on('error', () => resolve(''));
+  });
+}
+
+void main().catch(() => process.exit(0));

--- a/src/lib/session-start.ts
+++ b/src/lib/session-start.ts
@@ -1,0 +1,161 @@
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import matter from 'gray-matter';
+import { computeNodesHash } from './nodes.js';
+import { IndexFrontmatterSchema, SessionLogFrontmatterSchema } from './schemas.js';
+import { readState, writeState } from './state.js';
+
+export const DEFAULT_NUDGE_THRESHOLD = 5;
+export const NUDGE_THROTTLE_MS = 60 * 60 * 1000; // 1 hour
+
+export interface SessionStartContext {
+  kbDir: string;
+  nodesDir: string;
+  sessionsDir: string;
+  stateFile: string;
+  threshold?: number;
+  throttleMs?: number;
+  now?: () => Date;
+}
+
+export interface SessionStartResult {
+  /** Markdown text intended for injection into the session. */
+  additionalContext: string;
+  /** True if a nudge line was appended this run (and state mutated). */
+  nudged: boolean;
+  /** True if the index was missing and a stub was generated. */
+  indexMissing: boolean;
+  /** True if INDEX.md exists but its nodes_hash does not match nodes/. */
+  indexStale: boolean;
+  /** Number of pending session logs (stage_2 done, not curated). */
+  pendingSessions: number;
+}
+
+/**
+ * Builds the additional-context payload for the SessionStart sync hook.
+ *
+ * 1. Reads INDEX.md (or returns a "KB is empty" stub if missing).
+ * 2. Detects staleness by comparing the frontmatter `nodes_hash` against
+ *    the live hash of `nodes/`. If mismatched, appends a warning line.
+ * 3. Counts pending session logs and, when ≥ threshold and not throttled,
+ *    appends a nudge and persists `last_nudged_at` to `state.json`.
+ *
+ * Pure-ish: the only side effect is the state.json write when a nudge fires.
+ */
+export function buildSessionStartContext(ctx: SessionStartContext): SessionStartResult {
+  const now = ctx.now ?? (() => new Date());
+  const threshold = ctx.threshold ?? DEFAULT_NUDGE_THRESHOLD;
+  const throttleMs = ctx.throttleMs ?? NUDGE_THROTTLE_MS;
+
+  const { content: indexBody, frontmatterHash, missing } = loadIndex(ctx.kbDir);
+  const liveHash = computeNodesHash(ctx.nodesDir);
+  const indexStale = !missing && frontmatterHash !== null && frontmatterHash !== liveHash;
+
+  const pending = countPendingSessions(ctx.sessionsDir);
+  const state = readState(ctx.stateFile);
+  const nowDate = now();
+  const lastNudgedAt = parseLastNudgedAt(state.last_nudged_at ?? null);
+  const throttled =
+    lastNudgedAt !== null && nowDate.getTime() - lastNudgedAt.getTime() < throttleMs;
+  const shouldNudge = pending >= threshold && !throttled;
+
+  const lines: string[] = [];
+  lines.push(indexBody.trim());
+  if (indexStale) {
+    lines.push('');
+    lines.push(
+      `> KB index is stale — run \`ai-knowledge-base index rebuild\` to refresh (live hash differs from INDEX.md \`nodes_hash\`).`,
+    );
+  }
+  if (shouldNudge) {
+    lines.push('');
+    lines.push(
+      `> You have ${pending} pending session log(s). Run \`/kb:curate\` (or \`ai-knowledge-base curate\`) when ready.`,
+    );
+  }
+
+  if (shouldNudge) {
+    writeState(ctx.stateFile, { ...state, last_nudged_at: nowDate.toISOString() });
+  }
+
+  return {
+    additionalContext: lines.join('\n') + '\n',
+    nudged: shouldNudge,
+    indexMissing: missing,
+    indexStale,
+    pendingSessions: pending,
+  };
+}
+
+interface LoadedIndex {
+  content: string;
+  frontmatterHash: string | null;
+  missing: boolean;
+}
+
+function loadIndex(kbDir: string): LoadedIndex {
+  const indexFile = `${kbDir.replace(/[\\/]$/, '')}/INDEX.md`;
+  if (!existsSync(indexFile)) {
+    return {
+      content: stubIndex(),
+      frontmatterHash: null,
+      missing: true,
+    };
+  }
+  const raw = readFileSync(indexFile, 'utf8');
+  const parsed = matter(raw);
+  const result = IndexFrontmatterSchema.safeParse(parsed.data);
+  const hash = result.success ? normalizeNodesHash(result.data.nodes_hash) : null;
+  return {
+    content: parsed.content.trimStart(),
+    frontmatterHash: hash,
+    missing: false,
+  };
+}
+
+function stubIndex(): string {
+  return [
+    '# KB Index',
+    '',
+    '_The knowledge base is empty. Capture a session (the Stop hook fires automatically) or run `ai-knowledge-base node add` to seed it._',
+  ].join('\n');
+}
+
+function normalizeNodesHash(value: string): string {
+  // Stored as "sha256:<hex>"; compare against the raw hex from
+  // `computeNodesHash` by stripping the prefix.
+  return value.startsWith('sha256:') ? value.slice(7) : value;
+}
+
+/**
+ * Counts session logs that are stage-2-done but not yet curated. Mirrors the
+ * filter used by `listPendingSessions` in `src/lib/curate.ts`. Kept here so
+ * the consume hook does not have to load the entire curate module.
+ */
+export function countPendingSessions(sessionsDir: string): number {
+  if (!existsSync(sessionsDir)) return 0;
+  let count = 0;
+  for (const name of readdirSync(sessionsDir)) {
+    if (!name.endsWith('.md')) continue;
+    const file = join(sessionsDir, name);
+    try {
+      const parsed = matter(readFileSync(file, 'utf8'));
+      const fm = SessionLogFrontmatterSchema.safeParse(parsed.data);
+      if (!fm.success) continue;
+      if (fm.data.stage_2_status !== 'done') continue;
+      const data = parsed.data as { curator_processed_at?: unknown };
+      if (typeof data.curator_processed_at === 'string') continue;
+      count += 1;
+    } catch {
+      // Skip unreadable session logs; doctor will surface them.
+    }
+  }
+  return count;
+}
+
+function parseLastNudgedAt(value: string | null): Date | null {
+  if (value === null) return null;
+  const ms = Date.parse(value);
+  if (!Number.isFinite(ms)) return null;
+  return new Date(ms);
+}

--- a/tests/doctor-dangling.test.ts
+++ b/tests/doctor-dangling.test.ts
@@ -1,0 +1,90 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import matter from 'gray-matter';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { collectDanglingDerivedFrom } from '../src/commands/doctor.js';
+
+interface Harness {
+  root: string;
+  nodesDir: string;
+  sessionsDir: string;
+}
+
+function makeHarness(): Harness {
+  const root = mkdtempSync(join(tmpdir(), 'kb-doctor-dangling-'));
+  const nodesDir = join(root, '.ai/knowledge-base/nodes');
+  const sessionsDir = join(root, '.ai/knowledge-base/_sessions');
+  mkdirSync(join(nodesDir, 'practice'), { recursive: true });
+  mkdirSync(sessionsDir, { recursive: true });
+  return { root, nodesDir, sessionsDir };
+}
+
+function writeNode(harness: Harness, id: string, derivedFrom: string[]): void {
+  const fm = {
+    schema_version: 1,
+    id,
+    title: id,
+    kind: 'practice',
+    tags: [],
+    valid_from: '2026-01-01T00:00:00Z',
+    valid_until: null,
+    updated: '2026-01-01T00:00:00Z',
+    supersedes: null,
+    superseded_by: null,
+    derived_from: derivedFrom,
+    relates_to: [],
+    depends_on: [],
+    confidence: 'high',
+    summary: 's',
+  };
+  writeFileSync(join(harness.nodesDir, 'practice', `${id}.md`), matter.stringify('# x\nBody.', fm));
+}
+
+describe('collectDanglingDerivedFrom', () => {
+  let harness: Harness;
+  beforeEach(() => (harness = makeHarness()));
+  afterEach(() => rmSync(harness.root, { recursive: true, force: true }));
+
+  it('returns empty when every reference resolves', () => {
+    writeFileSync(join(harness.sessionsDir, 'session-a.md'), 'x');
+    mkdirSync(join(harness.root, 'docs'), { recursive: true });
+    writeFileSync(join(harness.root, 'docs/auth.md'), 'x');
+    writeNode(harness, 'practice-a', ['session-a.md', 'docs/auth.md']);
+    expect(collectDanglingDerivedFrom(harness.root, harness.nodesDir, harness.sessionsDir)).toEqual(
+      [],
+    );
+  });
+
+  it('reports bare filenames that do not exist under _sessions/', () => {
+    writeNode(harness, 'practice-b', ['session-missing.md']);
+    const out = collectDanglingDerivedFrom(harness.root, harness.nodesDir, harness.sessionsDir);
+    expect(out).toEqual([{ nodeId: 'practice-b', reference: 'session-missing.md' }]);
+  });
+
+  it('reports repo-relative paths that do not exist', () => {
+    writeNode(harness, 'practice-c', ['docs/missing.md']);
+    const out = collectDanglingDerivedFrom(harness.root, harness.nodesDir, harness.sessionsDir);
+    expect(out).toEqual([{ nodeId: 'practice-c', reference: 'docs/missing.md' }]);
+  });
+
+  it('aggregates dangling references across multiple nodes', () => {
+    writeFileSync(join(harness.sessionsDir, 'session-a.md'), 'x');
+    writeNode(harness, 'practice-a', ['session-a.md', 'docs/missing.md']);
+    writeNode(harness, 'practice-b', ['session-missing.md']);
+    const out = collectDanglingDerivedFrom(harness.root, harness.nodesDir, harness.sessionsDir);
+    expect(out).toEqual([
+      { nodeId: 'practice-a', reference: 'docs/missing.md' },
+      { nodeId: 'practice-b', reference: 'session-missing.md' },
+    ]);
+  });
+
+  it('returns empty when nodes dir is missing', () => {
+    const out = collectDanglingDerivedFrom(
+      harness.root,
+      join(harness.root, 'no-nodes'),
+      harness.sessionsDir,
+    );
+    expect(out).toEqual([]);
+  });
+});

--- a/tests/init.test.ts
+++ b/tests/init.test.ts
@@ -39,6 +39,7 @@ describe('init', () => {
       '.claude/commands/kb-bootstrap.md',
       '.claude/hooks/kb-capture.mjs',
       '.claude/hooks/kb-stage2-drain.mjs',
+      '.claude/hooks/kb-session-start.mjs',
       '.ai/.kb-builder/installed-version',
       '.ai/.kb-builder/prompts/stage-2-extract.md',
       '.ai/.kb-builder/prompts/curator.md',
@@ -120,7 +121,7 @@ describe('init', () => {
     }
   });
 
-  it('registers SessionStart drain hook with async: true', async () => {
+  it('registers SessionStart drain (async) and session-start (sync) hooks', async () => {
     await runCli(sandbox, ['init', '--assistants', 'claude']);
     const settings = JSON.parse(readFileSync(join(sandbox, '.claude/settings.json'), 'utf8')) as {
       hooks?: Record<
@@ -129,11 +130,22 @@ describe('init', () => {
       >;
     };
     const entries = settings.hooks?.['SessionStart'];
-    expect(entries, 'expected SessionStart hook entry').toBeDefined();
-    expect(entries?.[0]?.hooks[0]?.command).toBe(
-      'KB_BUILDER_HOOK=SessionStart node .claude/hooks/kb-stage2-drain.mjs',
+    expect(entries, 'expected SessionStart hook entries').toBeDefined();
+    expect(entries).toHaveLength(2);
+    const commands = entries?.flatMap((e) =>
+      e.hooks.map((h) => ({ command: h.command, async: h.async })),
     );
-    expect(entries?.[0]?.hooks[0]?.async).toBe(true);
+    expect(commands).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          command: 'KB_BUILDER_HOOK=SessionStart node .claude/hooks/kb-stage2-drain.mjs',
+          async: true,
+        }),
+        expect.objectContaining({
+          command: 'KB_BUILDER_HOOK=SessionStart node .claude/hooks/kb-session-start.mjs',
+        }),
+      ]),
+    );
   });
 
   it('ships the rename — no references to the old `kb-builder` binary in copied prompts', async () => {

--- a/tests/lib/session-start.test.ts
+++ b/tests/lib/session-start.test.ts
@@ -1,0 +1,257 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import matter from 'gray-matter';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { generateIndex, writeIndex } from '../../src/lib/index-gen.js';
+import {
+  DEFAULT_NUDGE_THRESHOLD,
+  buildSessionStartContext,
+  countPendingSessions,
+} from '../../src/lib/session-start.js';
+import { writeState, readState } from '../../src/lib/state.js';
+
+interface Harness {
+  root: string;
+  kbDir: string;
+  nodesDir: string;
+  sessionsDir: string;
+  stateFile: string;
+}
+
+function makeHarness(): Harness {
+  const root = mkdtempSync(join(tmpdir(), 'kb-session-start-'));
+  const kbDir = join(root, '.ai/knowledge-base');
+  const nodesDir = join(kbDir, 'nodes');
+  const sessionsDir = join(kbDir, '_sessions');
+  const stateFile = join(root, '.ai/.kb-builder/state.json');
+  mkdirSync(join(nodesDir, 'practice'), { recursive: true });
+  mkdirSync(join(nodesDir, 'map'), { recursive: true });
+  mkdirSync(sessionsDir, { recursive: true });
+  mkdirSync(dirname(stateFile), { recursive: true });
+  return { root, kbDir, nodesDir, sessionsDir, stateFile };
+}
+
+function seedSession(harness: Harness, sessionId: string, processed: boolean): void {
+  const fm: Record<string, unknown> = {
+    schema_version: 1,
+    session_id: sessionId,
+    captured_by: 'stop',
+    captured_at: '2026-05-11T10:00:00Z',
+    transcript_hash: `sha256:${sessionId}`,
+    stage_2_status: 'done',
+    stage_2_completed_at: '2026-05-11T10:00:01Z',
+    stage_2_error: null,
+    stage_2_log: null,
+    gitleaks_status: 'clean',
+    topics: [],
+    proposals: { practice: [], map: [] },
+  };
+  if (processed) fm['curator_processed_at'] = '2026-05-11T11:00:00Z';
+  writeFileSync(
+    join(harness.sessionsDir, `session-${sessionId}.md`),
+    matter.stringify('## body\n', fm),
+  );
+}
+
+function seedNode(harness: Harness, kind: 'practice' | 'map', id: string): void {
+  const fm = {
+    schema_version: 1,
+    id,
+    title: id,
+    kind,
+    tags: [],
+    valid_from: '2026-01-01T00:00:00Z',
+    valid_until: null,
+    updated: '2026-01-01T00:00:00Z',
+    supersedes: null,
+    superseded_by: null,
+    derived_from: [],
+    relates_to: [],
+    depends_on: [],
+    confidence: 'high',
+    summary: 's',
+  };
+  writeFileSync(join(harness.nodesDir, kind, `${id}.md`), matter.stringify(`# ${id}\nBody.`, fm));
+}
+
+function writeIndexFromCurrentNodes(harness: Harness): void {
+  const idx = generateIndex(harness.nodesDir);
+  mkdirSync(harness.kbDir, { recursive: true });
+  writeIndex(join(harness.kbDir, 'INDEX.md'), idx);
+}
+
+describe('countPendingSessions', () => {
+  let harness: Harness;
+  beforeEach(() => (harness = makeHarness()));
+  afterEach(() => rmSync(harness.root, { recursive: true, force: true }));
+
+  it('counts stage-2-done sessions not yet curated', () => {
+    seedSession(harness, 'a', false);
+    seedSession(harness, 'b', false);
+    seedSession(harness, 'c', true);
+    expect(countPendingSessions(harness.sessionsDir)).toBe(2);
+  });
+
+  it('returns 0 for a missing sessions directory', () => {
+    expect(countPendingSessions(join(harness.root, 'missing'))).toBe(0);
+  });
+});
+
+describe('buildSessionStartContext', () => {
+  let harness: Harness;
+  beforeEach(() => (harness = makeHarness()));
+  afterEach(() => rmSync(harness.root, { recursive: true, force: true }));
+
+  it('emits a stub when INDEX.md is missing', () => {
+    const result = buildSessionStartContext({
+      kbDir: harness.kbDir,
+      nodesDir: harness.nodesDir,
+      sessionsDir: harness.sessionsDir,
+      stateFile: harness.stateFile,
+    });
+    expect(result.indexMissing).toBe(true);
+    expect(result.additionalContext).toContain('# KB Index');
+    expect(result.additionalContext).toContain('empty');
+  });
+
+  it('injects the live INDEX.md when fresh and emits no warnings', () => {
+    seedNode(harness, 'practice', 'practice-foo');
+    writeIndexFromCurrentNodes(harness);
+    const result = buildSessionStartContext({
+      kbDir: harness.kbDir,
+      nodesDir: harness.nodesDir,
+      sessionsDir: harness.sessionsDir,
+      stateFile: harness.stateFile,
+    });
+    expect(result.indexStale).toBe(false);
+    expect(result.indexMissing).toBe(false);
+    expect(result.additionalContext).toContain('practice-foo');
+    expect(result.additionalContext).not.toContain('stale');
+    expect(result.additionalContext).not.toContain('pending session log');
+  });
+
+  it('appends a stale warning when nodes/ has drifted from INDEX.md', () => {
+    seedNode(harness, 'practice', 'practice-foo');
+    writeIndexFromCurrentNodes(harness);
+    // Drift: add another node so the live nodes_hash no longer matches.
+    seedNode(harness, 'map', 'map-bar');
+    const result = buildSessionStartContext({
+      kbDir: harness.kbDir,
+      nodesDir: harness.nodesDir,
+      sessionsDir: harness.sessionsDir,
+      stateFile: harness.stateFile,
+    });
+    expect(result.indexStale).toBe(true);
+    expect(result.additionalContext).toContain('KB index is stale');
+  });
+
+  it('appends a nudge when pending >= threshold and updates last_nudged_at', () => {
+    for (let i = 0; i < DEFAULT_NUDGE_THRESHOLD; i += 1) seedSession(harness, `s-${i}`, false);
+    const now = new Date('2026-05-11T10:00:00Z');
+    const result = buildSessionStartContext({
+      kbDir: harness.kbDir,
+      nodesDir: harness.nodesDir,
+      sessionsDir: harness.sessionsDir,
+      stateFile: harness.stateFile,
+      now: () => now,
+    });
+    expect(result.nudged).toBe(true);
+    expect(result.additionalContext).toContain(`${DEFAULT_NUDGE_THRESHOLD} pending session log(s)`);
+    const state = readState(harness.stateFile);
+    expect(state.last_nudged_at).toBe(now.toISOString());
+  });
+
+  it('respects the hourly throttle (no nudge within 1 hour of last_nudged_at)', () => {
+    for (let i = 0; i < DEFAULT_NUDGE_THRESHOLD; i += 1) seedSession(harness, `s-${i}`, false);
+    writeState(harness.stateFile, {
+      schema_version: 1,
+      last_nudged_at: '2026-05-11T10:00:00Z',
+    });
+    const result = buildSessionStartContext({
+      kbDir: harness.kbDir,
+      nodesDir: harness.nodesDir,
+      sessionsDir: harness.sessionsDir,
+      stateFile: harness.stateFile,
+      now: () => new Date('2026-05-11T10:30:00Z'), // 30 minutes later
+    });
+    expect(result.nudged).toBe(false);
+    expect(result.additionalContext).not.toContain('pending session log');
+  });
+
+  it('re-nudges after the throttle elapses', () => {
+    for (let i = 0; i < DEFAULT_NUDGE_THRESHOLD; i += 1) seedSession(harness, `s-${i}`, false);
+    writeState(harness.stateFile, {
+      schema_version: 1,
+      last_nudged_at: '2026-05-11T10:00:00Z',
+    });
+    const result = buildSessionStartContext({
+      kbDir: harness.kbDir,
+      nodesDir: harness.nodesDir,
+      sessionsDir: harness.sessionsDir,
+      stateFile: harness.stateFile,
+      now: () => new Date('2026-05-11T11:30:00Z'), // 90 minutes later
+    });
+    expect(result.nudged).toBe(true);
+  });
+
+  it('does not nudge when below threshold', () => {
+    seedSession(harness, 'just-one', false);
+    const result = buildSessionStartContext({
+      kbDir: harness.kbDir,
+      nodesDir: harness.nodesDir,
+      sessionsDir: harness.sessionsDir,
+      stateFile: harness.stateFile,
+      threshold: 5,
+    });
+    expect(result.nudged).toBe(false);
+    expect(result.pendingSessions).toBe(1);
+  });
+
+  it('preserves an existing lock when persisting last_nudged_at', () => {
+    for (let i = 0; i < DEFAULT_NUDGE_THRESHOLD; i += 1) seedSession(harness, `s-${i}`, false);
+    writeState(harness.stateFile, {
+      schema_version: 1,
+      lock: {
+        name: 'curator',
+        pid: 1234,
+        acquired_at: '2026-05-11T09:00:00Z',
+        ttl_ms: 1_800_000,
+      },
+    });
+    buildSessionStartContext({
+      kbDir: harness.kbDir,
+      nodesDir: harness.nodesDir,
+      sessionsDir: harness.sessionsDir,
+      stateFile: harness.stateFile,
+      now: () => new Date('2026-05-11T10:00:00Z'),
+    });
+    const state = readState(harness.stateFile);
+    expect(state.lock?.name).toBe('curator');
+    expect(state.lock?.pid).toBe(1234);
+    expect(typeof state.last_nudged_at).toBe('string');
+  });
+});
+
+describe('buildSessionStartContext additionalContext shape', () => {
+  let harness: Harness;
+  beforeEach(() => (harness = makeHarness()));
+  afterEach(() => rmSync(harness.root, { recursive: true, force: true }));
+
+  it('strips the INDEX frontmatter before injection', () => {
+    seedNode(harness, 'practice', 'practice-foo');
+    writeIndexFromCurrentNodes(harness);
+    // Make sure the raw file has frontmatter.
+    const raw = readFileSync(join(harness.kbDir, 'INDEX.md'), 'utf8');
+    expect(raw).toMatch(/^---\n/);
+    const result = buildSessionStartContext({
+      kbDir: harness.kbDir,
+      nodesDir: harness.nodesDir,
+      sessionsDir: harness.sessionsDir,
+      stateFile: harness.stateFile,
+    });
+    // The injected content is the body, no YAML frontmatter.
+    expect(result.additionalContext.startsWith('---')).toBe(false);
+    expect(result.additionalContext).toContain('# KB Index');
+  });
+});

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -20,6 +20,7 @@ export default defineConfig([
     entry: {
       'kb-capture': 'src/hooks/kb-capture.ts',
       'kb-stage2-drain': 'src/hooks/kb-stage2-drain.ts',
+      'kb-session-start': 'src/hooks/kb-session-start.ts',
     },
     outDir: 'dist/hooks',
     format: ['esm'],


### PR DESCRIPTION
## Summary

Ships M4: the consume pipeline. A sync `SessionStart` hook injects `INDEX.md` as `additionalContext` at session start, appends a stale-INDEX warning on `nodes_hash` drift, and emits a curate-backlog nudge throttled to once per hour. Doctor gains a `derived_from references resolve` check.

- New `src/lib/session-start.ts` with `buildSessionStartContext` — pure-ish, with the only side effect being `state.json.last_nudged_at` writes when a nudge fires.
- New `src/hooks/kb-session-start.ts` — sync `SessionStart` hook emitting Claude Code's `hookSpecificOutput.additionalContext` JSON, 1-second deadline, recursion-guarded.
- Registered alongside the existing async drain in `init.ts`. The drain stays async (so it does not block startup); consume is sync so its stdout reaches the assistant before the first turn.
- `tsup.config.ts` adds `kb-session-start` so the build pipeline ships the third hook bundle.
- Doctor gains `collectDanglingDerivedFrom` — resolves against absolute paths, repo-relative paths, and bare filenames under `_sessions/`. Warning, not error; `--verbose` lists offenders.

## Docs (per IMPLEMENTATION §15.5 M4)

- Core Concepts > How it works (capture / curate / consume pipeline, ASCII data flow).
- Core Concepts > Knowledge model (`practice` vs `map`, provenance, validity, confidence).
- Reference > Hook events — new sync SessionStart entry with JSON output contract.
- Reference > CLI — doctor check documented.

## Test plan

- [x] `npm test` — 136 passing, 1 skipped (real-gitleaks gate). 16 new cases:
  - `tests/lib/session-start.test.ts` (11): stub when INDEX missing, fresh injection, stale drift detection, threshold nudge, hourly throttle, re-nudge after throttle, lock preservation when persisting `last_nudged_at`, frontmatter stripping.
  - `tests/doctor-dangling.test.ts` (5): bare session filename, repo path, multi-node aggregation, missing nodes dir.
  - `tests/init.test.ts` — updated to expect two SessionStart hook entries and the new `.mjs` artifact.
- [x] `npm run typecheck`, `npm run lint`, `npm run format:check` — clean.
- [x] `npm run build` — produces three hook bundles + cli.

https://claude.ai/code/session_01CmiYNV6ejAPZp6DbJA1h7U

---
_Generated by [Claude Code](https://claude.ai/code/session_01CmiYNV6ejAPZp6DbJA1h7U)_