### PR TITLE
feat(M5): index rebuild CLI, expanded doctor, full docs site

### DIFF
--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -7,11 +7,158 @@ permalink: /architecture/
 
 # Architecture
 
-_Completed in M5._
+Aimed at contributors to `@e0ipso/ai-knowledge-base` and at future adapter authors who want to add support for AI assistants beyond Claude Code. For day-to-day usage, read [Core Concepts > How it works](../core-concepts/how-it-works.md) instead.
 
-This page is aimed at contributors to `@e0ipso/ai-knowledge-base` and at future adapter authors who want to add support for AI assistants beyond Claude Code.
+## Layout
 
-Until M5, the authoritative architecture documents are:
+```
+src/
+├── cli.ts                       # Commander entry point — wires CLI subcommands
+├── commands/                    # User-facing CLI command implementations
+│   ├── init.ts
+│   ├── doctor.ts
+│   ├── status.ts
+│   ├── curate.ts
+│   ├── node-add.ts
+│   ├── proposals-review.ts
+│   ├── bootstrap-incremental.ts
+│   └── index-rebuild.ts
+├── hooks/                       # Compiled-to-.mjs hook scripts
+│   ├── kb-capture.ts            # Stop / SessionEnd / PreCompact (stage-1)
+│   ├── kb-stage2-drain.ts       # SessionStart, async (stage-2)
+│   └── kb-session-start.ts      # SessionStart, sync (consume injection)
+├── lib/                         # Pure-ish reusable building blocks
+│   ├── schemas.ts               # All Zod schemas (`schema_version: 1` everywhere)
+│   ├── paths.ts                 # repoPaths, packageRoot, findRepoRoot
+│   ├── log.ts                   # Console logger (NO_COLOR-aware)
+│   ├── transcript.ts            # Parse Claude Code JSONL into role-tagged strings
+│   ├── gitleaks.ts              # Run gitleaks; redact findings
+│   ├── dedup-cache.ts           # SHA-256 dedup window for stage-1
+│   ├── queue.ts                 # Atomic `.queue.json` writes
+│   ├── session-log.ts           # Render/write session log markdown
+│   ├── capture.ts               # Top-level stage-1 orchestration
+│   ├── state.ts                 # `state.json` + named locks (PID + TTL)
+│   ├── headless.ts              # `claude -p` runner with stream-json + Zod validation
+│   ├── stage2-drain.ts          # Stage-2 queue drain
+│   ├── curate.ts                # Curator batching + proposal write
+│   ├── nodes.ts                 # Node walks + nodes_hash + slugify + proposal writes
+│   ├── index-gen.ts             # INDEX.md + GRAPH.md deterministic generation
+│   ├── ulid.ts                  # ULID for run-ids
+│   ├── bootstrap.ts             # Bootstrap-incremental pipeline
+│   ├── session-start.ts         # Consume-hook payload builder
+│   └── version.ts               # package.json version reader
+├── adapters/
+│   ├── types.ts                 # Adapter interface (v1 placeholder for multi-assistant)
+│   └── claude.ts                # Claude Code adapter (only v1 implementation)
+└── templates-source/            # Files copied verbatim into consumer repos
+    ├── prompts/                 # stage-2-extract.md, curator.md, bootstrap-incremental.md
+    ├── claude/                  # .claude/commands/* + settings.json scaffolding
+    ├── knowledge-base/          # .ai/knowledge-base/* scaffolding
+    └── precommit/               # pre-commit-config.yaml shipped to consumers
+```
 
-- [PRD.md](https://github.com/e0ipso/ai-knowledge-base/blob/main/PRD.md) — product requirements.
-- [IMPLEMENTATION.md](https://github.com/e0ipso/ai-knowledge-base/blob/main/IMPLEMENTATION.md) — technical design, decisions, and rationale. See in particular §1 (architecture overview), §10 (adapter interface), and §11 (key decisions and rationale).
+`tsup` builds two outputs:
+
+- `dist/cli.js` — the CLI binary (single ESM file with shebang).
+- `dist/hooks/*.mjs` — one bundle per hook script. `.mjs` extension means consumers don't need a `package.json` in the hooks dir.
+
+The `prepare` lifecycle (`npm install`, `npm publish`) runs `scripts/build-templates.mjs` which copies `templates-source/` into `templates/` and drops the compiled hooks into `templates/claude/hooks/`. The npm package ships `dist/` and `templates/` (see the `files` field in `package.json`).
+
+## Three pipelines, four hooks, two CLI shapes
+
+The system is three deliberately separate pipelines (capture, curate, consume) with four Claude Code hooks wiring them in. Each pipeline can be disabled by removing its hook entry — `init --force` re-registers them.
+
+```
+Stop / SessionEnd / PreCompact  →  kb-capture       (sync, ≤1 s)
+SessionStart                    →  kb-stage2-drain  (async)
+                                →  kb-session-start (sync, ≤1 s)
+```
+
+The two CLI shapes:
+
+- **Deterministic CLIs** (`init`, `doctor`, `status`, `node add`, `index rebuild`, `proposals review`) — no LLM, no subprocess. Pure code over filesystem state.
+- **LLM-invoking CLIs** (`curate`, `bootstrap-incremental`) — spawn `claude -p` via `runHeadlessClaude`, parse stream-JSON output, validate against Zod. All subprocesses get `KB_BUILDER_INTERNAL=1` so the spawned Claude doesn't fire our hooks recursively.
+
+## State files
+
+| File | Owner | Purpose |
+|---|---|---|
+| `.ai/knowledge-base/_sessions/<log>.md` | capture + stage-2 + curator | Per-session checkpoint; frontmatter tracks stage_2 status, gitleaks status, curator processed marker. |
+| `.ai/knowledge-base/_sessions/.queue.json` | capture + drain | Atomic stage-1 → stage-2 handoff queue. |
+| `.ai/knowledge-base/_sessions/.dedup-cache.json` | capture | 5-minute SHA-256 window so back-to-back Stop/SessionEnd/PreCompact don't double-capture. |
+| `.ai/knowledge-base/_logs/{stage-2,curator,bootstrap-incremental}/*.jsonl` | stage-2 + curator + bootstrap | Stream-JSON traces of every `claude -p` invocation. Gitignored. |
+| `.ai/knowledge-base/_proposed/{additions,modifications,contradictions}/` | curator + node-add + bootstrap | Pending proposals awaiting review. |
+| `.ai/knowledge-base/nodes/{practice,map}/` | proposals review | Canonical, accepted knowledge. The only thing the assistant sees via INDEX. |
+| `.ai/knowledge-base/INDEX.md`, `GRAPH.md` | curator + index-rebuild | Deterministic outputs derived from `nodes/`. INDEX is token-budgeted; GRAPH is the full edge listing. |
+| `.ai/.kb-builder/installed-version` | init | Marker recording package version + selected assistants. Committed. |
+| `.ai/.kb-builder/state.json` | drain + curator + bootstrap + consume | Single shared state file. `lock` (one at a time) + `last_nudged_at`. Gitignored. |
+| `.ai/.kb-builder/bootstrap-state.json` | bootstrap | SHA-256 of every doc the bootstrap pipelines have processed. Gitignored. |
+| `.ai/.kb-builder/prompts/*` | init | Local overrides for the three shipped prompts. Committed. |
+
+## Locking
+
+`state.json` holds one lock at a time. Each pipeline takes its own named lock (`name: <pipeline>`, `pid`, `acquired_at`, `ttl_ms`). 30-minute TTL; an older lock is treated as stale and reclaimed. The pipelines that need the lock:
+
+- `stage2-drain` — prevents two concurrent SessionStart drains from racing on the queue.
+- `curator` — prevents two concurrent curate runs from writing duplicate proposals.
+- `bootstrap-incremental` — prevents two concurrent bootstraps from writing duplicate proposals.
+
+The consume hook does **not** lock — it only reads INDEX and writes `last_nudged_at`, both of which are fine to clobber.
+
+## Schema versioning
+
+Every YAML frontmatter shape and every JSON state file carries `schema_version: 1`. v1 → v2 will ship a migration script under `src/lib/migrations/`. The runtime fails closed on shapes it can't validate (returns "no data" rather than guessing), so a stale-schema file in the wild can be detected by `doctor` rather than silently corrupted.
+
+## Adapter interface
+
+`src/adapters/types.ts` defines an `Adapter` interface intended to make adding non-Claude assistants tractable in v2:
+
+```ts
+interface Adapter {
+  name: string;
+  hookInstallPath(): string;
+  commandInstallPath(): string;
+  writeHookConfig(repoRoot: string, hooks: HookSpec[]): Promise<void>;
+  readTranscript(hookInput: unknown): Promise<RoleTaggedTranscript>;
+  runHeadless<T>(promptBody: string, stdin: string, schema: ZodSchema<T>, opts?: HeadlessOpts): Promise<T>;
+  renderSlashCommand(spec: SlashCommandSpec): string;
+}
+```
+
+Adding a new adapter is mostly mechanical: implement these five methods (`name`, `hookInstallPath`, `commandInstallPath`, `writeHookConfig`, `readTranscript`, `runHeadless`, `renderSlashCommand`) and add the adapter to the dispatch in `init.ts`. The hook scripts themselves are not adapter-specific — they parse hook input via the adapter's `readTranscript`, so the transcript-format details are hidden. v1 ships the Claude adapter only.
+
+## Determinism contract
+
+The non-LLM parts of the system are deterministic:
+
+- `computeNodesHash` is a content-addressed walk; same `nodes/` → same hash, regardless of mtime or filesystem.
+- `generateIndex` and `generateGraph` are pure functions of `nodes/` plus a `now` injection (used for `generated_at`). Two calls at the same instant produce byte-identical output.
+- `slugify`, `deriveNodeId`, and `ensureUniqueId` are pure.
+- ULID generation is the only randomness path on the hot path; it's confined to `run_id` minting (curator + bootstrap) where uniqueness, not reproducibility, is the goal.
+
+Tests rely on this: see `tests/lib/index-gen.test.ts` for golden-file comparisons.
+
+## What's intentionally not here
+
+Per [IMPLEMENTATION §12](https://github.com/e0ipso/ai-knowledge-base/blob/main/IMPLEMENTATION.md#12-implementation-phases):
+
+- **No `.config.json`.** Configuration values live in code as named constants. v1.5 will add a config file.
+- **No `init --upgrade`.** Re-run with `--force`; the gitignore-block and `.claude/settings.json` merging are idempotent.
+- **No `logs prune`.** v1.5.
+- **No multi-assistant adapter dispatch.** v2.
+- **No `bootstrap-incremental` overlap detection.** v2 (always writes additions; reviewer rejects duplicates).
+- **No managed-MCP injection.** The INDEX-as-additionalContext pattern is the entire injection surface.
+
+These are constraints, not omissions. Each one trades expressiveness for "the code is easy to read end-to-end in an afternoon."
+
+## Where to extend
+
+| You want to… | Look at… |
+|---|---|
+| Change extraction behavior | `templates-source/prompts/stage-2-extract.md` (project-tunable copy at `.ai/.kb-builder/prompts/stage-2-extract.md`). |
+| Change curator behavior | `templates-source/prompts/curator.md`. Tighten the dedup or contradiction logic in `src/lib/curate.ts`. |
+| Change bootstrap behavior | `templates-source/prompts/bootstrap-incremental.md` for the CLI prompt; `templates-source/claude/commands/kb-bootstrap.md` for the in-session agent. |
+| Add a new CLI subcommand | `src/commands/<name>.ts` + wire it in `src/cli.ts`. Add doc to `docs/reference/cli.md`. |
+| Add a new hook | `src/hooks/<name>.ts` + entry in `tsup.config.ts` + register in `src/commands/init.ts`. Doc in `docs/reference/hook-events.md`. |
+| Add a new state file | Schema in `src/lib/schemas.ts` (with `schema_version: 1`); read/write helpers next to the existing patterns. Add to `.gitignore` block in `src/commands/init.ts`. |
+| Add a new adapter | Implement `src/adapters/types.ts`'s interface. Update `src/commands/init.ts` to dispatch on the assistant list. |

--- a/docs/getting-started/ci-recipe.md
+++ b/docs/getting-started/ci-recipe.md
@@ -1,0 +1,128 @@
+---
+title: CI recipe
+parent: Getting Started
+nav_order: 3
+---
+
+# CI recipe
+
+`@e0ipso/ai-knowledge-base` is designed to run primarily in the contributor's local environment. The hooks fire during real Claude Code sessions; the curator runs when a human deliberately invokes it. CI's job is narrower: **guarantee that what's been committed is well-formed and not stale.**
+
+This page is an opinionated minimum. Extend it as your project's needs grow.
+
+## What CI should check
+
+1. **`doctor`.** Validates schemas, hook registration, INDEX freshness, dangling `derived_from`. Exits non-zero on errors (warnings are OK).
+2. **Pre-commit hooks pass.** `pre-commit run --all-files` runs gitleaks (and anything else you've added). This catches an accidental secret commit that slipped past the local pre-commit install.
+3. **No drift between `nodes/` and `INDEX.md`.** Running `ai-knowledge-base index rebuild` and then checking `git diff --exit-code .ai/knowledge-base/INDEX.md .ai/knowledge-base/GRAPH.md` ensures the index in source control matches the nodes. Trivial to wire in.
+
+You should **not** run `ai-knowledge-base curate` or `ai-knowledge-base bootstrap-incremental` in CI by default. Both invoke `claude -p`, both write proposals that need human review. CI is not the reviewer.
+
+## GitHub Actions example
+
+```yaml
+# .github/workflows/kb.yml
+name: knowledge-base
+
+on:
+  pull_request:
+    paths:
+      - '.ai/knowledge-base/**'
+      - '.ai/.kb-builder/**'
+      - '.claude/**'
+      - '.pre-commit-config.yaml'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install pre-commit
+        run: pip install pre-commit
+
+      - name: Run gitleaks (and any other pre-commit hooks)
+        run: pre-commit run --all-files
+
+      - name: Install ai-knowledge-base
+        run: npm install --no-save @e0ipso/ai-knowledge-base
+
+      - name: doctor
+        run: npx ai-knowledge-base doctor --verbose
+
+      - name: INDEX is in sync with nodes/
+        run: |
+          npx ai-knowledge-base index rebuild
+          git diff --exit-code .ai/knowledge-base/INDEX.md .ai/knowledge-base/GRAPH.md
+```
+
+The last step is the most important. If a contributor merged a hand-edit to `nodes/` without re-running the curator (or `index rebuild`), CI catches it.
+
+## GitLab CI example
+
+```yaml
+# .gitlab-ci.yml
+kb_validate:
+  image: node:22
+  before_script:
+    - apt-get update && apt-get install -y python3-pip
+    - pip3 install pre-commit
+    - npm install --no-save @e0ipso/ai-knowledge-base
+  script:
+    - pre-commit run --all-files
+    - npx ai-knowledge-base doctor --verbose
+    - npx ai-knowledge-base index rebuild
+    - git diff --exit-code .ai/knowledge-base/INDEX.md .ai/knowledge-base/GRAPH.md
+  rules:
+    - changes:
+        - .ai/knowledge-base/**/*
+        - .ai/.kb-builder/**/*
+        - .claude/**/*
+        - .pre-commit-config.yaml
+```
+
+## What about running `claude -p` in CI?
+
+You can — for example, to gate merging behind a curate pass on changed session logs — but it requires:
+
+1. An authenticated `claude` CLI in the CI environment (a long-lived API key bound to a CI-only Anthropic account).
+2. Acceptance that proposals will be written automatically and need to be reviewed before merging.
+3. Patience: the curator's per-batch timeout is 120 s by default, so a backlog of 30 sessions can take several minutes.
+
+The repo intentionally does not ship a turnkey "auto-curate" CI workflow. Two reasons:
+
+- The reviewer is the merge mechanism. Auto-writing proposals to a PR is fine; auto-merging proposals into `nodes/` defeats the design.
+- Authentication varies wildly across orgs. We don't want to canonicalize one approach.
+
+If you want to wire this up, the building blocks are:
+
+```yaml
+- name: Run curate
+  env:
+    ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+  run: npx ai-knowledge-base curate
+
+- name: Open PR for proposals
+  if: ${{ hashFiles('.ai/knowledge-base/_proposed/additions/*') != ''
+        || hashFiles('.ai/knowledge-base/_proposed/modifications/*') != ''
+        || hashFiles('.ai/knowledge-base/_proposed/contradictions/*') != '' }}
+  run: |
+    # Open a PR with the new proposals for human review.
+    # Use your team's preferred PR-opening action here.
+```
+
+## What about INDEX as a deploy artifact?
+
+If you publish your KB to a docs site, `INDEX.md` and `GRAPH.md` are valid jumping-off points. The deterministic-regen invariant means a docs build can call `ai-knowledge-base index rebuild` first to refresh them; or you can rely on `INDEX.md`'s `generated_at` frontmatter to decide whether to bust caches.
+
+## Catching schema-version mismatches early
+
+When you bump to schema v2 (whenever that ships), CI is the right place to fail loudly. The runtime fails closed on shapes it can't validate — the file becomes a parse failure, surfaces in `doctor`, and CI's `doctor --verbose` step catches it. No special wiring needed.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -7,9 +7,10 @@ permalink: /getting-started/
 
 # Getting Started
 
-Two pages:
+Pages:
 
 - [Installation & first init](installation.md) — install prerequisites, run `init`, verify with `doctor`.
-- [First capture → curate](first-capture.md) — _coming in M3._
+- [First capture → curate](first-capture.md) — walk through one full capture / stage-2 / curate / review cycle.
+- [CI recipe](ci-recipe.md) — keep the KB healthy in continuous integration.
 
-Until M3 ships, the `init` command sets up the directory structure and pre-commit secret scanner; running an AI session won't yet produce captures.
+After installation the three pipelines run on their own: capture fires on every Claude Code session event, stage-2 drains in the background, and consume injects `INDEX.md` at session start. The deliberate steps are `ai-knowledge-base curate` and `ai-knowledge-base proposals review` — both of which the contributor runs explicitly.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -136,10 +136,18 @@ Flags:
 
 See [Bootstrap > Incremental bootstrap](../bootstrap/incremental-bootstrap.md) for usage recipes and [Reference > `bootstrap-state.json` schema](bootstrap-state.md) for the state file shape.
 
-## Commands available in later phases
+## `index rebuild`
 
-| Command | Phase |
-|---|---|
-| `index rebuild` | M4 / M5 |
+```sh
+ai-knowledge-base index rebuild [--budget-tokens <n>]
+```
 
-When those phases ship, this page will document each subcommand's full flag set and exit codes.
+Regenerate `INDEX.md` and `GRAPH.md` from the current `nodes/` tree. Deterministic, no LLM. The curator and `node add` already regenerate INDEX/GRAPH at the end of every run, so use this command after you hand-edit a node file (or rebase someone else's changes into `nodes/`) and want to refresh the index without running a curator pass.
+
+`doctor`'s freshness check uses the frontmatter `nodes_hash` to detect drift between the recorded index and the live `nodes/` tree. Run `index rebuild` to clear that warning.
+
+Flags:
+
+- `--budget-tokens <n>` — INDEX.md token budget (default `2000`, ~4 chars per token). Per-kind sections trim oldest entries until the rendered body fits; trimmed counts are reported in a "_N additional nodes hidden by token budget — see GRAPH.md_" footer.
+
+`GRAPH.md` is always the full, unfiltered node listing — it doesn't honor the token budget. Treat INDEX as the at-a-glance summary the assistant gets injected, and GRAPH as the source of truth when the assistant needs full edges (`relates_to`, `depends_on`, `supersedes` chains).

--- a/docs/reference/frontmatter-schemas.md
+++ b/docs/reference/frontmatter-schemas.md
@@ -1,0 +1,216 @@
+---
+title: Frontmatter schemas
+parent: Reference
+nav_order: 6
+---
+
+# Frontmatter schemas
+
+Every YAML frontmatter block and every JSON state file is validated by a Zod schema at read time. The schemas live in [`src/lib/schemas.ts`](https://github.com/e0ipso/ai-knowledge-base/blob/main/src/lib/schemas.ts) and are the source of truth — when this page and the schema disagree, the schema wins.
+
+All shapes carry `schema_version: 1`. v1 → v2 will ship a migration script under `src/lib/migrations/`; until then a `schema_version` mismatch is treated as a parse failure and the file is silently dropped (the runtime fails closed, never guesses).
+
+## Node frontmatter (`nodes/{practice,map}/<slug>.md`)
+
+```yaml
+---
+schema_version: 1
+id: practice-prefer-constructor-injection      # `<kind>-<slug>`; slug from slugify(title)
+title: "..."                                   # display title
+kind: practice | map
+tags: [string, ...]                            # 1-N short lowercase tags
+valid_from: 2026-05-10T14:30:00Z               # ISO-8601
+valid_until: null                              # ISO-8601 or null (= currently valid)
+updated: 2026-05-10T14:30:00Z                  # last touched
+supersedes: null                               # node id or null
+superseded_by: null                            # node id or null
+derived_from:                                  # source(s): session log filenames or doc paths
+  - 20260510-1014-session-abc.md
+relates_to: [string, ...]                      # loose links to other node ids
+depends_on: [string, ...]                      # strict ordering links to other node ids
+confidence: low | medium | high
+summary: "≤140 char summary, rendered in INDEX.md"
+---
+
+# Title
+
+Body in markdown. 1-4 short paragraphs is typical.
+```
+
+Validated by `NodeFrontmatterSchema`.
+
+## Proposal frontmatter (`_proposed/{additions,modifications,contradictions}/<slug>.md`)
+
+The same shape as a node, plus a `proposal` block:
+
+```yaml
+---
+…all node fields…
+proposal:
+  kind: addition | modification | contradiction
+  source_sessions: [session-id, ...]           # which captured sessions produced this
+  target_node: practice-foo | null             # for modifications/contradictions
+  rationale: "free-text why this exists"       # e.g. "bootstrap: docs/auth.md" or "manual"
+  suggested_resolution: supersede | keep_both | reject | null
+  curator_log: _logs/curator/<run-id>__<ts>.jsonl | null
+---
+```
+
+Validated by `ProposalFrontmatterSchema`. Two invariants enforced at write time:
+
+- Contradictions **always** carry `suggested_resolution: null`. The curator never auto-resolves; the reviewer picks during `proposals review`.
+- `proposal.kind` must match the proposal's containing directory (`addition` → `additions/`, etc.).
+
+## Session log frontmatter (`_sessions/<YYYYMMDD-HHmm-id>.md`)
+
+```yaml
+---
+schema_version: 1
+session_id: <claude-code-session-id>
+captured_by: stop | session_end | pre_compact | manual
+captured_at: 2026-05-11T10:00:00Z
+transcript_hash: sha256:<hex>                   # dedup key
+stage_2_status: pending | done | failed | skipped
+stage_2_completed_at: <ISO> | null
+stage_2_error: <string> | null
+stage_2_log: _logs/stage-2/<id>__<ts>.jsonl | null
+gitleaks_status: clean | redacted | blocked | skipped
+topics: [string, ...]                           # deduped tags from stage-2 candidates
+proposals:
+  practice: [<Stage2Candidate>, ...]
+  map: [<Stage2Candidate>, ...]
+# After curate runs:
+curator_processed_at: 2026-05-11T11:00:00Z      # informational; if set, log is excluded from listPendingSessions
+curator_run_id: <ULID>
+---
+```
+
+Validated by `SessionLogFrontmatterSchema` (the curator fields are optional and read by helpers, not the schema).
+
+## Stage-2 candidate
+
+The shape the stage-2 prompt is expected to emit, and what the curator consumes:
+
+```yaml
+kind: practice | map
+tags: [string, ...]
+title: <string>
+summary: <≤140 chars>
+body: <markdown>
+confidence: low | medium | high
+supports_existing_node: <node-id> | null
+contradicts_existing_node: <node-id> | null
+```
+
+Validated by `Stage2CandidateSchema`. The stage-2 worker schema is `Stage2OutputSchema = { practice: [...], map: [...] }`.
+
+## Bootstrap candidate
+
+A superset of the stage-2 candidate — adds `derived_from` (the source-doc paths the chunk provided):
+
+```yaml
+kind: practice | map
+tags: [string, ...]
+title: <string>
+summary: <string>
+body: <markdown>
+confidence: low | medium | high
+derived_from: [string, ...]                     # at least one in practice; can be empty for single-doc batches
+supports_existing_node: null                    # always null in bootstrap output
+contradicts_existing_node: null                 # always null in bootstrap output
+```
+
+Validated by `BootstrapCandidateSchema`. The bootstrap-incremental worker output is `BootstrapOutputSchema = { practice: [...], map: [...] }`.
+
+## Curator action
+
+The curator emits a list of actions per batch:
+
+```yaml
+action: add | modify | contradict | drop
+candidate_origin: "<session_id>:<practice|map>:<index>"
+target_node_id: <node-id> | null                # for modify/contradict
+proposed_node: <CuratorProposedNode> | null     # null only for drop
+rationale: <free-text>
+suggested_resolution: supersede | keep_both | reject | null
+```
+
+The wrapper code converts each non-drop action into a proposal file with the right frontmatter. `CuratorOutputSchema` is the per-batch top-level shape (an array of actions).
+
+## INDEX.md frontmatter
+
+```yaml
+---
+schema_version: 1
+generated_at: 2026-05-10T14:30:00Z
+nodes_hash: sha256:<hex>                        # content hash of nodes/ (see below)
+node_count: 47
+budget_tokens: 2000
+---
+```
+
+Validated by `IndexFrontmatterSchema`. The `nodes_hash` field is what `doctor` and the consume hook compare against to detect drift.
+
+## GRAPH.md frontmatter
+
+```yaml
+---
+schema_version: 1
+generated_at: 2026-05-10T14:30:00Z
+nodes_hash: sha256:<hex>
+node_count: 47
+---
+```
+
+Validated by `GraphFrontmatterSchema`.
+
+## `nodes_hash` algorithm
+
+Deterministic across filesystems, independent of mtimes:
+
+1. Walk all `.md` files under `nodes/` recursively.
+2. For each file, compute `sha256(file_contents)`.
+3. Build the list of strings: `<relative-path-from-nodes-dir>\t<sha256-hex>`.
+4. Sort lexicographically by the string.
+5. Join with `\n`.
+6. `nodes_hash = sha256(joined)`.
+
+Implemented in `computeNodesHash` in `src/lib/nodes.ts`. Same content → same hash regardless of when or where the file system was created.
+
+## `state.json`
+
+```yaml
+---  # JSON, not YAML — the runtime parses it as JSON
+{
+  "schema_version": 1,
+  "lock": {                                     # null when no lock held
+    "name": "stage2-drain" | "curator" | "bootstrap-incremental",
+    "pid": 12345,
+    "acquired_at": "2026-05-11T10:00:00Z",
+    "ttl_ms": 1800000
+  } | null,
+  "last_nudged_at": "2026-05-11T10:00:00Z" | null
+}
+---
+```
+
+Validated by `StateFileSchema`. Gitignored. Lock TTL defaults to 30 minutes; older locks are reclaimed.
+
+## `bootstrap-state.json`
+
+See [Reference > `bootstrap-state.json` schema](bootstrap-state.md) for the full shape. Validated by `BootstrapStateSchema`.
+
+## Where each schema is used
+
+| Schema | Read at | Written by |
+|---|---|---|
+| `NodeFrontmatterSchema` | curator (existing-node refs), consume (INDEX gen), doctor (dangling refs) | proposals review (on accept) |
+| `ProposalFrontmatterSchema` | proposals review | curator, node-add, bootstrap-incremental |
+| `SessionLogFrontmatterSchema` | stage-2 drain, curator, consume | capture (stage-1), stage-2 drain (updates) |
+| `Stage2OutputSchema` | stage-2 drain (validating LLM output) | the LLM via `stage-2-extract.md` |
+| `BootstrapOutputSchema` | bootstrap-incremental (validating LLM output) | the LLM via `bootstrap-incremental.md` |
+| `CuratorOutputSchema` | curator (validating LLM output) | the LLM via `curator.md` |
+| `IndexFrontmatterSchema` | consume hook (stale detection), doctor (freshness) | curator, index-rebuild |
+| `GraphFrontmatterSchema` | (rarely read) | curator, index-rebuild |
+| `StateFileSchema` | stage-2 drain, curator, bootstrap-incremental, consume | all four pipelines |
+| `BootstrapStateSchema` | bootstrap-incremental | bootstrap-incremental |

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -12,5 +12,5 @@ permalink: /reference/
 - [Hook events](hook-events.md) — the four registered Claude Code events (capture + stage-2 drain).
 - [Settings](settings.md) — defaults for the stage-2 drain (bounds, timeouts, lock TTL).
 - [`bootstrap-state.json` schema](bootstrap-state.md) — content-hash state recorded by the bootstrap pipelines.
-- Frontmatter schemas — _coming in M4._
-- Failure modes — _coming progressively._
+- [Frontmatter schemas](frontmatter-schemas.md) — every YAML frontmatter and state-file shape (validated by Zod at read time).
+- For the canonical failure-mode catalog, see [Troubleshooting > Common issues](../troubleshooting/common-issues.md) and [PRD §9](https://github.com/e0ipso/ai-knowledge-base/blob/main/PRD.md#9-failure-modes-the-user-sees).

--- a/docs/troubleshooting/common-issues.md
+++ b/docs/troubleshooting/common-issues.md
@@ -1,0 +1,93 @@
+---
+title: Common issues
+parent: Troubleshooting
+nav_order: 1
+---
+
+# Common issues
+
+Each symptom links to the diagnostic command(s) that will confirm or rule out the cause. Run `ai-knowledge-base doctor --verbose` first for almost any problem — it surfaces nine common conditions and exits non-zero only on hard errors.
+
+## "Nothing is being captured."
+
+`ls .ai/knowledge-base/_sessions/` is empty or hasn't grown.
+
+Likely causes, in order:
+
+1. **The hooks aren't registered.** Open `.claude/settings.json` and look for `KB_BUILDER_HOOK=Stop` / `…=SessionEnd` / `…=PreCompact` entries. Missing? Run `ai-knowledge-base init --assistants claude --force`.
+2. **gitleaks isn't on PATH.** Capture aborts when gitleaks isn't available — the security guarantee outweighs availability. Run `ai-knowledge-base doctor`; if you see `gitleaks on PATH: not found on PATH …`, `pre-commit install` and re-run.
+3. **The 1-second deadline is firing.** Very long transcripts or a slow filesystem can push capture past the deadline; the hook exits silently. You'll usually still capture on the next Stop or PreCompact event. If this is happening reproducibly, file an issue.
+4. **`KB_BUILDER_INTERNAL=1` is set.** This is the recursion guard. If you've wrapped `claude` in a script, make sure the wrapper doesn't propagate this env var into normal sessions.
+
+## "Capture worked but stage-2 never runs."
+
+`_sessions/<log>.md` shows `stage_2_status: pending` indefinitely.
+
+Stage-2 runs on the next `SessionStart`, asynchronously. So:
+
+1. **Start a new session.** The `kb-stage2-drain.mjs` hook fires on session start. If the drain succeeds, the log moves to `stage_2_status: done` and proposals get populated.
+2. **Check `_logs/stage-2/<session-id>__<ts>.jsonl`.** If the file exists but the session is still `pending` or moved to `failed`, the drain ran but encountered an error. Read [Reading stage-2 logs](reading-stage-2-logs.md).
+3. **Check the lock.** `cat .ai/.kb-builder/state.json`. If `lock.name: stage2-drain` with a stale PID, the previous drain crashed — the lock will be reclaimed after 30 minutes, or you can delete the `lock` field manually.
+4. **Verify `claude` is on PATH** in the same shell environment Claude Code uses to spawn hooks. `ai-knowledge-base doctor` runs `claude --version` and reports.
+
+## "Curate writes no proposals."
+
+`ai-knowledge-base curate` prints `no pending sessions` even though `_sessions/` has stage-2-done logs.
+
+1. **The sessions are already curated.** Curated logs carry a `curator_processed_at` frontmatter field; `listPendingSessions` filters them out. This is the expected end state — pending only means "stage-2 done, not yet seen by the curator." Run `ai-knowledge-base status` to see the buckets.
+2. **The schema is invalid.** A hand-edited session log that no longer validates against `SessionLogFrontmatterSchema` will be silently skipped. Run `ai-knowledge-base doctor`; check the log itself with `head <log>.md`.
+
+## "The curator wrote weird proposals."
+
+Most of the time this is prompt drift. Two things to do:
+
+1. **Read the run log.** `_logs/curator/<run-id>__<ts>.jsonl` has the full stream-json trace. See [Reading curator logs](reading-curator-logs.md) for how to parse it.
+2. **Tune the curator prompt.** Edit `.ai/.kb-builder/prompts/curator.md` (your local override). Bump the `Version: N` comment when you change behavior. The calibration loop is documented in [Editing the curator prompt](../customization/curator-prompt.md).
+
+## "INDEX.md is stale."
+
+Doctor says `INDEX.md is fresh: stale (nodes_hash drift)`. The SessionStart hook also appends a `> KB index is stale …` line to the injected context.
+
+Cause: someone hand-edited a node file (or rebased changes that touched `nodes/`) without running a curator pass.
+
+Fix: `ai-knowledge-base index rebuild`.
+
+The curator regenerates INDEX/GRAPH at the end of every run, so this only happens after manual edits or rebases. The pre-commit hook can be configured to block commits with stale INDEX — see [Reference > Settings](../reference/settings.md).
+
+## "doctor warns about dangling derived_from."
+
+`ai-knowledge-base doctor --verbose` lists `<node-id>: <ref>` pairs.
+
+Three flavors of cause:
+
+1. **Session log was deleted.** `_sessions/` is gitignored — if you wiped `.ai/knowledge-base/_sessions/` to clean up, every node derived from those sessions now has dangling refs. This is fine; the warning is informational. The consume path silently ignores dangling refs.
+2. **Source doc moved.** A bootstrap-derived node's `derived_from: docs/architecture/auth.md` is now invalid because the doc was renamed. Either update the node manually, or accept the warning as documentation of the move.
+3. **Reference is a typo.** Hand-edited the node, fat-fingered the path. Fix the path in the node frontmatter.
+
+Dangling references are never an error — they're a warning. The curator treats them as "evidence not available" and proceeds.
+
+## "Proposals review can't accept a contradiction."
+
+Contradiction proposals require a `suggested_resolution` (`supersede`, `keep_both`, or `reject`). The curator always emits `null` there; the reviewer must choose. If the TUI seems stuck, you may have skipped that prompt — re-run `ai-knowledge-base proposals review` and step through that proposal explicitly.
+
+## "Bootstrap re-processes docs I've already done."
+
+`.ai/.kb-builder/bootstrap-state.json` records SHA-256 of every processed doc. If a re-run is processing them again:
+
+1. **The file was deleted.** Check `cat .ai/.kb-builder/bootstrap-state.json`. If missing, the next run starts fresh.
+2. **The file is malformed.** Doctor doesn't currently check the bootstrap state file — if it's hand-edited to an invalid shape, the runtime falls back to an empty state. Fix the JSON.
+3. **The doc actually changed.** Even whitespace counts. `git diff` against the last bootstrap-commit timestamp to see what shifted.
+
+## "The KB feels noisy / the assistant gets too much context."
+
+Tune the INDEX token budget. `ai-knowledge-base index rebuild --budget-tokens 1000` re-renders INDEX at a tighter budget; oldest entries per kind get trimmed and a footer reports the hidden count. The full edge listing is still in `GRAPH.md` for the assistant to read explicitly.
+
+If the noise is in the content itself (proposals that should never have been written), tighten the prompts in `.ai/.kb-builder/prompts/`. The "what to skip" sections in [stage-2](../customization/stage-2-prompt.md), [curator](../customization/curator-prompt.md), and [bootstrap-incremental](../customization/bootstrap-incremental-prompt.md) prompts are the right levers.
+
+## When all else fails
+
+1. `ai-knowledge-base doctor --verbose` — comprehensive checks.
+2. `cat .ai/.kb-builder/state.json` — current lock + last_nudged_at.
+3. `cat .ai/knowledge-base/_sessions/.queue.json` — pending stage-2 entries.
+4. `ls .ai/knowledge-base/_logs/*/` — find the most recent run log; read it.
+5. File an issue at [the GitHub repo](https://github.com/e0ipso/ai-knowledge-base/issues) with the doctor output and the relevant log snippets.

--- a/docs/troubleshooting/index.md
+++ b/docs/troubleshooting/index.md
@@ -9,8 +9,8 @@ permalink: /troubleshooting/
 
 Pages:
 
+- [Common issues](common-issues.md) — the symptoms most contributors hit, in order of frequency.
 - [Reading stage-2 logs](reading-stage-2-logs.md) — interpreting the stream-json traces under `_logs/stage-2/`.
 - [Reading curator logs](reading-curator-logs.md) — interpreting the stream-json traces under `_logs/curator/`.
-- Common issues — _coming progressively in M3–M5._
 
-For the canonical list of failure modes and recovery steps, see [PRD §9](https://github.com/e0ipso/ai-knowledge-base/blob/main/PRD.md#9-failure-modes-the-user-sees).
+Most checks have a CLI form: `ai-knowledge-base doctor --verbose` is the first command to run when something is off. See [PRD §9](https://github.com/e0ipso/ai-knowledge-base/blob/main/PRD.md#9-failure-modes-the-user-sees) for the canonical failure-mode catalog.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,6 +2,7 @@ import { Command } from 'commander';
 import { runBootstrapIncrementalCommand } from './commands/bootstrap-incremental.js';
 import { runCurateCommand } from './commands/curate.js';
 import { runDoctor } from './commands/doctor.js';
+import { runIndexRebuild } from './commands/index-rebuild.js';
 import { runInit } from './commands/init.js';
 import { runNodeAdd } from './commands/node-add.js';
 import { runProposalsReview } from './commands/proposals-review.js';
@@ -135,6 +136,19 @@ async function main(): Promise<void> {
     .description('Interactively draft a new node; writes a proposal under _proposed/additions/.')
     .action(async () => {
       const code = await runNodeAdd();
+      process.exit(code);
+    });
+
+  const indexGroup = program.command('index').description('Manage INDEX.md and GRAPH.md.');
+  indexGroup
+    .command('rebuild')
+    .description('Regenerate INDEX.md and GRAPH.md from the current nodes/ tree (deterministic).')
+    .option('--budget-tokens <n>', 'INDEX.md token budget (default 2000)', (v) => parseInt(v, 10))
+    .action(async (opts: { budgetTokens?: number }) => {
+      const rebuildOpts: { budgetTokens?: number } = {};
+      if (typeof opts.budgetTokens === 'number' && !Number.isNaN(opts.budgetTokens))
+        rebuildOpts.budgetTokens = opts.budgetTokens;
+      const code = await runIndexRebuild(rebuildOpts);
       process.exit(code);
     });
 

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -2,9 +2,11 @@ import { execFile } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
 import { isAbsolute, join } from 'node:path';
 import { promisify } from 'node:util';
+import matter from 'gray-matter';
 import { log } from '../lib/log.js';
-import { readAllNodes } from '../lib/nodes.js';
+import { computeNodesHash, readAllNodes } from '../lib/nodes.js';
 import { findRepoRoot, repoPaths } from '../lib/paths.js';
+import { IndexFrontmatterSchema } from '../lib/schemas.js';
 
 const exec = promisify(execFile);
 
@@ -40,6 +42,19 @@ export async function runDoctor(opts: DoctorOptions): Promise<number> {
   checks.push({
     name: '.gitignore lists ai-knowledge-base paths',
     result: checkGitignore(paths.gitignoreFile),
+  });
+
+  checks.push({
+    name: 'Claude hooks registered',
+    result: checkClaudeHooks(paths.claudeSettingsFile, paths.claudeHooksDir),
+  });
+  checks.push({
+    name: 'shipped prompts present',
+    result: checkPrompts(paths.builderDir),
+  });
+  checks.push({
+    name: 'INDEX.md is fresh',
+    result: checkIndexFreshness(join(paths.kbDir, 'INDEX.md'), paths.nodesDir),
   });
 
   const dangling = collectDanglingDerivedFrom(root, paths.nodesDir, paths.sessionsDir);
@@ -192,6 +207,101 @@ function checkPreCommit(file: string): CheckResult {
     return { ok: true, detail: 'gitleaks entry present' };
   }
   return { ok: false, level: 'warn', detail: 'present but no gitleaks entry found' };
+}
+
+const EXPECTED_HOOK_SCRIPTS: Record<string, string[]> = {
+  Stop: ['.claude/hooks/kb-capture.mjs'],
+  SessionEnd: ['.claude/hooks/kb-capture.mjs'],
+  PreCompact: ['.claude/hooks/kb-capture.mjs'],
+  SessionStart: ['.claude/hooks/kb-stage2-drain.mjs', '.claude/hooks/kb-session-start.mjs'],
+};
+
+function checkClaudeHooks(settingsFile: string, hooksDir: string): CheckResult {
+  if (!existsSync(settingsFile)) {
+    return {
+      ok: false,
+      level: 'error',
+      detail: 'no .claude/settings.json. Run `ai-knowledge-base init --assistants claude --force`.',
+    };
+  }
+  let settings: {
+    hooks?: Record<string, Array<{ hooks: Array<{ command?: string }> }>>;
+  };
+  try {
+    settings = JSON.parse(readFileSync(settingsFile, 'utf8')) as typeof settings;
+  } catch (err) {
+    return { ok: false, level: 'error', detail: `unparseable: ${(err as Error).message}` };
+  }
+  const hooks = settings.hooks ?? {};
+  const missing: string[] = [];
+  for (const [event, scripts] of Object.entries(EXPECTED_HOOK_SCRIPTS)) {
+    const commands = (hooks[event] ?? []).flatMap((e) =>
+      (e.hooks ?? []).map((h) => h.command ?? ''),
+    );
+    for (const script of scripts) {
+      if (!commands.some((c) => c.includes(script))) {
+        missing.push(`${event} → ${script}`);
+      }
+    }
+  }
+  const missingFiles: string[] = [];
+  for (const script of new Set(Object.values(EXPECTED_HOOK_SCRIPTS).flat())) {
+    const file = join(hooksDir, script.split('/').pop()!);
+    if (!existsSync(file)) missingFiles.push(script);
+  }
+  if (missing.length === 0 && missingFiles.length === 0) {
+    return { ok: true, detail: 'all expected hook entries and scripts present' };
+  }
+  const parts: string[] = [];
+  if (missing.length > 0) parts.push(`missing registrations: ${missing.join(', ')}`);
+  if (missingFiles.length > 0) parts.push(`missing scripts: ${missingFiles.join(', ')}`);
+  return {
+    ok: false,
+    level: 'error',
+    detail: parts.join('; ') + '. Re-run `ai-knowledge-base init --assistants claude --force`.',
+  };
+}
+
+function checkPrompts(builderDir: string): CheckResult {
+  const expected = ['stage-2-extract.md', 'curator.md', 'bootstrap-incremental.md'];
+  const missing = expected.filter((p) => !existsSync(join(builderDir, 'prompts', p)));
+  if (missing.length === 0) {
+    return { ok: true, detail: 'stage-2, curator, bootstrap-incremental' };
+  }
+  return {
+    ok: false,
+    level: 'warn',
+    detail: `missing local override(s): ${missing.join(', ')}. The bundled package fallback is still used; re-run \`init --force\` to restore.`,
+  };
+}
+
+function checkIndexFreshness(indexFile: string, nodesDir: string): CheckResult {
+  if (!existsSync(indexFile)) {
+    return {
+      ok: false,
+      level: 'warn',
+      detail: 'INDEX.md missing — run `ai-knowledge-base index rebuild`.',
+    };
+  }
+  try {
+    const parsed = matter(readFileSync(indexFile, 'utf8'));
+    const fm = IndexFrontmatterSchema.safeParse(parsed.data);
+    if (!fm.success) {
+      return { ok: false, level: 'warn', detail: 'INDEX.md frontmatter is invalid; rebuild it.' };
+    }
+    const recorded = fm.data.nodes_hash.startsWith('sha256:')
+      ? fm.data.nodes_hash.slice(7)
+      : fm.data.nodes_hash;
+    const live = computeNodesHash(nodesDir);
+    if (recorded === live) return { ok: true, detail: `fresh (${fm.data.node_count} node(s))` };
+    return {
+      ok: false,
+      level: 'warn',
+      detail: 'stale (nodes_hash drift) — run `ai-knowledge-base index rebuild`.',
+    };
+  } catch (err) {
+    return { ok: false, level: 'warn', detail: `unreadable: ${(err as Error).message}` };
+  }
 }
 
 function checkGitignore(file: string): CheckResult {

--- a/src/commands/index-rebuild.ts
+++ b/src/commands/index-rebuild.ts
@@ -1,0 +1,46 @@
+import { existsSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { generateGraph, generateIndex, writeGraph, writeIndex } from '../lib/index-gen.js';
+import { log } from '../lib/log.js';
+import { findRepoRoot, repoPaths } from '../lib/paths.js';
+
+export interface IndexRebuildOptions {
+  budgetTokens?: number;
+}
+
+/**
+ * Thin wrapper around the deterministic `generateIndex` / `generateGraph`
+ * helpers. The curator already regenerates INDEX/GRAPH at the end of every
+ * run; this command exists for the case where a contributor edits a node
+ * file by hand (or runs `proposals review` and wants to refresh before
+ * committing) and wants to refresh the index without a curate pass.
+ */
+export async function runIndexRebuild(opts: IndexRebuildOptions = {}): Promise<number> {
+  const root = findRepoRoot();
+  const paths = repoPaths(root);
+
+  if (!existsSync(paths.installedVersionFile)) {
+    log.error(
+      'ai-knowledge-base is not initialized in this repo. Run `ai-knowledge-base init --assistants claude`.',
+    );
+    return 1;
+  }
+
+  mkdirSync(paths.kbDir, { recursive: true });
+  const genOpts: { budgetTokens?: number; now: Date } = { now: new Date() };
+  if (opts.budgetTokens !== undefined) genOpts.budgetTokens = opts.budgetTokens;
+
+  const index = generateIndex(paths.nodesDir, genOpts);
+  writeIndex(join(paths.kbDir, 'INDEX.md'), index);
+  const graph = generateGraph(paths.nodesDir, { now: genOpts.now });
+  writeGraph(join(paths.kbDir, 'GRAPH.md'), graph);
+
+  log.success(
+    `Regenerated INDEX.md and GRAPH.md from ${index.nodeCount} node(s)` +
+      (index.hiddenByBudget > 0
+        ? ` (${index.hiddenByBudget} hidden by token budget; see GRAPH.md for the full list)`
+        : '') +
+      '.',
+  );
+  return 0;
+}

--- a/tests/index-rebuild.test.ts
+++ b/tests/index-rebuild.test.ts
@@ -1,0 +1,133 @@
+import { execFile } from 'node:child_process';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+import matter from 'gray-matter';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { cleanSandbox, makeSandbox, runCli } from './helpers.js';
+
+const exec = promisify(execFile);
+
+function writeNode(sandbox: string, kind: 'practice' | 'map', id: string): void {
+  const dir = join(sandbox, '.ai/knowledge-base/nodes', kind);
+  mkdirSync(dir, { recursive: true });
+  const fm = {
+    schema_version: 1,
+    id,
+    title: id,
+    kind,
+    tags: [],
+    valid_from: '2026-01-01T00:00:00Z',
+    valid_until: null,
+    updated: '2026-01-01T00:00:00Z',
+    supersedes: null,
+    superseded_by: null,
+    derived_from: [],
+    relates_to: [],
+    depends_on: [],
+    confidence: 'high',
+    summary: 's',
+  };
+  writeFileSync(join(dir, `${id}.md`), matter.stringify('# x\nBody.', fm));
+}
+
+describe('index rebuild', () => {
+  let sandbox: string;
+  beforeEach(async () => {
+    sandbox = makeSandbox();
+    await exec('git', ['init', '-q'], { cwd: sandbox });
+    await runCli(sandbox, ['init', '--assistants', 'claude']);
+  });
+  afterEach(() => cleanSandbox(sandbox));
+
+  it('regenerates INDEX.md and GRAPH.md from the current nodes tree', async () => {
+    writeNode(sandbox, 'practice', 'practice-foo');
+    writeNode(sandbox, 'map', 'map-bar');
+    const before = readFileSync(join(sandbox, '.ai/knowledge-base/INDEX.md'), 'utf8');
+    const result = await runCli(sandbox, ['index', 'rebuild']);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('Regenerated INDEX.md and GRAPH.md from 2 node(s)');
+    const after = readFileSync(join(sandbox, '.ai/knowledge-base/INDEX.md'), 'utf8');
+    expect(after).not.toBe(before);
+    expect(after).toContain('practice-foo');
+    expect(after).toContain('map-bar');
+    const graph = readFileSync(join(sandbox, '.ai/knowledge-base/GRAPH.md'), 'utf8');
+    expect(graph).toContain('## practice-foo');
+    expect(graph).toContain('## map-bar');
+  });
+
+  it('errors when the repo is not initialized', async () => {
+    const other = makeSandbox();
+    try {
+      await exec('git', ['init', '-q'], { cwd: other });
+      const result = await runCli(other, ['index', 'rebuild']);
+      expect(result.exitCode).not.toBe(0);
+      expect(result.stderr + result.stdout).toContain('not initialized');
+    } finally {
+      cleanSandbox(other);
+    }
+  });
+
+  it('honors --budget-tokens for INDEX trimming', async () => {
+    // Seed enough practice nodes that a tiny budget triggers a hidden footer.
+    for (let i = 0; i < 12; i += 1) writeNode(sandbox, 'practice', `practice-${i}`);
+    const result = await runCli(sandbox, ['index', 'rebuild', '--budget-tokens', '50']);
+    expect(result.exitCode).toBe(0);
+    const body = readFileSync(join(sandbox, '.ai/knowledge-base/INDEX.md'), 'utf8');
+    expect(body).toContain('additional nodes hidden by token budget');
+    // INDEX records the requested budget.
+    const fm = matter(body).data as { budget_tokens?: number };
+    expect(fm.budget_tokens).toBe(50);
+  });
+
+  it('writes a freshness-aligned INDEX (doctor reports fresh after rebuild)', async () => {
+    writeNode(sandbox, 'practice', 'practice-foo');
+    // Run rebuild then doctor; INDEX should be reported fresh.
+    expect((await runCli(sandbox, ['index', 'rebuild'])).exitCode).toBe(0);
+    const doc = await runCli(sandbox, ['doctor']);
+    expect(doc.stdout + doc.stderr).toContain('INDEX.md is fresh');
+    expect((doc.stdout + doc.stderr).toLowerCase()).not.toContain('stale (nodes_hash');
+  });
+});
+
+describe('doctor: stale INDEX detection', () => {
+  let sandbox: string;
+  beforeEach(async () => {
+    sandbox = makeSandbox();
+    await exec('git', ['init', '-q'], { cwd: sandbox });
+    await runCli(sandbox, ['init', '--assistants', 'claude']);
+  });
+  afterEach(() => cleanSandbox(sandbox));
+
+  it('warns when nodes drift after INDEX was written', async () => {
+    writeNode(sandbox, 'practice', 'practice-foo');
+    expect((await runCli(sandbox, ['index', 'rebuild'])).exitCode).toBe(0);
+    // Drift: add another node without rebuilding.
+    writeNode(sandbox, 'map', 'map-bar');
+    const doc = await runCli(sandbox, ['doctor']);
+    expect(doc.exitCode).toBe(0); // warning, not error
+    expect(doc.stdout + doc.stderr).toContain('stale');
+  });
+});
+
+describe('doctor: missing INDEX', () => {
+  let sandbox: string;
+  beforeEach(async () => {
+    sandbox = makeSandbox();
+    await exec('git', ['init', '-q'], { cwd: sandbox });
+    await runCli(sandbox, ['init', '--assistants', 'claude']);
+  });
+  afterEach(() => cleanSandbox(sandbox));
+
+  it('warns when INDEX.md was deleted', async () => {
+    const indexFile = join(sandbox, '.ai/knowledge-base/INDEX.md');
+    if (existsSync(indexFile)) {
+      writeFileSync(indexFile, '');
+      // Make it truly invalid (empty -> no frontmatter).
+    }
+    // Replace with no frontmatter so the freshness check warns.
+    writeFileSync(indexFile, '# KB Index\n');
+    const doc = await runCli(sandbox, ['doctor']);
+    expect(doc.stdout + doc.stderr).toContain('INDEX.md');
+  });
+});


### PR DESCRIPTION
## Summary

Ships the final v1 milestone: a thin `index rebuild` CLI, three additional `doctor` checks, and completion of the docs site.

**CLI**

- `ai-knowledge-base index rebuild [--budget-tokens <n>]` — deterministic regeneration of `INDEX.md` and `GRAPH.md` from `nodes/`. Wraps the existing `index-gen.ts` helpers.

**Doctor (three new checks)**

- `Claude hooks registered` — verifies every expected hook event in `.claude/settings.json` AND that every script file is present on disk. Hard error.
- `shipped prompts present` — checks the local override copies of stage-2, curator, and bootstrap-incremental prompts. Warning (package fallback still works).
- `INDEX.md is fresh` — compares the INDEX frontmatter `nodes_hash` against `computeNodesHash(nodes/)`. Warning on drift, pointing the user at `index rebuild`.

**Docs (per IMPLEMENTATION §15.5 M5)**

- Architecture page — full design overview for contributors and adapter authors: layout, pipelines/hooks, state files, locking, schema versioning, adapter interface, determinism contract, "where to extend" table.
- Troubleshooting > Common issues — symptoms most contributors will hit with diagnostic commands.
- Reference > Frontmatter schemas — every YAML/JSON shape validated by the runtime, plus the `nodes_hash` algorithm.
- Reference > CLI updated with the `index rebuild` entry and an expanded doctor section.
- Getting Started > CI recipe — GitHub Actions and GitLab CI examples (doctor + pre-commit + INDEX-in-sync check).

## Test plan

- [x] `npm test` — 142 passing, 1 skipped (real-gitleaks gate). +6 cases in `tests/index-rebuild.test.ts` covering regen, error on uninitialized repo, `--budget-tokens` honoring, post-rebuild freshness, drift warning, missing-INDEX warning.
- [x] `npm run typecheck`, `npm run lint`, `npm run format:check` — clean.
- [x] `npm run build` — produces the new `index rebuild` subcommand alongside the existing CLI + three hook bundles.

https://claude.ai/code/session_01CmiYNV6ejAPZp6DbJA1h7U

---
_Generated by [Claude Code](https://claude.ai/code/session_01CmiYNV6ejAPZp6DbJA1h7U)_