### PR TITLE
feat(v1.5): settings file, init --upgrade, logs prune, real-claude E2E

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,51 @@
+name: E2E (real-claude)
+
+# Manual-only — this workflow spawns real `claude -p` subprocesses and so
+# burns API credits. Do NOT add `push` or `pull_request` triggers.
+on:
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Why are you running the real-claude E2E?'
+        required: false
+        default: 'manual smoke'
+
+jobs:
+  e2e:
+    name: full capture → drain → curate → review cycle
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      KB_RUN_REAL_CLAUDE: '1'
+      # Required by `claude -p` when run with an API key (the default in CI).
+      # OAuth subscription flow does not work in a non-interactive runner.
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      NO_COLOR: '1'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      # Install the official Claude Code CLI (the binary the test invokes
+      # under the hood). Pin to a specific channel; the suite expects the
+      # `-p`, `--output-format stream-json`, `--verbose`, and `--allowedTools`
+      # flags. If you upgrade the CLI and the test starts failing on
+      # subprocess flags, that's the contract breaking.
+      - name: Install Claude Code CLI
+        run: npm install -g @anthropic-ai/claude-code
+
+      - name: Verify claude CLI
+        run: claude --version
+
+      - name: Run real-claude E2E
+        run: npx vitest run tests/e2e --reporter=verbose

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,29 @@ npm run lint           # eslint
 npm run format:check   # prettier
 ```
 
-The optional real-`claude` end-to-end suite is gated behind an env var (see `tests/e2e/`); it spawns the actual `claude -p` CLI against fixture transcripts. Run it on demand when changing prompt templates.
+### Real-`claude` E2E suite
+
+The optional real-`claude` suite under `tests/e2e/` is gated behind `KB_RUN_REAL_CLAUDE=1`. When the env var is unset (the default) every spec is skipped, so `npm test` stays cheap and deterministic. When set, the suite spawns the actual `claude -p` CLI for stage-2 extraction and curation against a fixture transcript and asserts that the full cycle produces a node and a populated `INDEX.md`.
+
+```sh
+# Local invocation (requires `claude` on PATH, authenticated):
+KB_RUN_REAL_CLAUDE=1 npx vitest run tests/e2e
+```
+
+Per-stage timeout is 5 minutes; the full suite typically finishes in 2–4 minutes when nothing is wrong.
+
+CI does not run the E2E suite on every PR. Trigger it manually via the **E2E (real-claude)** workflow in GitHub Actions (`workflow_dispatch`). The job needs:
+
+- `ANTHROPIC_API_KEY` repository secret (the workflow installs the Claude Code CLI globally; in CI it authenticates via env var, not OAuth).
+- A reason for the run, surfaced as a `workflow_dispatch` input for the audit trail.
+
+Run it on demand when:
+
+- Changing a prompt template (`src/templates-source/prompts/*.md`).
+- Touching `src/lib/headless.ts` or the `claude -p` subprocess flags.
+- Bumping the pinned Claude Code CLI version.
+
+The suite asserts on a stable project-unique substring from the fixture transcript ("Bravo Insider") so that minor wording drift between Claude model versions doesn't break it. If the assertion regresses, inspect the JSONL log under the temp sandbox's `_logs/stage-2/` and `_logs/curator/` to see exactly what the model produced.
 
 ## Schema-version bump policy
 

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -138,16 +138,61 @@ The non-LLM parts of the system are deterministic:
 
 Tests rely on this: see `tests/lib/index-gen.test.ts` for golden-file comparisons.
 
+## Testing strategy
+
+Three layers, each catching a different class of regression. Together they cover the system without making every PR pay for the slowest one.
+
+### Unit + integration (default `npm test`)
+
+```sh
+npm test               # vitest run, all 24+ test files
+```
+
+Includes:
+
+- **Pure-function tests** for every `src/lib/` module — frontmatter parsers, Zod schemas, INDEX generator (golden-file), `nodes_hash`, dedup cache, gitleaks parser, queue atomic-write, lock TTL, stale-INDEX detection, role-tagged transcript splitter, stream-json line parser, settings resolver, duration parser, logs-prune walker.
+- **Integration tests** for every LLM-invoking pipeline (`stage2-drain`, `curate`, `bootstrap`) using the `Stage2Runner` / `CuratorRunner` / `BootstrapRunner` seams: tests inject a fake runner that returns the schema-shaped JSON directly, bypassing the `claude -p` subprocess entirely. The seam is the same one the real `ClaudeAdapter.runHeadless` plugs into, so the pipeline code path is exercised in full — only the subprocess is faked.
+- **CLI integration tests** that build the package, run the actual binary against a temp-directory sandbox, and assert on stdout, exit codes, and filesystem state. See `tests/init.test.ts`, `tests/upgrade.test.ts`, `tests/doctor.test.ts`, `tests/logs-prune.test.ts`.
+
+These run on every PR; the suite finishes in ~10 seconds locally.
+
+### Real-`claude` end-to-end (`tests/e2e/`)
+
+Gated behind `KB_RUN_REAL_CLAUDE=1` so the default test run never spawns subprocesses against the Anthropic API. When enabled, `tests/e2e/full-cycle.test.ts` exercises one full cycle on a synthetic repo:
+
+1. `ai-knowledge-base init` populates a temp directory.
+2. A fixture session log carrying the bravo-insider transcript lands in `_sessions/` with `stage_2_status: pending`.
+3. `drainStage2Queue` runs against the real `claude -p` with the shipped stage-2 prompt and a 5-minute timeout.
+4. `runCurate` runs against the real `claude -p` with the shipped curator prompt.
+5. The proposals-review TUI's "accept all" path (via the `actions` test seam) promotes every proposal into `nodes/`.
+6. `ai-knowledge-base index rebuild` produces `INDEX.md`.
+7. The test asserts at least one node exists and that either a node or `INDEX.md` mentions "Bravo Insider" — a project-unique substring from the fixture transcript.
+
+The assertion is intentionally loose (any haystack matches) so that minor wording drift between Claude model versions doesn't break it. If it regresses, the failing run leaves the stream-json logs under the temp sandbox's `_logs/stage-2/` and `_logs/curator/` for inspection.
+
+The suite is run manually via the `E2E (real-claude)` GitHub Actions workflow (`workflow_dispatch`-only). The workflow installs `@anthropic-ai/claude-code` globally and authenticates via `ANTHROPIC_API_KEY`. See [`CONTRIBUTING.md`](https://github.com/e0ipso/ai-knowledge-base/blob/main/CONTRIBUTING.md#real-claude-e2e-suite) for when to trigger it.
+
+### Manual testing
+
+`docs/manual-test-plan.md` (planned) covers tests that resist automation: PreCompact timing on long sessions, hook installation on Windows, vendored gitleaks binary on each platform, and real session-capture quality. These are exercises performed before a significant release.
+
+### Mocking strategy summary
+
+| What | How | Why |
+|---|---|---|
+| `claude -p` subprocess in unit tests | Fake `Stage2Runner`/`CuratorRunner`/`BootstrapRunner` returning schema-shaped JSON | Pipeline code is exercised; no API spend or determinism worries. |
+| `claude -p` subprocess at the spawn layer | `SpawnFn` seam in `runHeadlessClaude` | Lets us test the `headless.ts` parser against handcrafted stream-json fragments without process startup cost. |
+| File system | Sandbox temp directory + `cleanSandbox()` | No global state leakage between tests. |
+| `claude` CLI for E2E | Real binary, gated by env var | Catches prompt regressions, CLI flag drift, and model-output-shape surprises that the JSON-shaped mocks can't see. |
+
 ## What's intentionally not here
 
 Per [IMPLEMENTATION §12](https://github.com/e0ipso/ai-knowledge-base/blob/main/IMPLEMENTATION.md#12-implementation-phases):
 
-- **No `.config.json`.** Configuration values live in code as named constants. v1.5 will add a config file.
-- **No `init --upgrade`.** Re-run with `--force`; the gitignore-block and `.claude/settings.json` merging are idempotent.
-- **No `logs prune`.** v1.5.
 - **No multi-assistant adapter dispatch.** v2.
 - **No `bootstrap-incremental` overlap detection.** v2 (always writes additions; reviewer rejects duplicates).
 - **No managed-MCP injection.** The INDEX-as-additionalContext pattern is the entire injection surface.
+- **No auto-prune of `_logs/`.** v1.5 ships `ai-knowledge-base logs prune` as the manual valve; a future release may automate it via `settings.logsRetentionDays`.
 
 These are constraints, not omissions. Each one trades expressiveness for "the code is easy to read end-to-end in an afternoon."
 

--- a/docs/customization/index.md
+++ b/docs/customization/index.md
@@ -12,5 +12,6 @@ Pages:
 - [Editing the stage-2 prompt](stage-2-prompt.md) — tune the capture extractor for your project's vocabulary.
 - [Editing the curator prompt](curator-prompt.md) — control how stage-2 candidates become proposals.
 - [Editing the bootstrap-incremental prompt](bootstrap-incremental-prompt.md) — tune the chunked extraction for `bootstrap-incremental`.
+- [Tuning settings](tuning-settings.md) — recipes for the most common `.config.json` changes; trade-offs explained.
 
 Prompts are copied to `.ai/.kb-builder/prompts/` during `init` so you can override locally; hooks pick up the local copy if present and fall back to the bundled template. Reference settings live under [Reference > Settings](../reference/settings.md).

--- a/docs/customization/tuning-settings.md
+++ b/docs/customization/tuning-settings.md
@@ -1,0 +1,95 @@
+---
+title: Tuning settings
+parent: Customization
+nav_order: 4
+---
+
+# Tuning settings
+
+The defaults in `.ai/knowledge-base/.config.json` are aimed at a small-to-medium repo with a single contributor. This page walks through the knobs you'll most often want to change and what the trade-offs look like. For the full key reference see [Reference > Settings](../reference/settings.md).
+
+## Where to put overrides
+
+Two layers, both optional:
+
+- **Project**: `.ai/knowledge-base/.config.json` — committed. Edit this when the override should apply to every contributor.
+- **User**: `~/.config/@e0ipso/ai-knowledge-base/config.json` (or `$XDG_CONFIG_HOME/...`) — not committed. Edit this when only your machine needs the override (e.g. a slow laptop that times out on stage-2).
+
+Project wins. So a contributor cannot accidentally relax a project-mandated value with a user override.
+
+## Common changes
+
+### "Stage-2 keeps timing out"
+
+```json
+{
+  "schema_version": 1,
+  "stage2Timeout": 180000
+}
+```
+
+The default of 60 s is plenty for short user-turn transcripts but tight for long, dense sessions. Triple it; the cost is up to 3 × longer for a session-id to drain if it's actually stuck. The retry budget (`maxAttempts`) is unchanged, so a truly broken entry still gets skipped after three failed attempts.
+
+### "The drain processes too few entries per session"
+
+```json
+{
+  "schema_version": 1,
+  "drainBound": 20
+}
+```
+
+Useful when a developer comes back from a long break with a deep queue. Higher values keep session start async-but-slow until the queue is empty; lower values keep session start instant but spread the drain across many sessions.
+
+### "INDEX.md is being trimmed but I want everything"
+
+```json
+{
+  "schema_version": 1,
+  "indexBudgetTokens": 8000
+}
+```
+
+The default 2000-token budget is generous for ~50 nodes. Past ~200 nodes you'll start seeing the `_N additional nodes hidden_` footer. Bumping this trades context-window space for completeness; `GRAPH.md` is always the unfiltered source of truth, so the AI can still pull from it on demand.
+
+### "The curate nudge is too quiet (or too loud)"
+
+```json
+{
+  "schema_version": 1,
+  "curationThreshold": 2
+}
+```
+
+Lower threshold = nudge after fewer pending session logs. The nudge is still throttled to once per hour by `last_nudged_at` in `state.json`; if you want it more aggressive you currently have to drop the threshold instead of the throttle.
+
+### "I want logs pruned more aggressively by default"
+
+```json
+{
+  "schema_version": 1,
+  "logsRetentionDays": 7
+}
+```
+
+Affects the default `--older-than` window of `ai-knowledge-base logs prune`. The CLI flag still wins per invocation.
+
+## Per-command flags vs. settings
+
+Every per-command flag (`--batch-size`, `--token-budget`, `--timeout`, `--budget-tokens`, `--older-than`) wins over the settings file for that run. So you can keep the project default conservative and crank a single one-off invocation when needed:
+
+```sh
+ai-knowledge-base curate --token-budget 100000 --timeout 300000
+```
+
+## Verifying a settings change
+
+```sh
+ai-knowledge-base doctor
+```
+
+The `settings file is valid` check reports the number of overrides found and exits non-zero on a Zod validation failure (unknown key, negative number, wrong type). Pair it with `--verbose` for the rest of the diagnostics.
+
+## Schema versioning
+
+The Settings schema follows the moderate policy in CONTRIBUTING.md: `schema_version` bumps only on renames, removals, or semantic changes. Adding a new optional key does **not** bump the version, so your existing `.config.json` keeps working when the package adds new settings — they fall back to the documented defaults.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -12,5 +12,6 @@ Pages:
 - [Installation & first init](installation.md) — install prerequisites, run `init`, verify with `doctor`.
 - [First capture → curate](first-capture.md) — walk through one full capture / stage-2 / curate / review cycle.
 - [CI recipe](ci-recipe.md) — keep the KB healthy in continuous integration.
+- [Upgrading](upgrading.md) — refresh hooks, prompts, and config to a newer package version with `init --upgrade`.
 
 After installation the three pipelines run on their own: capture fires on every Claude Code session event, stage-2 drains in the background, and consume injects `INDEX.md` at session start. The deliberate steps are `ai-knowledge-base curate` and `ai-knowledge-base proposals review` — both of which the contributor runs explicitly.

--- a/docs/getting-started/upgrading.md
+++ b/docs/getting-started/upgrading.md
@@ -1,0 +1,93 @@
+---
+title: Upgrading
+parent: Getting Started
+nav_order: 4
+---
+
+# Upgrading
+
+When a new release of `@e0ipso/ai-knowledge-base` ships changes to hook scripts, slash commands, or default prompts, you need to refresh the copies installed in your repo. `init --upgrade` does this safely: it preserves the things you have customized (your `.config.json`, your local prompt overrides) and refreshes everything else.
+
+## TL;DR
+
+```sh
+npm install --save-dev @e0ipso/ai-knowledge-base@latest
+npx @e0ipso/ai-knowledge-base init --assistants claude --upgrade
+ai-knowledge-base doctor
+```
+
+## What gets refreshed
+
+| Thing | Behavior |
+|---|---|
+| `.claude/hooks/*.mjs` | Always overwritten from the package. These are operational scripts; you should not customize them in place. |
+| `.claude/commands/*.md` | Always overwritten from the package. |
+| `.claude/settings.json` hook registrations | Refreshed (existing user-defined hook entries preserved; ai-knowledge-base entries replaced by the new versions). |
+| `.gitignore` | Managed block is refreshed in place. New entries appear; existing user entries outside the block are untouched. |
+| `.pre-commit-config.yaml` | Created only if missing. |
+| `.ai/knowledge-base/.config.json` | Created only if missing. An existing file is never overwritten, regardless of `--force` or `--upgrade`. |
+| `.ai/.kb-builder/prompts/*.md` | Copied only when missing locally. If a prompt already exists, it is preserved (the upgrade preflight reports it as a "local override preserved" line). |
+| `.ai/.kb-builder/installed-version` | Stamped with the new package version. |
+
+## Preflight first
+
+`init --upgrade --dry-run` prints the changelist without writing:
+
+```sh
+ai-knowledge-base init --assistants claude --upgrade --dry-run
+```
+
+Sample output:
+
+```
+• Upgrade preflight in /path/to/repo
+  installed: 1.0.0
+  package:   1.5.0
+
+Planned changes:
+  • [hook-script]         refresh .claude/hooks/kb-capture.mjs
+  • [hook-script]         refresh .claude/hooks/kb-stage2-drain.mjs
+  • [slash-command]       refresh .claude/commands/kb-bootstrap.md
+  • [prompt-preserved]    local override preserved: .ai/.kb-builder/prompts/curator.md
+  • [hook-registration]   refresh ai-knowledge-base hook entries in .claude/settings.json
+  • [installed-version]   stamp installed-version: 1.0.0 → 1.5.0
+
+✓ --dry-run: 6 change(s) listed; nothing written.
+```
+
+When a prompt is preserved, the package's new bundled version is **not** copied — your override stays in effect. If you'd like to adopt the new bundled prompt, delete your override and re-run `init --upgrade`. The next preflight will report the file as `[prompt-new]` and copy the fresh template.
+
+## Applying
+
+Drop the `--dry-run` flag to apply:
+
+```sh
+ai-knowledge-base init --assistants claude --upgrade
+```
+
+The command is idempotent — running it twice in a row prints `Already at <version>. Nothing to do.` after the first successful run.
+
+## When is an upgrade needed?
+
+`ai-knowledge-base doctor` runs an `installed-version is current` check. When it warns, run `init --upgrade`:
+
+```
+⚠ installed-version is current: installed 1.0.0 ≠ package 1.5.0. Run `ai-knowledge-base init --upgrade` to refresh templates.
+```
+
+The check is a warning, not an error — the previous templates keep working until you upgrade — but you'll miss new slash commands or hook events shipped in subsequent releases.
+
+## `--upgrade` vs. `--force`
+
+| | `--force` | `--upgrade` |
+|---|---|---|
+| Overwrites hooks | yes | yes |
+| Overwrites slash commands | yes | yes |
+| Overwrites prompts | yes | **no** (preserved) |
+| Overwrites `.config.json` | **no** (warns) | **no** |
+| Refreshes `.claude/settings.json` hook entries | yes | yes |
+| Stamps installed-version | yes | yes |
+| Prints a preflight | no | yes |
+| Pairs with `--dry-run` | no | yes |
+
+Use `--upgrade` when bumping to a new package version. Use `--force` only when you've deliberately broken something and want to restore the original templates (it overwrites your local prompt customizations).

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -11,7 +11,7 @@ The package installs an `ai-knowledge-base` binary. After `npm install -g @e0ips
 ## `init`
 
 ```sh
-ai-knowledge-base init --assistants <list> [--force]
+ai-knowledge-base init --assistants <list> [--force] [--upgrade [--dry-run]]
 ```
 
 First-time setup for a repo. Copies the directory skeleton, slash commands, hook scripts, and pre-commit config; registers the capture hook against three Claude Code events; writes `.ai/.kb-builder/installed-version`.
@@ -19,7 +19,11 @@ First-time setup for a repo. Copies the directory skeleton, slash commands, hook
 Flags:
 
 - `-a, --assistants <list>` (required) — comma-separated list of AI assistants to wire up. v1 supports `claude` only; the list form exists for forward compatibility.
-- `-f, --force` — overwrite existing files. Without this flag, re-running `init` on an already-initialized repo exits with a notice and does nothing.
+- `-f, --force` — overwrite existing files. Without this flag, re-running `init` on an already-initialized repo exits with a notice and does nothing. `--force` does **not** overwrite an existing `.ai/knowledge-base/.config.json` (use the file's own editor) and is incompatible with `--upgrade` (use one or the other).
+- `-u, --upgrade` — refresh hooks, slash commands, prompts, and hook registrations to match the current package version, while preserving local prompt overrides under `.ai/.kb-builder/prompts/` and the existing `.config.json`. Prints a preflight changelist, then applies. Combine with `--dry-run` to print the preflight only.
+- `--dry-run` — only meaningful with `--upgrade`. Lists planned changes without writing.
+
+See [Getting Started > Upgrading](../getting-started/upgrading.md) for a walkthrough.
 
 What `init` writes:
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -140,6 +140,45 @@ Flags:
 
 See [Bootstrap > Incremental bootstrap](../bootstrap/incremental-bootstrap.md) for usage recipes and [Reference > `bootstrap-state.json` schema](bootstrap-state.md) for the state file shape.
 
+## `logs prune`
+
+```sh
+ai-knowledge-base logs prune [--older-than <duration>] [--dry-run]
+```
+
+Walks `.ai/knowledge-base/_logs/{stage-2,curator,bootstrap-incremental}` and deletes JSONL files whose mtime is older than the cutoff. Reports per-bucket counts and freed bytes. Stream-json logs accumulate across every stage-2 drain, curate run, and bootstrap-incremental run; v1.5 ships this as the manual pressure-release valve. (No automated pruning yet — a future release may key off `settings.logsRetentionDays`.)
+
+Flags:
+
+- `--older-than <duration>` — `ms`-package style. Accepts `30d`, `2w`, `12h`, `45m`, `30s`, `500ms`, `1y`. Defaults to `<settings.logsRetentionDays>d` (`30d` out of the box).
+- `--dry-run` — list what would be deleted without touching files. Still reports bytes-freed estimates from `stat`.
+
+Examples:
+
+```sh
+# Show what's eligible at the default 30-day cutoff.
+ai-knowledge-base logs prune --dry-run
+
+# Aggressive: keep only the last week.
+ai-knowledge-base logs prune --older-than 7d
+
+# Daily housekeeping in a long-running CI job.
+ai-knowledge-base logs prune --older-than 1d
+```
+
+Output format:
+
+```
+• Deleted 12 log file(s) older than 30d (2026-04-11T10:00:00.000Z).
+  • stage-2: 8/14 eligible — 4.2 MB
+  • curator: 3/9 eligible — 1.1 MB
+  • bootstrap-incremental: 1/2 eligible — 220 KB
+
+✓ freed 5.5 MB across 3 bucket(s).
+```
+
+See also: [Troubleshooting > Pruning logs](../troubleshooting/pruning-logs.md).
+
 ## `index rebuild`
 
 ```sh

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -6,29 +6,72 @@ nav_order: 4
 
 # Settings
 
-Settings are not yet exposed as a `.config.json` file (planned for M3). The defaults baked into the package are documented below for completeness.
+`ai-knowledge-base` reads its tunable knobs from a two-layer settings file:
 
-## Stage-2 drain (M2)
+1. **Project-level**: `.ai/knowledge-base/.config.json` (committed to the repo). Created by `init` populated with the package defaults.
+2. **User-level**: `~/.config/@e0ipso/ai-knowledge-base/config.json` (or `$XDG_CONFIG_HOME/@e0ipso/ai-knowledge-base/config.json` if set). Not committed.
 
-These settings live in `src/lib/stage2-drain.ts` and `src/lib/headless.ts`. They are not currently user-configurable; the values are the result of "what makes sense for a small-to-medium KB and a single contributor."
+Both files are optional. Resolution order (later wins):
 
-| Setting | Default | Where applied | Behavior |
+```
+package defaults  ←  user file  ←  project file
+```
+
+This means the repo's own `.config.json` is always authoritative. The user file lets a contributor reduce e.g. `stage2Timeout` for a slow box without touching the project's checked-in config.
+
+## File shape
+
+```json
+{
+  "schema_version": 1,
+  "drainBound": 5,
+  "maxAttempts": 3,
+  "stage2Timeout": 60000,
+  "lockTtlMs": 1800000,
+  "indexBudgetTokens": 2000,
+  "curationThreshold": 5,
+  "bootstrapTokenBudget": 10000,
+  "gitleaksRulesPath": null,
+  "logsRetentionDays": 30
+}
+```
+
+The Zod schema is strict: unknown keys cause `doctor` to fail with a validation error. Every key except `schema_version` is optional; omitted keys fall through to the next layer.
+
+A malformed user file is not fatal — `resolveSettings()` emits a warning to the calling command and treats the file as absent so a corrupted user override cannot brick the CLI.
+
+## Keys
+
+| Key | Type | Default | Behavior |
 |---|---|---|---|
-| `drainBound` | 5 entries | `drainStage2Queue` | Maximum number of queue entries processed per `SessionStart` invocation. Remaining entries are deferred to the next session. Keeps a long backlog from blocking a quick session start, even though the hook is async. |
-| `maxAttempts` | 3 attempts | `drainStage2Queue` | A queue entry that fails (parse error, schema mismatch, timeout, non-zero exit) is rotated to the back of the queue with `attempts` incremented. After the third failure the session log is marked `stage_2_status: skipped` and the entry is removed from the queue. |
-| `stage2Timeout` | 60,000 ms | `runHeadlessClaude` | Per-entry wall-clock deadline for the spawned `claude -p` subprocess. A timeout counts as a failed attempt for retry purposes. |
-| `lockTtl` | 30 minutes | `acquireLock` | If a `state.json` lock is older than its TTL it is treated as stale and reclaimed. Prevents a crashed drain from blocking subsequent runs forever. |
+| `drainBound` | int > 0 | `5` | Maximum number of stage-2 queue entries the async drain processes per `SessionStart`. Remaining entries are deferred to the next session. Keeps a long backlog from blocking a quick session start. |
+| `maxAttempts` | int > 0 | `3` | A failed stage-2 entry (parse error, schema mismatch, timeout, non-zero exit) is rotated to the back of the queue with `attempts` incremented. After this many failures the session log is marked `stage_2_status: skipped` and the entry is removed. |
+| `stage2Timeout` | int > 0 (ms) | `60000` | Per-entry wall-clock deadline for the spawned `claude -p` stage-2 subprocess. A timeout counts as a failed attempt for retry purposes. |
+| `lockTtlMs` | int > 0 (ms) | `1800000` (30 min) | TTL for the `.ai/.kb-builder/state.json` lock. A lock older than its TTL is treated as stale and reclaimed, preventing a crashed run from blocking subsequent invocations. Applies to the stage-2 drain, curator, and bootstrap-incremental locks. |
+| `indexBudgetTokens` | int > 0 | `2000` | INDEX.md token budget (~4 chars/token). Per-kind sections trim oldest entries until the rendered body fits; trimmed counts go into a "_N additional nodes hidden by token budget_" footer. |
+| `curationThreshold` | int > 0 | `5` | Number of pending session logs that triggers the curate-nudge on the next `SessionStart`. The nudge is throttled to at most once per hour. |
+| `bootstrapTokenBudget` | int > 0 | `10000` | Approximate per-batch token budget for `ai-knowledge-base bootstrap-incremental`. Docs are atomic — a single oversized doc lands in its own batch. |
+| `gitleaksRulesPath` | string or null | `null` | Reserved for a future capture-time gitleaks rule override. Not yet honored by the capture hook; v1.5 ships the setting so users can write the path now without a future schema bump. |
+| `logsRetentionDays` | int > 0 | `30` | Default `--older-than` window for `ai-knowledge-base logs prune`. The CLI flag still wins when given. |
 
-## Stage-2 drain lock
+## CLI flags vs. settings
 
-`.ai/.kb-builder/state.json` carries `{ schema_version: 1, lock?: { name, pid, acquired_at, ttl_ms }, last_nudged_at? }`. The lock guards against two concurrent `SessionStart` events draining the same queue. Fields:
+Per-command flags (`--batch-size`, `--token-budget`, `--timeout`, `--budget-tokens`) always override the settings value for that run. Use flags for one-off experiments, the settings file for the steady state.
+
+## Lock state
+
+`.ai/.kb-builder/state.json` carries `{ schema_version: 1, lock?: { name, pid, acquired_at, ttl_ms }, last_nudged_at? }`. The lock guards against concurrent stage-2 drains, curate runs, and bootstrap-incremental runs. Field reference:
 
 | Field | Purpose |
 |---|---|
-| `name` | Always `"stage2-drain"` for the drain. Curator (M3) will use its own name. |
-| `pid` | The OS pid of the process holding the lock. Mostly informational; the lock is released by name+pid match. |
+| `name` | `"stage2-drain"`, `"curator"`, or `"bootstrap-incremental"`. |
+| `pid` | OS pid of the process holding the lock. Mostly informational; the lock is released by name+pid match. |
 | `acquired_at` | ISO 8601 timestamp. Compared against `ttl_ms` to decide whether a lock is stale. |
-| `ttl_ms` | Lock TTL in milliseconds. 1,800,000 (30 minutes) by default. |
+| `ttl_ms` | Lock TTL in milliseconds. Sourced from `lockTtlMs` above. |
+
+## Doctor
+
+`ai-knowledge-base doctor` runs a `settings file is valid` check. If `.config.json` is missing the check is a warning (defaults are in effect); if it is unparseable or fails Zod validation the check is an error and `doctor` exits 1.
 
 ## Stage-2 log files
 
@@ -38,7 +81,7 @@ Each drain invocation writes one stream-json file per processed entry under `.ai
 .ai/knowledge-base/_logs/stage-2/<session-id>__YYYYMMDDTHHMMSSZ.jsonl
 ```
 
-The path is recorded in the session log's `stage_2_log` field. Logs are gitignored by default. See [Troubleshooting > Reading the stage-2 log](../troubleshooting/reading-stage-2-logs.md).
+The path is recorded in the session log's `stage_2_log` field. Logs are gitignored by default. See [Troubleshooting > Reading the stage-2 log](../troubleshooting/reading-stage-2-logs.md). Use `ai-knowledge-base logs prune` to bound their growth.
 
 ## Frontmatter changes on stage-2 completion
 
@@ -56,7 +99,3 @@ proposals:
 ```
 
 On failure, only `stage_2_status` (`failed` or `skipped`), `stage_2_completed_at` (set only when `skipped`), `stage_2_error`, and `stage_2_log` are updated; `proposals` is left empty.
-
-## Future settings (planned for M3)
-
-`.ai/knowledge-base/.config.json` (committed) plus `~/.config/@e0ipso/ai-knowledge-base/config.json` (per-user override). Will surface: `drainBound`, `maxAttempts`, `stage2Timeout`, `lockTtl`, INDEX token budget, curation threshold, gitleaks ruleset path. Project settings win.

--- a/docs/troubleshooting/index.md
+++ b/docs/troubleshooting/index.md
@@ -12,5 +12,6 @@ Pages:
 - [Common issues](common-issues.md) — the symptoms most contributors hit, in order of frequency.
 - [Reading stage-2 logs](reading-stage-2-logs.md) — interpreting the stream-json traces under `_logs/stage-2/`.
 - [Reading curator logs](reading-curator-logs.md) — interpreting the stream-json traces under `_logs/curator/`.
+- [Pruning logs](pruning-logs.md) — bounding the growth of `_logs/` with `ai-knowledge-base logs prune`.
 
 Most checks have a CLI form: `ai-knowledge-base doctor --verbose` is the first command to run when something is off. See [PRD §9](https://github.com/e0ipso/ai-knowledge-base/blob/main/PRD.md#9-failure-modes-the-user-sees) for the canonical failure-mode catalog.

--- a/docs/troubleshooting/pruning-logs.md
+++ b/docs/troubleshooting/pruning-logs.md
@@ -1,0 +1,76 @@
+---
+title: Pruning logs
+parent: Troubleshooting
+nav_order: 4
+---
+
+# Pruning logs
+
+`.ai/knowledge-base/_logs/` accumulates a stream-json trace per stage-2 entry, curator run, and bootstrap-incremental run. The directory is gitignored, but it can grow without bound on a long-lived repo. `ai-knowledge-base logs prune` is the manual housekeeping tool.
+
+## When to prune
+
+You probably want to prune when:
+
+- `du -sh .ai/knowledge-base/_logs/` reports more than a few hundred megabytes.
+- You're packaging the repo (e.g. for a tarball) and want a small payload.
+- You just resolved a stage-2 incident and the per-attempt traces are no longer interesting.
+
+You do **not** want to prune when:
+
+- A failed stage-2 entry is still in the queue (`ai-knowledge-base status` shows non-zero). The trace files are how you debug what the model did.
+- You're investigating a regression that you traced to a specific run-id — those logs are your evidence.
+
+## Recipes
+
+Show what would be removed without touching anything:
+
+```sh
+ai-knowledge-base logs prune --dry-run
+```
+
+Prune everything older than two weeks:
+
+```sh
+ai-knowledge-base logs prune --older-than 2w
+```
+
+Override the default retention to one day for a hot CI job:
+
+```sh
+ai-knowledge-base logs prune --older-than 1d
+```
+
+Drop the default retention permanently to seven days for everyone on the project — edit `.ai/knowledge-base/.config.json`:
+
+```json
+{
+  "schema_version": 1,
+  "logsRetentionDays": 7
+}
+```
+
+Subsequent `ai-knowledge-base logs prune` invocations (without `--older-than`) will use this as the default. CLI flags still win when present.
+
+## Output
+
+Per-bucket counts and freed bytes:
+
+```
+• Deleted 12 log file(s) older than 30d (2026-04-11T10:00:00.000Z).
+  • stage-2: 8/14 eligible — 4.2 MB
+  • curator: 3/9 eligible — 1.1 MB
+  • bootstrap-incremental: 1/2 eligible — 220 KB
+
+✓ freed 5.5 MB across 3 bucket(s).
+```
+
+`X/Y eligible` means: of `Y` files scanned in the bucket, `X` had an mtime older than the cutoff and were deleted. Each bucket reports independently; an empty bucket simply lists `0/0 eligible — 0 B`.
+
+## What is NOT pruned
+
+- Files outside the three bucket directories (`_logs/<anything-else>/`) — only `stage-2/`, `curator/`, `bootstrap-incremental/` are walked.
+- Non-`.jsonl` files (READMEs, manual notes you dropped in).
+- Files whose mtime is at the cutoff exactly or newer (strict less-than comparison).
+
+The frontmatter `stage_2_log` reference on a session log keeps pointing at the now-deleted file. Today, that just means the consumer's "open the log" workflow becomes "the log isn't here anymore" — nothing in the pipeline reads stage-2 logs after the drain succeeds. If you need a guaranteed forensic record, copy the relevant log file out of `_logs/` before pruning.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,6 +4,7 @@ import { runCurateCommand } from './commands/curate.js';
 import { runDoctor } from './commands/doctor.js';
 import { runIndexRebuild } from './commands/index-rebuild.js';
 import { runInit } from './commands/init.js';
+import { runLogsPrune } from './commands/logs-prune.js';
 import { runNodeAdd } from './commands/node-add.js';
 import { runProposalsReview } from './commands/proposals-review.js';
 import { runStatus } from './commands/status.js';
@@ -169,6 +170,25 @@ async function main(): Promise<void> {
       if (typeof opts.budgetTokens === 'number' && !Number.isNaN(opts.budgetTokens))
         rebuildOpts.budgetTokens = opts.budgetTokens;
       const code = await runIndexRebuild(rebuildOpts);
+      process.exit(code);
+    });
+
+  const logsGroup = program.command('logs').description('Manage stream-json log files.');
+  logsGroup
+    .command('prune')
+    .description(
+      'Delete JSONL log files under .ai/knowledge-base/_logs/ older than a duration (default: 30d or settings.logsRetentionDays).',
+    )
+    .option(
+      '--older-than <duration>',
+      "ms-style duration (e.g. '30d', '2w', '12h'); files older than this are deleted",
+    )
+    .option('--dry-run', 'list what would be deleted without touching files', false)
+    .action(async (opts: { olderThan?: string; dryRun?: boolean }) => {
+      const pruneOpts: { olderThan?: string; dryRun?: boolean } = {};
+      if (typeof opts.olderThan === 'string') pruneOpts.olderThan = opts.olderThan;
+      if (opts.dryRun) pruneOpts.dryRun = true;
+      const code = await runLogsPrune(pruneOpts);
       process.exit(code);
     });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -30,11 +30,31 @@ async function main(): Promise<void> {
           .filter(Boolean),
     )
     .option('-f, --force', 'overwrite existing ai-knowledge-base files', false)
-    .action(async (opts: { assistants: string[]; force?: boolean }) => {
-      const initOpts: { assistants: string[]; force?: boolean } = { assistants: opts.assistants };
-      if (opts.force) initOpts.force = true;
-      await runInit(initOpts);
-    });
+    .option(
+      '-u, --upgrade',
+      'refresh hooks/slash commands/prompts to the current package version while preserving local overrides and .config.json',
+      false,
+    )
+    .option('--dry-run', 'with --upgrade: list planned changes without writing', false)
+    .action(
+      async (opts: {
+        assistants: string[];
+        force?: boolean;
+        upgrade?: boolean;
+        dryRun?: boolean;
+      }) => {
+        const initOpts: {
+          assistants: string[];
+          force?: boolean;
+          upgrade?: boolean;
+          dryRun?: boolean;
+        } = { assistants: opts.assistants };
+        if (opts.force) initOpts.force = true;
+        if (opts.upgrade) initOpts.upgrade = true;
+        if (opts.dryRun) initOpts.dryRun = true;
+        await runInit(initOpts);
+      },
+    );
 
   program
     .command('status')

--- a/src/commands/bootstrap-incremental.ts
+++ b/src/commands/bootstrap-incremental.ts
@@ -8,6 +8,7 @@ import {
 } from '../lib/bootstrap.js';
 import { log } from '../lib/log.js';
 import { findRepoRoot, packageTemplatesDir, repoPaths } from '../lib/paths.js';
+import { resolveSettings } from '../lib/settings.js';
 
 export interface BootstrapIncrementalOptions {
   from: string;
@@ -47,6 +48,9 @@ export async function runBootstrapIncrementalCommand(
   const runner: BootstrapRunner = (prompt, stdin, schema, runnerOpts) =>
     adapter.runHeadless(prompt, stdin, schema, runnerOpts);
 
+  const { settings, warnings } = resolveSettings({ projectFile: paths.projectConfigFile });
+  for (const w of warnings) log.warn(w);
+
   const ctx: BootstrapContext = {
     sourceDir,
     repoRoot: root,
@@ -57,6 +61,8 @@ export async function runBootstrapIncrementalCommand(
     bootstrapStateFile: join(paths.builderDir, 'bootstrap-state.json'),
     promptTemplate,
     runner,
+    tokenBudget: settings.bootstrapTokenBudget,
+    lockTtlMs: settings.lockTtlMs,
   };
   if (opts.include !== undefined) ctx.include = opts.include;
   if (opts.exclude !== undefined) ctx.exclude = opts.exclude;

--- a/src/commands/curate.ts
+++ b/src/commands/curate.ts
@@ -4,6 +4,7 @@ import { ClaudeAdapter } from '../adapters/claude.js';
 import { runCurate, type CuratorRunner } from '../lib/curate.js';
 import { log } from '../lib/log.js';
 import { findRepoRoot, packageTemplatesDir, repoPaths } from '../lib/paths.js';
+import { resolveSettings } from '../lib/settings.js';
 
 export interface CurateCommandOptions {
   batchSize?: number;
@@ -33,6 +34,8 @@ export async function runCurateCommand(opts: CurateCommandOptions = {}): Promise
     adapter.runHeadless(prompt, stdin, schema, runnerOpts);
 
   log.info('Curating pending session logs…');
+  const { settings, warnings } = resolveSettings({ projectFile: paths.projectConfigFile });
+  for (const w of warnings) log.warn(w);
   const baseOpts = {
     kbDir: paths.kbDir,
     sessionsDir: paths.sessionsDir,
@@ -42,6 +45,8 @@ export async function runCurateCommand(opts: CurateCommandOptions = {}): Promise
     stateFile: join(paths.builderDir, 'state.json'),
     promptTemplate,
     runner,
+    lockTtlMs: settings.lockTtlMs,
+    indexBudgetTokens: settings.indexBudgetTokens,
   };
   const result = await runCurate({
     ...baseOpts,

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -7,6 +7,7 @@ import { log } from '../lib/log.js';
 import { computeNodesHash, readAllNodes } from '../lib/nodes.js';
 import { findRepoRoot, repoPaths } from '../lib/paths.js';
 import { IndexFrontmatterSchema, SettingsSchema } from '../lib/schemas.js';
+import { packageVersion } from '../lib/version.js';
 
 const exec = promisify(execFile);
 
@@ -34,6 +35,10 @@ export async function runDoctor(opts: DoctorOptions): Promise<number> {
   checks.push({
     name: '.ai/.kb-builder/installed-version',
     result: checkInstalledVersion(paths.installedVersionFile),
+  });
+  checks.push({
+    name: 'installed-version is current',
+    result: checkInstalledVersionCurrent(paths.installedVersionFile),
   });
   checks.push({
     name: 'pre-commit config installed',
@@ -195,6 +200,34 @@ function checkInstalledVersion(file: string): CheckResult {
     return { ok: true, detail: parsed.version ?? 'present (no version field)' };
   } catch (err) {
     return { ok: false, level: 'error', detail: `unreadable: ${(err as Error).message}` };
+  }
+}
+
+function checkInstalledVersionCurrent(file: string): CheckResult {
+  if (!existsSync(file)) {
+    return {
+      ok: false,
+      level: 'warn',
+      detail: 'no installed-version stamp; skipping currency check.',
+    };
+  }
+  try {
+    const parsed = JSON.parse(readFileSync(file, 'utf8')) as { version?: string };
+    const installed = typeof parsed.version === 'string' ? parsed.version : null;
+    const current = packageVersion();
+    if (installed === null) {
+      return { ok: false, level: 'warn', detail: 'installed-version has no `version` field.' };
+    }
+    if (installed === current) {
+      return { ok: true, detail: `${current}` };
+    }
+    return {
+      ok: false,
+      level: 'warn',
+      detail: `installed ${installed} ≠ package ${current}. Run \`ai-knowledge-base init --upgrade\` to refresh templates.`,
+    };
+  } catch (err) {
+    return { ok: false, level: 'warn', detail: `unreadable: ${(err as Error).message}` };
   }
 }
 

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -6,7 +6,7 @@ import matter from 'gray-matter';
 import { log } from '../lib/log.js';
 import { computeNodesHash, readAllNodes } from '../lib/nodes.js';
 import { findRepoRoot, repoPaths } from '../lib/paths.js';
-import { IndexFrontmatterSchema } from '../lib/schemas.js';
+import { IndexFrontmatterSchema, SettingsSchema } from '../lib/schemas.js';
 
 const exec = promisify(execFile);
 
@@ -51,6 +51,10 @@ export async function runDoctor(opts: DoctorOptions): Promise<number> {
   checks.push({
     name: 'shipped prompts present',
     result: checkPrompts(paths.builderDir),
+  });
+  checks.push({
+    name: 'settings file is valid',
+    result: checkSettings(paths.projectConfigFile),
   });
   checks.push({
     name: 'INDEX.md is fresh',
@@ -302,6 +306,40 @@ function checkIndexFreshness(indexFile: string, nodesDir: string): CheckResult {
   } catch (err) {
     return { ok: false, level: 'warn', detail: `unreadable: ${(err as Error).message}` };
   }
+}
+
+function checkSettings(file: string): CheckResult {
+  if (!existsSync(file)) {
+    return {
+      ok: false,
+      level: 'warn',
+      detail: `no .ai/knowledge-base/.config.json — package defaults are in effect. Run \`ai-knowledge-base init --upgrade\` to create one.`,
+    };
+  }
+  let raw: string;
+  try {
+    raw = readFileSync(file, 'utf8');
+  } catch (err) {
+    return { ok: false, level: 'error', detail: `unreadable: ${(err as Error).message}` };
+  }
+  let json: unknown;
+  try {
+    json = JSON.parse(raw);
+  } catch (err) {
+    return { ok: false, level: 'error', detail: `invalid JSON: ${(err as Error).message}` };
+  }
+  const parsed = SettingsSchema.safeParse(json);
+  if (!parsed.success) {
+    return {
+      ok: false,
+      level: 'error',
+      detail: `schema validation failed: ${parsed.error.issues
+        .map((i) => `${i.path.join('.') || '(root)'}: ${i.message}`)
+        .join('; ')}`,
+    };
+  }
+  const keys = Object.keys(parsed.data).filter((k) => k !== 'schema_version').length;
+  return { ok: true, detail: `valid (${keys} override(s))` };
 }
 
 function checkGitignore(file: string): CheckResult {

--- a/src/commands/index-rebuild.ts
+++ b/src/commands/index-rebuild.ts
@@ -3,6 +3,7 @@ import { join } from 'node:path';
 import { generateGraph, generateIndex, writeGraph, writeIndex } from '../lib/index-gen.js';
 import { log } from '../lib/log.js';
 import { findRepoRoot, repoPaths } from '../lib/paths.js';
+import { resolveSettings } from '../lib/settings.js';
 
 export interface IndexRebuildOptions {
   budgetTokens?: number;
@@ -27,7 +28,12 @@ export async function runIndexRebuild(opts: IndexRebuildOptions = {}): Promise<n
   }
 
   mkdirSync(paths.kbDir, { recursive: true });
-  const genOpts: { budgetTokens?: number; now: Date } = { now: new Date() };
+  const { settings, warnings } = resolveSettings({ projectFile: paths.projectConfigFile });
+  for (const w of warnings) log.warn(w);
+  const genOpts: { budgetTokens?: number; now: Date } = {
+    now: new Date(),
+    budgetTokens: settings.indexBudgetTokens,
+  };
   if (opts.budgetTokens !== undefined) genOpts.budgetTokens = opts.budgetTokens;
 
   const index = generateIndex(paths.nodesDir, genOpts);

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,4 +1,12 @@
-import { cpSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
 import { join } from 'node:path';
 import { ClaudeAdapter } from '../adapters/claude.js';
 import { log } from '../lib/log.js';
@@ -9,6 +17,8 @@ import { packageVersion } from '../lib/version.js';
 export interface InitOptions {
   assistants: string[];
   force?: boolean;
+  upgrade?: boolean;
+  dryRun?: boolean;
 }
 
 interface InstalledVersion {
@@ -32,16 +42,7 @@ const GITIGNORE_LINES = [
 const SUPPORTED_ASSISTANTS = new Set(['claude']);
 
 export async function runInit(opts: InitOptions): Promise<void> {
-  for (const a of opts.assistants) {
-    if (!SUPPORTED_ASSISTANTS.has(a)) {
-      throw new Error(
-        `Unsupported assistant '${a}'. v1 only supports: ${[...SUPPORTED_ASSISTANTS].join(', ')}.`,
-      );
-    }
-  }
-  if (!opts.assistants.includes('claude')) {
-    throw new Error('Assistant list must include "claude" (the only assistant supported in v1).');
-  }
+  validateAssistants(opts.assistants);
 
   const root = findRepoRoot();
   const paths = repoPaths(root);
@@ -52,6 +53,11 @@ export async function runInit(opts: InitOptions): Promise<void> {
     );
   }
 
+  if (opts.upgrade) {
+    await runUpgrade(opts, root, paths, templatesDir);
+    return;
+  }
+
   log.info(`Initializing in ${root}`);
 
   // Already initialized?
@@ -60,7 +66,7 @@ export async function runInit(opts: InitOptions): Promise<void> {
       readFileSync(paths.installedVersionFile, 'utf8'),
     ) as InstalledVersion;
     log.warn(
-      `Already initialized (version ${existing.version}). Re-run with --force to overwrite templates.`,
+      `Already initialized (version ${existing.version}). Re-run with --force to overwrite templates, or use \`init --upgrade\` to refresh templates while preserving local prompt overrides and \`.config.json\`.`,
     );
     return;
   }
@@ -69,24 +75,7 @@ export async function runInit(opts: InitOptions): Promise<void> {
   copyTree(join(templatesDir, 'knowledge-base'), paths.kbDir);
 
   // 2. Claude-specific files (commands + settings + hooks).
-  if (opts.assistants.includes('claude')) {
-    const claudeAdapter = new ClaudeAdapter();
-    const claudeTemplateDir = join(templatesDir, 'claude');
-    if (existsSync(claudeTemplateDir)) {
-      copyTree(claudeTemplateDir, paths.claudeDir);
-    }
-    await claudeAdapter.writeHookConfig(root, [
-      { event: 'Stop', scriptPath: '.claude/hooks/kb-capture.mjs' },
-      { event: 'SessionEnd', scriptPath: '.claude/hooks/kb-capture.mjs' },
-      { event: 'PreCompact', scriptPath: '.claude/hooks/kb-capture.mjs' },
-      {
-        event: 'SessionStart',
-        scriptPath: '.claude/hooks/kb-stage2-drain.mjs',
-        async: true,
-      },
-      { event: 'SessionStart', scriptPath: '.claude/hooks/kb-session-start.mjs' },
-    ]);
-  }
+  await installClaude(opts.assistants, templatesDir, paths.claudeDir, root);
 
   // 3. Prompts under .ai/.kb-builder/prompts (for local override).
   const promptsSrc = join(templatesDir, 'prompts');
@@ -112,15 +101,7 @@ export async function runInit(opts: InitOptions): Promise<void> {
   }
 
   // 7. Write installed-version marker.
-  const installed: InstalledVersion = {
-    schema_version: 1,
-    package: '@e0ipso/ai-knowledge-base',
-    version: packageVersion(),
-    installed_at: new Date().toISOString(),
-    assistants: opts.assistants,
-  };
-  mkdirSync(paths.builderDir, { recursive: true });
-  writeFileSync(paths.installedVersionFile, `${JSON.stringify(installed, null, 2)}\n`);
+  writeInstalledVersion(paths.installedVersionFile, paths.builderDir, opts.assistants);
 
   log.success('Initialized.');
   log.plain('');
@@ -129,6 +110,318 @@ export async function runInit(opts: InitOptions): Promise<void> {
   log.plain('     and the updated `.gitignore`.');
   log.plain('  2. Install pre-commit (https://pre-commit.com) and run `pre-commit install`.');
   log.plain('  3. Run `ai-knowledge-base doctor` to verify the setup.');
+}
+
+function validateAssistants(assistants: string[]): void {
+  for (const a of assistants) {
+    if (!SUPPORTED_ASSISTANTS.has(a)) {
+      throw new Error(
+        `Unsupported assistant '${a}'. v1 only supports: ${[...SUPPORTED_ASSISTANTS].join(', ')}.`,
+      );
+    }
+  }
+  if (!assistants.includes('claude')) {
+    throw new Error('Assistant list must include "claude" (the only assistant supported in v1).');
+  }
+}
+
+interface UpgradeChange {
+  kind:
+    | 'hook-script'
+    | 'slash-command'
+    | 'prompt-new'
+    | 'prompt-preserved'
+    | 'hook-registration'
+    | 'gitignore'
+    | 'config-json'
+    | 'pre-commit-config'
+    | 'installed-version';
+  detail: string;
+}
+
+async function runUpgrade(
+  opts: InitOptions,
+  root: string,
+  paths: ReturnType<typeof repoPaths>,
+  templatesDir: string,
+): Promise<void> {
+  if (!existsSync(paths.installedVersionFile)) {
+    throw new Error(
+      'Not initialized. Run `ai-knowledge-base init --assistants claude` for a first-time install.',
+    );
+  }
+  const installed = JSON.parse(
+    readFileSync(paths.installedVersionFile, 'utf8'),
+  ) as InstalledVersion;
+  const current = packageVersion();
+
+  log.info(`Upgrade preflight in ${root}`);
+  log.plain(`  installed: ${installed.version}`);
+  log.plain(`  package:   ${current}`);
+
+  const changes = collectUpgradeChanges({
+    installed,
+    current,
+    root,
+    paths,
+    templatesDir,
+    assistants: opts.assistants,
+  });
+
+  if (changes.length === 0 && installed.version === current) {
+    log.success(`Already at ${current}. Nothing to do.`);
+    return;
+  }
+
+  log.plain('');
+  log.plain('Planned changes:');
+  for (const c of changes) {
+    log.plain(`  • [${c.kind}] ${c.detail}`);
+  }
+
+  if (opts.dryRun) {
+    log.plain('');
+    log.success(`--dry-run: ${changes.length} change(s) listed; nothing written.`);
+    return;
+  }
+
+  // Apply phase. Each function is idempotent so re-running is safe.
+  log.plain('');
+  log.info('Applying…');
+
+  // Hook scripts + slash commands: overwrite from templates.
+  copyTree(join(templatesDir, 'claude', 'hooks'), paths.claudeHooksDir);
+  copyTree(join(templatesDir, 'claude', 'commands'), paths.claudeCommandsDir);
+
+  // Refresh hook registrations in .claude/settings.json (preserves user-defined hooks).
+  await installClaude(opts.assistants, templatesDir, paths.claudeDir, root);
+
+  // Prompts: copy only those missing locally, preserve customized ones.
+  copyPromptsPreservingLocal(join(templatesDir, 'prompts'), join(paths.builderDir, 'prompts'));
+
+  // Gitignore: idempotent block update covers new lines.
+  updateGitignore(paths.gitignoreFile);
+
+  // Pre-commit config: only write if missing (init's existing behavior).
+  installPreCommitConfig(paths.preCommitConfigFile, templatesDir);
+
+  // Settings: only create if missing; never overwrite existing.
+  if (!existsSync(paths.projectConfigFile)) {
+    mkdirSync(paths.kbDir, { recursive: true });
+    writeFileSync(paths.projectConfigFile, defaultProjectConfigBody());
+  }
+
+  // Stamp the new installed-version.
+  writeInstalledVersion(paths.installedVersionFile, paths.builderDir, opts.assistants);
+
+  log.success(`Upgraded to ${current}.`);
+  log.plain('Run `ai-knowledge-base doctor` to verify.');
+}
+
+interface UpgradeContext {
+  installed: InstalledVersion;
+  current: string;
+  root: string;
+  paths: ReturnType<typeof repoPaths>;
+  templatesDir: string;
+  assistants: string[];
+}
+
+function collectUpgradeChanges(ctx: UpgradeContext): UpgradeChange[] {
+  const out: UpgradeChange[] = [];
+
+  // Hook scripts.
+  const hookSrc = join(ctx.templatesDir, 'claude', 'hooks');
+  if (existsSync(hookSrc)) {
+    for (const name of readdirSync(hookSrc)) {
+      const src = join(hookSrc, name);
+      const dst = join(ctx.paths.claudeHooksDir, name);
+      if (!existsSync(dst) || !filesEqual(src, dst)) {
+        out.push({ kind: 'hook-script', detail: `refresh .claude/hooks/${name}` });
+      }
+    }
+  }
+
+  // Slash commands.
+  const cmdSrc = join(ctx.templatesDir, 'claude', 'commands');
+  if (existsSync(cmdSrc)) {
+    for (const name of readdirSync(cmdSrc)) {
+      const src = join(cmdSrc, name);
+      const dst = join(ctx.paths.claudeCommandsDir, name);
+      if (!existsSync(dst) || !filesEqual(src, dst)) {
+        out.push({ kind: 'slash-command', detail: `refresh .claude/commands/${name}` });
+      }
+    }
+  }
+
+  // Prompts (preserve existing local overrides).
+  const promptSrc = join(ctx.templatesDir, 'prompts');
+  if (existsSync(promptSrc)) {
+    for (const name of readdirSync(promptSrc)) {
+      const dst = join(ctx.paths.builderDir, 'prompts', name);
+      if (!existsSync(dst)) {
+        out.push({ kind: 'prompt-new', detail: `copy new prompt .ai/.kb-builder/prompts/${name}` });
+      } else if (!filesEqual(join(promptSrc, name), dst)) {
+        out.push({
+          kind: 'prompt-preserved',
+          detail: `local override preserved: .ai/.kb-builder/prompts/${name}`,
+        });
+      }
+    }
+  }
+
+  // Hook registrations: only report if any expected entry is missing.
+  if (hookRegistrationsNeedRefresh(ctx.paths.claudeSettingsFile)) {
+    out.push({
+      kind: 'hook-registration',
+      detail: 'refresh ai-knowledge-base hook entries in .claude/settings.json',
+    });
+  }
+
+  // Gitignore: report only if the block is missing lines.
+  const gitignoreState = inspectGitignore(ctx.paths.gitignoreFile);
+  if (!gitignoreState.blockPresent) {
+    out.push({ kind: 'gitignore', detail: `add ai-knowledge-base block to .gitignore` });
+  } else if (gitignoreState.missingLines.length > 0) {
+    out.push({
+      kind: 'gitignore',
+      detail: `add missing .gitignore lines: ${gitignoreState.missingLines.join(', ')}`,
+    });
+  }
+
+  // .config.json: create only if absent.
+  if (!existsSync(ctx.paths.projectConfigFile)) {
+    out.push({
+      kind: 'config-json',
+      detail: 'create default .ai/knowledge-base/.config.json',
+    });
+  }
+
+  // pre-commit config (only if missing — init never overwrites).
+  if (!existsSync(ctx.paths.preCommitConfigFile)) {
+    out.push({ kind: 'pre-commit-config', detail: 'create .pre-commit-config.yaml' });
+  }
+
+  // installed-version stamp.
+  if (ctx.installed.version !== ctx.current) {
+    out.push({
+      kind: 'installed-version',
+      detail: `stamp installed-version: ${ctx.installed.version} → ${ctx.current}`,
+    });
+  }
+
+  return out;
+}
+
+interface GitignoreState {
+  blockPresent: boolean;
+  missingLines: string[];
+}
+
+const EXPECTED_HOOK_COMMANDS: Array<{ event: string; command: string; async?: boolean }> = [
+  { event: 'Stop', command: 'KB_BUILDER_HOOK=Stop node .claude/hooks/kb-capture.mjs' },
+  { event: 'SessionEnd', command: 'KB_BUILDER_HOOK=SessionEnd node .claude/hooks/kb-capture.mjs' },
+  { event: 'PreCompact', command: 'KB_BUILDER_HOOK=PreCompact node .claude/hooks/kb-capture.mjs' },
+  {
+    event: 'SessionStart',
+    command: 'KB_BUILDER_HOOK=SessionStart node .claude/hooks/kb-stage2-drain.mjs',
+    async: true,
+  },
+  {
+    event: 'SessionStart',
+    command: 'KB_BUILDER_HOOK=SessionStart node .claude/hooks/kb-session-start.mjs',
+  },
+];
+
+function hookRegistrationsNeedRefresh(settingsFile: string): boolean {
+  if (!existsSync(settingsFile)) return true;
+  let parsed: {
+    hooks?: Record<string, Array<{ hooks?: Array<{ command?: string; async?: boolean }> }>>;
+  };
+  try {
+    parsed = JSON.parse(readFileSync(settingsFile, 'utf8')) as typeof parsed;
+  } catch {
+    return true;
+  }
+  const hooks = parsed.hooks ?? {};
+  for (const expected of EXPECTED_HOOK_COMMANDS) {
+    const entries = hooks[expected.event] ?? [];
+    const flat = entries.flatMap((e) => e.hooks ?? []);
+    const match = flat.find((h) => h.command === expected.command);
+    if (!match) return true;
+    if (expected.async === true && match.async !== true) return true;
+  }
+  return false;
+}
+
+function inspectGitignore(file: string): GitignoreState {
+  if (!existsSync(file)) return { blockPresent: false, missingLines: GITIGNORE_LINES.slice() };
+  const body = readFileSync(file, 'utf8');
+  const blockPresent = body.includes(GITIGNORE_BLOCK_START);
+  const missing = GITIGNORE_LINES.filter((line) => !body.includes(line));
+  return { blockPresent, missingLines: missing };
+}
+
+function filesEqual(a: string, b: string): boolean {
+  try {
+    const sa = statSync(a);
+    const sb = statSync(b);
+    if (sa.size !== sb.size) return false;
+    return readFileSync(a).equals(readFileSync(b));
+  } catch {
+    return false;
+  }
+}
+
+function copyPromptsPreservingLocal(src: string, dst: string): void {
+  if (!existsSync(src)) return;
+  mkdirSync(dst, { recursive: true });
+  for (const name of readdirSync(src)) {
+    const srcPath = join(src, name);
+    const dstPath = join(dst, name);
+    if (existsSync(dstPath)) {
+      // Preserve any existing prompt (treat as local override).
+      continue;
+    }
+    cpSync(srcPath, dstPath);
+  }
+}
+
+async function installClaude(
+  assistants: string[],
+  templatesDir: string,
+  claudeDir: string,
+  root: string,
+): Promise<void> {
+  if (!assistants.includes('claude')) return;
+  const adapter = new ClaudeAdapter();
+  const claudeTemplateDir = join(templatesDir, 'claude');
+  if (existsSync(claudeTemplateDir)) {
+    copyTree(claudeTemplateDir, claudeDir);
+  }
+  await adapter.writeHookConfig(root, [
+    { event: 'Stop', scriptPath: '.claude/hooks/kb-capture.mjs' },
+    { event: 'SessionEnd', scriptPath: '.claude/hooks/kb-capture.mjs' },
+    { event: 'PreCompact', scriptPath: '.claude/hooks/kb-capture.mjs' },
+    {
+      event: 'SessionStart',
+      scriptPath: '.claude/hooks/kb-stage2-drain.mjs',
+      async: true,
+    },
+    { event: 'SessionStart', scriptPath: '.claude/hooks/kb-session-start.mjs' },
+  ]);
+}
+
+function writeInstalledVersion(file: string, builderDir: string, assistants: string[]): void {
+  const installed: InstalledVersion = {
+    schema_version: 1,
+    package: '@e0ipso/ai-knowledge-base',
+    version: packageVersion(),
+    installed_at: new Date().toISOString(),
+    assistants,
+  };
+  mkdirSync(builderDir, { recursive: true });
+  writeFileSync(file, `${JSON.stringify(installed, null, 2)}\n`);
 }
 
 function copyTree(src: string, dest: string): void {

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -3,6 +3,7 @@ import { join } from 'node:path';
 import { ClaudeAdapter } from '../adapters/claude.js';
 import { log } from '../lib/log.js';
 import { findRepoRoot, packageTemplatesDir, repoPaths } from '../lib/paths.js';
+import { defaultProjectConfigBody } from '../lib/settings.js';
 import { packageVersion } from '../lib/version.js';
 
 export interface InitOptions {
@@ -99,7 +100,18 @@ export async function runInit(opts: InitOptions): Promise<void> {
   // 5. Update .gitignore.
   updateGitignore(paths.gitignoreFile);
 
-  // 6. Write installed-version marker.
+  // 6. Write default settings file unless one is already present. `--force`
+  // intentionally does not overwrite an existing .config.json — users edit it.
+  if (!existsSync(paths.projectConfigFile)) {
+    mkdirSync(paths.kbDir, { recursive: true });
+    writeFileSync(paths.projectConfigFile, defaultProjectConfigBody());
+  } else if (opts.force) {
+    log.warn(
+      `.ai/knowledge-base/.config.json already exists; not overwriting (use \`init --upgrade\` to refresh templates without touching settings).`,
+    );
+  }
+
+  // 7. Write installed-version marker.
   const installed: InstalledVersion = {
     schema_version: 1,
     package: '@e0ipso/ai-knowledge-base',

--- a/src/commands/logs-prune.ts
+++ b/src/commands/logs-prune.ts
@@ -1,0 +1,63 @@
+import { existsSync } from 'node:fs';
+import { log } from '../lib/log.js';
+import { LOG_BUCKETS, formatBytes, parseDurationMs, pruneLogs } from '../lib/logs-prune.js';
+import { findRepoRoot, repoPaths } from '../lib/paths.js';
+import { resolveSettings } from '../lib/settings.js';
+
+export interface LogsPruneOptions {
+  olderThan?: string;
+  dryRun?: boolean;
+}
+
+export async function runLogsPrune(opts: LogsPruneOptions = {}): Promise<number> {
+  const root = findRepoRoot();
+  const paths = repoPaths(root);
+
+  if (!existsSync(paths.installedVersionFile)) {
+    log.error(
+      'ai-knowledge-base is not initialized in this repo. Run `ai-knowledge-base init --assistants claude`.',
+    );
+    return 1;
+  }
+
+  const { settings, warnings } = resolveSettings({ projectFile: paths.projectConfigFile });
+  for (const w of warnings) log.warn(w);
+
+  // Default to settings.logsRetentionDays when --older-than is not given.
+  const olderThan = opts.olderThan ?? `${settings.logsRetentionDays}d`;
+  let durationMs: number;
+  try {
+    durationMs = parseDurationMs(olderThan);
+  } catch (err) {
+    log.error((err as Error).message);
+    return 1;
+  }
+
+  const now = Date.now();
+  const cutoffMs = now - durationMs;
+
+  const result = pruneLogs({
+    logsDir: paths.logsDir,
+    cutoffMs,
+    ...(opts.dryRun ? { dryRun: true } : {}),
+  });
+
+  const action = result.dryRun ? 'Would delete' : 'Deleted';
+  log.info(
+    `${action} ${result.totalFilesDeleted} log file(s) older than ${olderThan} (${result.cutoffIso}).`,
+  );
+  for (const bucket of result.buckets) {
+    log.plain(
+      `  • ${bucket.bucket}: ${bucket.filesDeleted}/${bucket.filesScanned} eligible — ${formatBytes(
+        bucket.bytesFreed,
+      )}`,
+    );
+  }
+  log.plain('');
+  log.success(
+    `${result.dryRun ? 'Dry-run: ' : ''}freed ${formatBytes(result.totalBytesFreed)} across ${
+      LOG_BUCKETS.length
+    } bucket(s).`,
+  );
+  return 0;
+}

--- a/src/hooks/kb-session-start.ts
+++ b/src/hooks/kb-session-start.ts
@@ -14,6 +14,7 @@ import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { buildSessionStartContext } from '../lib/session-start.js';
 import { findRepoRoot, repoPaths } from '../lib/paths.js';
+import { resolveSettings } from '../lib/settings.js';
 
 const PACKAGE_TAG = '[ai-knowledge-base]';
 const HARD_DEADLINE_MS = 1000;
@@ -45,11 +46,13 @@ async function main(): Promise<void> {
   if (!existsSync(paths.installedVersionFile)) return;
 
   try {
+    const { settings } = resolveSettings({ projectFile: paths.projectConfigFile });
     const result = buildSessionStartContext({
       kbDir: paths.kbDir,
       nodesDir: paths.nodesDir,
       sessionsDir: paths.sessionsDir,
       stateFile: join(paths.builderDir, 'state.json'),
+      threshold: settings.curationThreshold,
     });
     process.stdout.write(
       `${JSON.stringify({

--- a/src/hooks/kb-stage2-drain.ts
+++ b/src/hooks/kb-stage2-drain.ts
@@ -13,6 +13,7 @@ import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { runHeadlessClaude } from '../lib/headless.js';
 import { findRepoRoot, packageTemplatesDir, repoPaths } from '../lib/paths.js';
+import { resolveSettings } from '../lib/settings.js';
 import { drainStage2Queue, type Stage2Runner } from '../lib/stage2-drain.js';
 
 const PACKAGE_TAG = '[ai-knowledge-base]';
@@ -48,12 +49,17 @@ async function main(): Promise<void> {
     runHeadlessClaude(prompt, stdin, schema, opts);
 
   try {
+    const { settings } = resolveSettings({ projectFile: paths.projectConfigFile });
     const summary = await drainStage2Queue({
       sessionsDir: paths.sessionsDir,
       logsDir: paths.logsDir,
       stateFile: join(paths.builderDir, 'state.json'),
       promptTemplate,
       runner,
+      maxEntries: settings.drainBound,
+      maxAttempts: settings.maxAttempts,
+      timeoutMs: settings.stage2Timeout,
+      lockTtlMs: settings.lockTtlMs,
     });
     if (summary.status === 'locked') {
       // Another drain is in flight; nothing to do.

--- a/src/lib/bootstrap.ts
+++ b/src/lib/bootstrap.ts
@@ -58,6 +58,7 @@ export interface BootstrapContext {
   dryRun?: boolean;
   tokenBudget?: number;
   timeoutMs?: number;
+  lockTtlMs?: number;
   now?: () => Date;
   pid?: number;
   /** Test seam: override the run id. */
@@ -424,6 +425,7 @@ export async function runBootstrapIncremental(ctx: BootstrapContext): Promise<Bo
     name: BOOTSTRAP_LOCK_NAME,
     pid,
     now: now(),
+    ...(ctx.lockTtlMs !== undefined ? { ttlMs: ctx.lockTtlMs } : {}),
   });
   if (!acquired) {
     return {

--- a/src/lib/curate.ts
+++ b/src/lib/curate.ts
@@ -48,6 +48,8 @@ export interface CurateContext {
   batchSize?: number;
   tokenBudget?: number;
   timeoutMs?: number;
+  lockTtlMs?: number;
+  indexBudgetTokens?: number;
   now?: () => Date;
   pid?: number;
   /** Test seam: override ULID. */
@@ -267,6 +269,7 @@ export async function runCurate(ctx: CurateContext): Promise<CurateResult> {
     name: CURATOR_LOCK_NAME,
     pid,
     now: now(),
+    ...(ctx.lockTtlMs !== undefined ? { ttlMs: ctx.lockTtlMs } : {}),
   });
   if (!acquired) {
     return {
@@ -461,7 +464,9 @@ function markSessionsProcessed(sessions: PendingSession[], runId: string, now: D
 
 function regenerateIndexAndGraph(ctx: CurateContext, now: Date): void {
   mkdirSync(ctx.kbDir, { recursive: true });
-  const index = generateIndex(ctx.nodesDir, { now });
+  const indexOpts: { now: Date; budgetTokens?: number } = { now };
+  if (ctx.indexBudgetTokens !== undefined) indexOpts.budgetTokens = ctx.indexBudgetTokens;
+  const index = generateIndex(ctx.nodesDir, indexOpts);
   writeIndex(join(ctx.kbDir, 'INDEX.md'), index);
   const graph = generateGraph(ctx.nodesDir, { now });
   writeGraph(join(ctx.kbDir, 'GRAPH.md'), graph);

--- a/src/lib/logs-prune.ts
+++ b/src/lib/logs-prune.ts
@@ -1,0 +1,135 @@
+import { existsSync, readdirSync, statSync, unlinkSync } from 'node:fs';
+import { join } from 'node:path';
+
+export const LOG_BUCKETS = ['stage-2', 'curator', 'bootstrap-incremental'] as const;
+export type LogBucket = (typeof LOG_BUCKETS)[number];
+
+export interface BucketReport {
+  bucket: LogBucket;
+  filesDeleted: number;
+  bytesFreed: number;
+  filesScanned: number;
+}
+
+export interface PruneResult {
+  cutoffMs: number;
+  cutoffIso: string;
+  totalFilesDeleted: number;
+  totalBytesFreed: number;
+  buckets: BucketReport[];
+  dryRun: boolean;
+}
+
+export interface PruneOptions {
+  logsDir: string;
+  /** Cutoff in ms-since-epoch; files with mtime < cutoff are eligible. */
+  cutoffMs: number;
+  dryRun?: boolean;
+  now?: () => Date;
+}
+
+/**
+ * Walks each of `LOG_BUCKETS` under `logsDir` and deletes JSONL files whose
+ * mtime predates `cutoffMs`. Reports per-bucket counts and freed bytes.
+ * `dryRun: true` short-circuits the unlinks — counts and bytes are still
+ * accumulated from `statSync`.
+ */
+export function pruneLogs(opts: PruneOptions): PruneResult {
+  const buckets: BucketReport[] = [];
+  let totalFiles = 0;
+  let totalBytes = 0;
+  for (const bucket of LOG_BUCKETS) {
+    const dir = join(opts.logsDir, bucket);
+    const report: BucketReport = {
+      bucket,
+      filesDeleted: 0,
+      bytesFreed: 0,
+      filesScanned: 0,
+    };
+    if (existsSync(dir)) {
+      for (const name of readdirSync(dir)) {
+        if (!name.endsWith('.jsonl')) continue;
+        const full = join(dir, name);
+        let info;
+        try {
+          info = statSync(full);
+        } catch {
+          continue;
+        }
+        if (!info.isFile()) continue;
+        report.filesScanned += 1;
+        if (info.mtimeMs < opts.cutoffMs) {
+          if (!opts.dryRun) {
+            try {
+              unlinkSync(full);
+            } catch {
+              continue;
+            }
+          }
+          report.filesDeleted += 1;
+          report.bytesFreed += info.size;
+        }
+      }
+    }
+    buckets.push(report);
+    totalFiles += report.filesDeleted;
+    totalBytes += report.bytesFreed;
+  }
+  return {
+    cutoffMs: opts.cutoffMs,
+    cutoffIso: new Date(opts.cutoffMs).toISOString(),
+    totalFilesDeleted: totalFiles,
+    totalBytesFreed: totalBytes,
+    buckets,
+    dryRun: opts.dryRun === true,
+  };
+}
+
+const DURATION_UNITS: Record<string, number> = {
+  ms: 1,
+  s: 1000,
+  m: 60 * 1000,
+  h: 60 * 60 * 1000,
+  d: 24 * 60 * 60 * 1000,
+  w: 7 * 24 * 60 * 60 * 1000,
+  y: 365 * 24 * 60 * 60 * 1000,
+};
+
+/**
+ * Parses `ms`-package-style duration strings: `30d`, `2w`, `12h`, `45m`,
+ * `90s`, `500ms`, `1y`. Returns the duration in milliseconds. Throws on
+ * unrecognized or non-positive input.
+ */
+export function parseDurationMs(input: string): number {
+  const trimmed = input.trim().toLowerCase();
+  // Tail unit first (allow multi-char "ms"). RegExp is anchored.
+  const match = trimmed.match(/^(\d+(?:\.\d+)?)\s*(ms|[smhdwy])$/);
+  if (!match) {
+    throw new Error(
+      `unrecognized duration: ${JSON.stringify(input)}. Expected formats like 30d, 2w, 12h, 45m.`,
+    );
+  }
+  const value = Number(match[1]);
+  const unit = match[2]!;
+  const factor = DURATION_UNITS[unit];
+  if (factor === undefined || !Number.isFinite(value) || value <= 0) {
+    throw new Error(`invalid duration: ${JSON.stringify(input)}`);
+  }
+  return Math.round(value * factor);
+}
+
+/**
+ * Formats a byte count as a short string (1.2 MB, 999 B). Used for the CLI
+ * "freed N bytes" summary; mostly cosmetic.
+ */
+export function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  const units = ['KB', 'MB', 'GB', 'TB'];
+  let n = bytes / 1024;
+  let i = 0;
+  while (n >= 1024 && i < units.length - 1) {
+    n /= 1024;
+    i += 1;
+  }
+  return `${n.toFixed(1)} ${units[i]}`;
+}

--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -41,6 +41,7 @@ export interface RepoPaths {
   kbDir: string;
   builderDir: string;
   installedVersionFile: string;
+  projectConfigFile: string;
   sessionsDir: string;
   proposedDir: string;
   logsDir: string;
@@ -64,6 +65,7 @@ export function repoPaths(root: string): RepoPaths {
     kbDir,
     builderDir,
     installedVersionFile: join(builderDir, 'installed-version'),
+    projectConfigFile: join(kbDir, '.config.json'),
     sessionsDir: join(kbDir, '_sessions'),
     proposedDir: join(kbDir, '_proposed'),
     logsDir: join(kbDir, '_logs'),

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -223,6 +223,30 @@ export const BootstrapDocEntrySchema = z.object({
 });
 export type BootstrapDocEntry = z.infer<typeof BootstrapDocEntrySchema>;
 
+/**
+ * Settings shipped in `.ai/knowledge-base/.config.json` (project-level, committed)
+ * and `~/.config/@e0ipso/ai-knowledge-base/config.json` (user-level overrides).
+ *
+ * Every field is optional in the on-disk file; `resolveSettings()` layers the
+ * documented defaults under user-level overrides under project-level overrides.
+ * The `schema_version` field is the only required key when a file is present.
+ */
+export const SettingsSchema = z
+  .object({
+    schema_version: z.literal(1),
+    drainBound: z.number().int().positive().optional(),
+    maxAttempts: z.number().int().positive().optional(),
+    stage2Timeout: z.number().int().positive().optional(),
+    lockTtlMs: z.number().int().positive().optional(),
+    indexBudgetTokens: z.number().int().positive().optional(),
+    curationThreshold: z.number().int().positive().optional(),
+    bootstrapTokenBudget: z.number().int().positive().optional(),
+    gitleaksRulesPath: z.string().nullable().optional(),
+    logsRetentionDays: z.number().int().positive().optional(),
+  })
+  .strict();
+export type SettingsFile = z.infer<typeof SettingsSchema>;
+
 export const BootstrapStateSchema = z.object({
   schema_version: z.literal(1),
   last_full_bootstrap_at: z.string().nullable().optional(),

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -1,0 +1,139 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { SettingsSchema, type SettingsFile } from './schemas.js';
+
+/**
+ * Documented defaults. These mirror the constants previously hard-coded into
+ * `stage2-drain.ts`, `curate.ts`, `bootstrap.ts`, `index-gen.ts`, and
+ * `session-start.ts`. Changing a default here changes the value used when no
+ * `.config.json` overrides it.
+ */
+export const SETTINGS_DEFAULTS = {
+  drainBound: 5,
+  maxAttempts: 3,
+  stage2Timeout: 60_000,
+  lockTtlMs: 30 * 60 * 1000,
+  indexBudgetTokens: 2000,
+  curationThreshold: 5,
+  bootstrapTokenBudget: 10_000,
+  gitleaksRulesPath: null as string | null,
+  logsRetentionDays: 30,
+} as const;
+
+export type EffectiveSettings = {
+  -readonly [K in keyof typeof SETTINGS_DEFAULTS]: (typeof SETTINGS_DEFAULTS)[K];
+};
+
+export type ResolveSettingsResult = {
+  settings: EffectiveSettings;
+  projectFile: string | null;
+  userFile: string | null;
+  warnings: string[];
+};
+
+export interface ResolveOptions {
+  projectFile?: string;
+  userFile?: string;
+}
+
+/**
+ * Resolves the effective settings: defaults ← user overrides ← project overrides.
+ *
+ * Either file may be missing; missing files are silently ignored. A file
+ * present but unparseable (invalid JSON / fails Zod) produces a warning and
+ * is treated as absent, so a corrupted user file cannot brick the CLI.
+ */
+export function resolveSettings(opts: ResolveOptions = {}): ResolveSettingsResult {
+  const projectFile = opts.projectFile ?? null;
+  const userFile = opts.userFile ?? defaultUserConfigPath();
+  const warnings: string[] = [];
+
+  const user = loadFile(userFile, warnings);
+  const project = projectFile ? loadFile(projectFile, warnings) : null;
+
+  const effective: EffectiveSettings = { ...SETTINGS_DEFAULTS };
+  applyOverrides(effective, user);
+  applyOverrides(effective, project);
+
+  return {
+    settings: effective,
+    projectFile: projectFile ?? null,
+    userFile: existsSync(userFile) ? userFile : null,
+    warnings,
+  };
+}
+
+function applyOverrides(target: EffectiveSettings, src: SettingsFile | null): void {
+  if (!src) return;
+  for (const key of Object.keys(SETTINGS_DEFAULTS) as Array<keyof typeof SETTINGS_DEFAULTS>) {
+    const value = src[key];
+    if (value !== undefined) {
+      // `as never` is required because TypeScript cannot prove the per-key
+      // value types align across the union; the Zod schema does.
+      (target as Record<string, unknown>)[key] = value as never;
+    }
+  }
+}
+
+function loadFile(file: string, warnings: string[]): SettingsFile | null {
+  if (!existsSync(file)) return null;
+  let raw: string;
+  try {
+    raw = readFileSync(file, 'utf8');
+  } catch (err) {
+    warnings.push(`settings file unreadable (${file}): ${(err as Error).message}`);
+    return null;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    warnings.push(`settings file is not valid JSON (${file}): ${(err as Error).message}`);
+    return null;
+  }
+  const result = SettingsSchema.safeParse(parsed);
+  if (!result.success) {
+    warnings.push(`settings file failed schema validation (${file}): ${result.error.message}`);
+    return null;
+  }
+  return result.data;
+}
+
+/**
+ * The user-level override path. Honors `XDG_CONFIG_HOME` if set; otherwise
+ * falls back to `~/.config/`.
+ */
+export function defaultUserConfigPath(env: NodeJS.ProcessEnv = process.env): string {
+  const xdg = env['XDG_CONFIG_HOME'];
+  const base = xdg && xdg.length > 0 ? xdg : join(homedir(), '.config');
+  return join(base, '@e0ipso', 'ai-knowledge-base', 'config.json');
+}
+
+/**
+ * The committed project-level path inside a consuming repo.
+ */
+export function projectConfigPath(kbDir: string): string {
+  return join(kbDir, '.config.json');
+}
+
+/**
+ * The default committed `.config.json` body. Written by `init` and
+ * `init --upgrade` when the file does not exist. Includes every supported key
+ * with its documented default so users have something to discover and edit.
+ */
+export function defaultProjectConfigBody(): string {
+  const body: SettingsFile = {
+    schema_version: 1,
+    drainBound: SETTINGS_DEFAULTS.drainBound,
+    maxAttempts: SETTINGS_DEFAULTS.maxAttempts,
+    stage2Timeout: SETTINGS_DEFAULTS.stage2Timeout,
+    lockTtlMs: SETTINGS_DEFAULTS.lockTtlMs,
+    indexBudgetTokens: SETTINGS_DEFAULTS.indexBudgetTokens,
+    curationThreshold: SETTINGS_DEFAULTS.curationThreshold,
+    bootstrapTokenBudget: SETTINGS_DEFAULTS.bootstrapTokenBudget,
+    gitleaksRulesPath: SETTINGS_DEFAULTS.gitleaksRulesPath,
+    logsRetentionDays: SETTINGS_DEFAULTS.logsRetentionDays,
+  };
+  return `${JSON.stringify(body, null, 2)}\n`;
+}

--- a/src/lib/stage2-drain.ts
+++ b/src/lib/stage2-drain.ts
@@ -28,6 +28,7 @@ export interface DrainContext {
   maxEntries?: number;
   maxAttempts?: number;
   timeoutMs?: number;
+  lockTtlMs?: number;
   pid?: number;
 }
 
@@ -68,6 +69,7 @@ export async function drainStage2Queue(ctx: DrainContext): Promise<DrainSummary>
     name: STAGE2_LOCK_NAME,
     pid,
     now: now(),
+    ...(ctx.lockTtlMs !== undefined ? { ttlMs: ctx.lockTtlMs } : {}),
   });
   if (!lockHeld) {
     return { status: 'locked', processed: [], remaining: readQueue(queueFile).entries.length };

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -1,4 +1,6 @@
 import { execFile } from 'node:child_process';
+import { writeFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { promisify } from 'node:util';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { cleanSandbox, makeSandbox, runCli } from './helpers.js';
@@ -30,6 +32,19 @@ describe('doctor', () => {
     expect(combined).toContain('installed-version');
     expect(combined).toContain('pre-commit config installed');
     expect(combined).toContain('.gitignore lists ai-knowledge-base paths');
+    expect(combined).toContain('settings file is valid');
+  });
+
+  it('flags an invalid .config.json as an error', async () => {
+    await runCli(sandbox, ['init', '--assistants', 'claude']);
+    writeFileSync(
+      join(sandbox, '.ai/knowledge-base/.config.json'),
+      JSON.stringify({ schema_version: 1, drainBound: -1 }),
+    );
+    const result = await runCli(sandbox, ['doctor']);
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout + result.stderr).toContain('settings file is valid');
+    expect(result.stdout + result.stderr).toContain('schema validation failed');
   });
 });
 

--- a/tests/e2e/full-cycle.test.ts
+++ b/tests/e2e/full-cycle.test.ts
@@ -1,0 +1,224 @@
+import { execFile } from 'node:child_process';
+import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+import matter from 'gray-matter';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { ClaudeAdapter } from '../../src/adapters/claude.js';
+import { runCurate, type CuratorRunner } from '../../src/lib/curate.js';
+import { drainStage2Queue, type Stage2Runner } from '../../src/lib/stage2-drain.js';
+import { type ReviewAction, runProposalsReview } from '../../src/commands/proposals-review.js';
+import { cleanSandbox, makeSandbox, runCli } from '../helpers.js';
+
+const exec = promisify(execFile);
+const here = dirname(fileURLToPath(import.meta.url));
+const fixtureTranscriptPath = resolve(here, '../fixtures/transcripts/bravo-insider/transcript.md');
+
+const ENABLED = process.env['KB_RUN_REAL_CLAUDE'] === '1';
+const FIVE_MINUTES_MS = 5 * 60 * 1000;
+
+// Use a project-unique substring that should appear in any reasonable
+// extraction or curation of the fixture transcript.
+const UNIQUE_TERM = 'Bravo Insider';
+
+describe.skipIf(!ENABLED)('e2e: full capture → drain → curate → review cycle', () => {
+  let sandbox: string;
+  let origCwd: string;
+
+  beforeEach(async () => {
+    origCwd = process.cwd();
+    sandbox = makeSandbox('ai-kb-e2e-');
+    await exec('git', ['init', '-q'], { cwd: sandbox });
+    const init = await runCli(sandbox, ['init', '--assistants', 'claude']);
+    expect(init.exitCode).toBe(0);
+  });
+
+  afterEach(() => {
+    try {
+      process.chdir(origCwd);
+    } catch {
+      // ignore
+    }
+    cleanSandbox(sandbox);
+  });
+
+  it(
+    'produces a populated node and INDEX.md referencing the fixture term',
+    async () => {
+      const kbDir = join(sandbox, '.ai/knowledge-base');
+      const sessionsDir = join(kbDir, '_sessions');
+      const logsDir = join(kbDir, '_logs');
+      const proposedDir = join(kbDir, '_proposed');
+      const nodesDir = join(kbDir, 'nodes');
+      const stateFile = join(sandbox, '.ai/.kb-builder/state.json');
+
+      // 1. Plant a session log + queue entry pointing at the bravo-insider fixture.
+      const transcript = readFileSync(fixtureTranscriptPath, 'utf8');
+      const sessionId = '2026-05-11-1200-bravo-insider';
+      const sessionLogFile = `${sessionId}.md`;
+      const sessionLogPath = join(sessionsDir, sessionLogFile);
+      mkdirSync(sessionsDir, { recursive: true });
+
+      const sessionFrontmatter = {
+        schema_version: 1,
+        session_id: sessionId,
+        captured_by: 'manual',
+        captured_at: new Date().toISOString(),
+        transcript_hash: 'sha256:e2e-fixture',
+        stage_2_status: 'pending',
+        stage_2_completed_at: null,
+        stage_2_error: null,
+        stage_2_log: null,
+        gitleaks_status: 'clean',
+        topics: [] as string[],
+        proposals: { practice: [] as unknown[], map: [] as unknown[] },
+      };
+      const sessionBody = [
+        '## Stage 1: redacted transcript slice',
+        '',
+        transcript.trim(),
+        '',
+        '## Stage 2: structured summary',
+        '',
+        '(populated by stage-2 worker)',
+        '',
+      ].join('\n');
+      writeFileSync(sessionLogPath, matter.stringify(sessionBody, sessionFrontmatter));
+
+      writeFileSync(
+        join(sessionsDir, '.queue.json'),
+        JSON.stringify(
+          {
+            schema_version: 1,
+            entries: [
+              {
+                session_id: sessionId,
+                session_log: sessionLogFile,
+                captured_by: 'manual',
+                captured_at: sessionFrontmatter.captured_at,
+                attempts: 0,
+              },
+            ],
+          },
+          null,
+          2,
+        ) + '\n',
+      );
+
+      // 2. Drain stage-2 with the real Claude adapter.
+      const adapter = new ClaudeAdapter();
+      const stage2Runner: Stage2Runner = (prompt, stdin, schema, opts) =>
+        adapter.runHeadless(prompt, stdin, schema, opts);
+
+      const stage2Prompt = readFileSync(
+        join(sandbox, '.ai/.kb-builder/prompts/stage-2-extract.md'),
+        'utf8',
+      );
+
+      const drainSummary = await drainStage2Queue({
+        sessionsDir,
+        logsDir,
+        stateFile,
+        promptTemplate: stage2Prompt,
+        runner: stage2Runner,
+        timeoutMs: FIVE_MINUTES_MS,
+      });
+
+      expect(drainSummary.status).toBe('completed');
+      expect(drainSummary.processed.length).toBeGreaterThan(0);
+      const drainEntry = drainSummary.processed[0]!;
+      expect(drainEntry.status).toBe('done');
+
+      const sessionAfter = matter(readFileSync(sessionLogPath, 'utf8'));
+      expect((sessionAfter.data as { stage_2_status?: string }).stage_2_status).toBe('done');
+
+      // 3. Run curate with the real Claude adapter.
+      const curatorRunner: CuratorRunner = (prompt, stdin, schema, opts) =>
+        adapter.runHeadless(prompt, stdin, schema, opts);
+      const curatorPrompt = readFileSync(
+        join(sandbox, '.ai/.kb-builder/prompts/curator.md'),
+        'utf8',
+      );
+
+      const curateResult = await runCurate({
+        kbDir,
+        sessionsDir,
+        nodesDir,
+        proposedDir,
+        logsDir,
+        stateFile,
+        promptTemplate: curatorPrompt,
+        runner: curatorRunner,
+        timeoutMs: FIVE_MINUTES_MS,
+      });
+
+      expect(curateResult.status).toBe('completed');
+      expect(curateResult.proposalsWritten).toBeGreaterThan(0);
+
+      // 4. Accept all proposals via the review TUI's accept-all path.
+      const additionsBefore = existsSync(join(proposedDir, 'additions'))
+        ? readdirSync(join(proposedDir, 'additions')).filter((f) => f.endsWith('.md'))
+        : [];
+      const modificationsBefore = existsSync(join(proposedDir, 'modifications'))
+        ? readdirSync(join(proposedDir, 'modifications')).filter((f) => f.endsWith('.md'))
+        : [];
+      const contradictionsBefore = existsSync(join(proposedDir, 'contradictions'))
+        ? readdirSync(join(proposedDir, 'contradictions')).filter((f) => f.endsWith('.md'))
+        : [];
+      const totalProposals =
+        additionsBefore.length + modificationsBefore.length + contradictionsBefore.length;
+
+      // Contradictions require a `set_resolution` action before accept; for the
+      // fixture transcript we expect no contradictions, but handle them safely.
+      const actions: ReviewAction[] = [];
+      for (let i = 0; i < additionsBefore.length + modificationsBefore.length; i += 1) {
+        actions.push({ type: 'accept' });
+      }
+      for (let i = 0; i < contradictionsBefore.length; i += 1) {
+        actions.push({ type: 'set_resolution', value: 'supersede' });
+        actions.push({ type: 'accept' });
+      }
+
+      process.chdir(sandbox);
+      const reviewCode = await runProposalsReview({ actions });
+      expect(reviewCode).toBe(0);
+
+      // 5. Assert: at least one node was written, and INDEX.md mentions the
+      // fixture term. INDEX is not regenerated by the review command (that's
+      // the curate / index-rebuild step) — but the curate run we already
+      // performed wrote one fresh. Run index rebuild to be deterministic.
+      const rebuildResult = await runCli(sandbox, ['index', 'rebuild']);
+      expect(rebuildResult.exitCode).toBe(0);
+
+      const allNodeFiles = collectNodes(nodesDir);
+      expect(allNodeFiles.length).toBeGreaterThan(0);
+
+      const indexFile = join(kbDir, 'INDEX.md');
+      expect(existsSync(indexFile)).toBe(true);
+      const indexBody = readFileSync(indexFile, 'utf8');
+
+      // The unique-term assertion must match against the combined node bodies
+      // OR the INDEX itself — different models may put it in different places.
+      const haystacks = [indexBody, ...allNodeFiles.map((f) => readFileSync(f, 'utf8'))];
+      const found = haystacks.some((h) => h.toLowerCase().includes(UNIQUE_TERM.toLowerCase()));
+      expect(
+        found,
+        `expected at least one node or INDEX.md to mention '${UNIQUE_TERM}'. Got ${totalProposals} proposal(s), ${allNodeFiles.length} node(s).`,
+      ).toBe(true);
+    },
+    FIVE_MINUTES_MS * 3 + 60_000,
+  );
+});
+
+function collectNodes(nodesDir: string): string[] {
+  const out: string[] = [];
+  for (const kind of ['practice', 'map']) {
+    const dir = join(nodesDir, kind);
+    if (!existsSync(dir)) continue;
+    for (const name of readdirSync(dir)) {
+      if (name.endsWith('.md')) out.push(join(dir, name));
+    }
+  }
+  return out;
+}

--- a/tests/init.test.ts
+++ b/tests/init.test.ts
@@ -44,6 +44,7 @@ describe('init', () => {
       '.ai/.kb-builder/prompts/stage-2-extract.md',
       '.ai/.kb-builder/prompts/curator.md',
       '.ai/.kb-builder/prompts/bootstrap-incremental.md',
+      '.ai/knowledge-base/.config.json',
       '.pre-commit-config.yaml',
       '.gitignore',
     ];
@@ -146,6 +147,33 @@ describe('init', () => {
         }),
       ]),
     );
+  });
+
+  it('writes a default .config.json populated with defaults', async () => {
+    await runCli(sandbox, ['init', '--assistants', 'claude']);
+    const body = JSON.parse(
+      readFileSync(join(sandbox, '.ai/knowledge-base/.config.json'), 'utf8'),
+    ) as Record<string, unknown>;
+    expect(body['schema_version']).toBe(1);
+    expect(body['drainBound']).toBe(5);
+    expect(body['maxAttempts']).toBe(3);
+    expect(body['stage2Timeout']).toBe(60000);
+    expect(body['indexBudgetTokens']).toBe(2000);
+    expect(body['curationThreshold']).toBe(5);
+    expect(body['bootstrapTokenBudget']).toBe(10000);
+    expect(body['logsRetentionDays']).toBe(30);
+  });
+
+  it('does not overwrite an existing .config.json even with --force', async () => {
+    await runCli(sandbox, ['init', '--assistants', 'claude']);
+    const configFile = join(sandbox, '.ai/knowledge-base/.config.json');
+    const customized = JSON.stringify({ schema_version: 1, drainBound: 99 }, null, 2) + '\n';
+    writeFileSync(configFile, customized);
+
+    const result = await runCli(sandbox, ['init', '--assistants', 'claude', '--force']);
+    expect(result.exitCode).toBe(0);
+    expect(readFileSync(configFile, 'utf8')).toBe(customized);
+    expect(result.stdout + result.stderr).toContain('.config.json already exists');
   });
 
   it('ships the rename — no references to the old `kb-builder` binary in copied prompts', async () => {

--- a/tests/lib/logs-prune.test.ts
+++ b/tests/lib/logs-prune.test.ts
@@ -1,0 +1,133 @@
+import { existsSync, mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { formatBytes, parseDurationMs, pruneLogs } from '../../src/lib/logs-prune.js';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+describe('parseDurationMs', () => {
+  it('parses days', () => {
+    expect(parseDurationMs('30d')).toBe(30 * DAY_MS);
+  });
+  it('parses weeks', () => {
+    expect(parseDurationMs('2w')).toBe(14 * DAY_MS);
+  });
+  it('parses hours', () => {
+    expect(parseDurationMs('12h')).toBe(12 * 60 * 60 * 1000);
+  });
+  it('parses minutes', () => {
+    expect(parseDurationMs('5m')).toBe(5 * 60 * 1000);
+  });
+  it('parses seconds', () => {
+    expect(parseDurationMs('30s')).toBe(30 * 1000);
+  });
+  it('parses ms', () => {
+    expect(parseDurationMs('500ms')).toBe(500);
+  });
+  it('parses years', () => {
+    expect(parseDurationMs('1y')).toBe(365 * DAY_MS);
+  });
+  it('throws on bad input', () => {
+    expect(() => parseDurationMs('30')).toThrow();
+    expect(() => parseDurationMs('abc')).toThrow();
+    expect(() => parseDurationMs('0d')).toThrow();
+    expect(() => parseDurationMs('-1d')).toThrow();
+    expect(() => parseDurationMs('30x')).toThrow();
+  });
+  it('is case-insensitive and whitespace-tolerant', () => {
+    expect(parseDurationMs(' 30D ')).toBe(30 * DAY_MS);
+  });
+});
+
+describe('formatBytes', () => {
+  it('uses bytes below 1024', () => {
+    expect(formatBytes(0)).toBe('0 B');
+    expect(formatBytes(1023)).toBe('1023 B');
+  });
+  it('scales through KB/MB/GB', () => {
+    expect(formatBytes(1024)).toBe('1.0 KB');
+    expect(formatBytes(1024 * 1024)).toBe('1.0 MB');
+    expect(formatBytes(1024 * 1024 * 1024)).toBe('1.0 GB');
+  });
+});
+
+describe('pruneLogs', () => {
+  let sandbox: string;
+  beforeEach(() => {
+    sandbox = mkdtempSync(join(tmpdir(), 'kb-prune-'));
+  });
+  afterEach(() => rmSync(sandbox, { recursive: true, force: true }));
+
+  function makeLog(bucket: string, name: string, ageMs: number, body = 'x'): string {
+    const dir = join(sandbox, bucket);
+    mkdirSync(dir, { recursive: true });
+    const full = join(dir, name);
+    writeFileSync(full, body);
+    const past = new Date(Date.now() - ageMs);
+    utimesSync(full, past, past);
+    return full;
+  }
+
+  it('deletes files older than the cutoff in each bucket', () => {
+    const old1 = makeLog('stage-2', 'old.jsonl', 40 * DAY_MS);
+    const fresh1 = makeLog('stage-2', 'fresh.jsonl', 1 * DAY_MS);
+    const old2 = makeLog('curator', 'old.jsonl', 90 * DAY_MS);
+    const old3 = makeLog('bootstrap-incremental', 'old.jsonl', 50 * DAY_MS);
+
+    const result = pruneLogs({
+      logsDir: sandbox,
+      cutoffMs: Date.now() - 30 * DAY_MS,
+    });
+
+    expect(result.totalFilesDeleted).toBe(3);
+    expect(existsSync(old1)).toBe(false);
+    expect(existsSync(fresh1)).toBe(true);
+    expect(existsSync(old2)).toBe(false);
+    expect(existsSync(old3)).toBe(false);
+
+    const stage2 = result.buckets.find((b) => b.bucket === 'stage-2');
+    expect(stage2?.filesDeleted).toBe(1);
+    expect(stage2?.filesScanned).toBe(2);
+  });
+
+  it('respects --dry-run: deletes nothing but reports counts', () => {
+    const old1 = makeLog('stage-2', 'old.jsonl', 40 * DAY_MS, 'aaaa');
+
+    const result = pruneLogs({
+      logsDir: sandbox,
+      cutoffMs: Date.now() - 30 * DAY_MS,
+      dryRun: true,
+    });
+
+    expect(existsSync(old1)).toBe(true);
+    expect(result.totalFilesDeleted).toBe(1);
+    expect(result.totalBytesFreed).toBe(4);
+    expect(result.dryRun).toBe(true);
+  });
+
+  it('skips non-.jsonl files', () => {
+    const other = join(sandbox, 'stage-2', 'README.md');
+    mkdirSync(join(sandbox, 'stage-2'), { recursive: true });
+    writeFileSync(other, 'x');
+    const past = new Date(Date.now() - 90 * DAY_MS);
+    utimesSync(other, past, past);
+
+    const result = pruneLogs({
+      logsDir: sandbox,
+      cutoffMs: Date.now() - 30 * DAY_MS,
+    });
+
+    expect(result.totalFilesDeleted).toBe(0);
+    expect(existsSync(other)).toBe(true);
+  });
+
+  it('handles missing bucket directories without error', () => {
+    const result = pruneLogs({
+      logsDir: join(sandbox, 'does-not-exist'),
+      cutoffMs: Date.now() - 30 * DAY_MS,
+    });
+    expect(result.totalFilesDeleted).toBe(0);
+    expect(result.buckets).toHaveLength(3);
+  });
+});

--- a/tests/lib/settings.test.ts
+++ b/tests/lib/settings.test.ts
@@ -1,0 +1,116 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  SETTINGS_DEFAULTS,
+  defaultProjectConfigBody,
+  defaultUserConfigPath,
+  projectConfigPath,
+  resolveSettings,
+} from '../../src/lib/settings.js';
+
+describe('settings', () => {
+  let sandbox: string;
+  beforeEach(() => {
+    sandbox = mkdtempSync(join(tmpdir(), 'kb-settings-'));
+  });
+  afterEach(() => rmSync(sandbox, { recursive: true, force: true }));
+
+  it('falls back to documented defaults when no files exist', () => {
+    const result = resolveSettings({
+      projectFile: join(sandbox, 'missing-project.json'),
+      userFile: join(sandbox, 'missing-user.json'),
+    });
+    expect(result.settings).toEqual(SETTINGS_DEFAULTS);
+    expect(result.warnings).toEqual([]);
+    expect(result.userFile).toBeNull();
+  });
+
+  it('layers user overrides on top of defaults', () => {
+    const userFile = join(sandbox, 'user.json');
+    writeFileSync(
+      userFile,
+      JSON.stringify({ schema_version: 1, drainBound: 99, indexBudgetTokens: 4096 }),
+    );
+    const result = resolveSettings({
+      projectFile: join(sandbox, 'missing.json'),
+      userFile,
+    });
+    expect(result.settings.drainBound).toBe(99);
+    expect(result.settings.indexBudgetTokens).toBe(4096);
+    expect(result.settings.maxAttempts).toBe(SETTINGS_DEFAULTS.maxAttempts);
+  });
+
+  it('layers project overrides on top of user overrides', () => {
+    const userFile = join(sandbox, 'user.json');
+    const projectFile = join(sandbox, 'project.json');
+    writeFileSync(userFile, JSON.stringify({ schema_version: 1, drainBound: 10 }));
+    writeFileSync(projectFile, JSON.stringify({ schema_version: 1, drainBound: 3 }));
+    const result = resolveSettings({ projectFile, userFile });
+    expect(result.settings.drainBound).toBe(3);
+  });
+
+  it('emits a warning and treats invalid JSON as absent', () => {
+    const projectFile = join(sandbox, 'project.json');
+    writeFileSync(projectFile, '{ not json');
+    const result = resolveSettings({
+      projectFile,
+      userFile: join(sandbox, 'missing.json'),
+    });
+    expect(result.warnings.length).toBeGreaterThan(0);
+    expect(result.warnings[0]).toContain('not valid JSON');
+    expect(result.settings).toEqual(SETTINGS_DEFAULTS);
+  });
+
+  it('emits a warning and treats schema mismatch as absent', () => {
+    const projectFile = join(sandbox, 'project.json');
+    writeFileSync(projectFile, JSON.stringify({ schema_version: 1, drainBound: -5 }));
+    const result = resolveSettings({
+      projectFile,
+      userFile: join(sandbox, 'missing.json'),
+    });
+    expect(result.warnings.length).toBeGreaterThan(0);
+    expect(result.warnings[0]).toContain('schema validation');
+    expect(result.settings).toEqual(SETTINGS_DEFAULTS);
+  });
+
+  it('rejects unknown keys (strict schema)', () => {
+    const projectFile = join(sandbox, 'project.json');
+    writeFileSync(projectFile, JSON.stringify({ schema_version: 1, mystery: 1 }));
+    const result = resolveSettings({
+      projectFile,
+      userFile: join(sandbox, 'missing.json'),
+    });
+    expect(result.warnings.length).toBeGreaterThan(0);
+  });
+
+  it('defaultProjectConfigBody round-trips through resolveSettings', () => {
+    const projectFile = join(sandbox, 'project.json');
+    writeFileSync(projectFile, defaultProjectConfigBody());
+    const result = resolveSettings({
+      projectFile,
+      userFile: join(sandbox, 'missing.json'),
+    });
+    expect(result.warnings).toEqual([]);
+    expect(result.settings).toEqual(SETTINGS_DEFAULTS);
+  });
+
+  it('defaultUserConfigPath honors XDG_CONFIG_HOME', () => {
+    const xdg = join(sandbox, 'xdg');
+    mkdirSync(xdg, { recursive: true });
+    const path = defaultUserConfigPath({ XDG_CONFIG_HOME: xdg } as NodeJS.ProcessEnv);
+    expect(path).toBe(join(xdg, '@e0ipso', 'ai-knowledge-base', 'config.json'));
+  });
+
+  it('defaultUserConfigPath falls back to ~/.config when XDG is unset', () => {
+    const path = defaultUserConfigPath({} as NodeJS.ProcessEnv);
+    expect(dirname(path)).toMatch(/[\\/]@e0ipso[\\/]ai-knowledge-base$/);
+  });
+
+  it('projectConfigPath joins to the kb dir', () => {
+    expect(projectConfigPath('/repo/.ai/knowledge-base')).toBe(
+      '/repo/.ai/knowledge-base/.config.json',
+    );
+  });
+});

--- a/tests/logs-prune.test.ts
+++ b/tests/logs-prune.test.ts
@@ -1,0 +1,70 @@
+import { execFile } from 'node:child_process';
+import { existsSync, mkdirSync, utimesSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { cleanSandbox, makeSandbox, runCli } from './helpers.js';
+
+const exec = promisify(execFile);
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+describe('logs prune', () => {
+  let sandbox: string;
+
+  beforeEach(async () => {
+    sandbox = makeSandbox();
+    await exec('git', ['init', '-q'], { cwd: sandbox });
+    await runCli(sandbox, ['init', '--assistants', 'claude']);
+  });
+
+  afterEach(() => cleanSandbox(sandbox));
+
+  function plantLog(bucket: string, name: string, ageMs: number, body = 'x'): string {
+    const dir = join(sandbox, '.ai/knowledge-base/_logs', bucket);
+    mkdirSync(dir, { recursive: true });
+    const full = join(dir, name);
+    writeFileSync(full, body);
+    const past = new Date(Date.now() - ageMs);
+    utimesSync(full, past, past);
+    return full;
+  }
+
+  it('deletes log files older than --older-than and reports per-bucket counts', async () => {
+    const old = plantLog('stage-2', 'old.jsonl', 60 * DAY_MS);
+    const fresh = plantLog('stage-2', 'fresh.jsonl', 1 * DAY_MS);
+
+    const result = await runCli(sandbox, ['logs', 'prune', '--older-than', '30d']);
+    expect(result.exitCode).toBe(0);
+    expect(existsSync(old)).toBe(false);
+    expect(existsSync(fresh)).toBe(true);
+    expect(result.stdout).toMatch(/Deleted 1 log file/);
+    expect(result.stdout).toMatch(/stage-2: 1\/2 eligible/);
+  });
+
+  it('honors --dry-run', async () => {
+    const old = plantLog('curator', 'old.jsonl', 60 * DAY_MS, 'hello');
+
+    const result = await runCli(sandbox, ['logs', 'prune', '--older-than', '30d', '--dry-run']);
+    expect(result.exitCode).toBe(0);
+    expect(existsSync(old)).toBe(true);
+    expect(result.stdout).toMatch(/Would delete 1 log file/);
+    expect(result.stdout).toMatch(/Dry-run:/);
+  });
+
+  it('defaults to the settings logsRetentionDays when --older-than is omitted', async () => {
+    // The default-init writes logsRetentionDays = 30.
+    const old = plantLog('bootstrap-incremental', 'old.jsonl', 60 * DAY_MS);
+    const fresh = plantLog('bootstrap-incremental', 'fresh.jsonl', 5 * DAY_MS);
+
+    const result = await runCli(sandbox, ['logs', 'prune']);
+    expect(result.exitCode).toBe(0);
+    expect(existsSync(old)).toBe(false);
+    expect(existsSync(fresh)).toBe(true);
+  });
+
+  it('fails with a clear message on an invalid duration', async () => {
+    const result = await runCli(sandbox, ['logs', 'prune', '--older-than', 'foobar']);
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr + result.stdout).toMatch(/unrecognized duration/);
+  });
+});

--- a/tests/upgrade.test.ts
+++ b/tests/upgrade.test.ts
@@ -1,0 +1,162 @@
+import { execFile } from 'node:child_process';
+import { existsSync, readFileSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { cleanSandbox, makeSandbox, runCli } from './helpers.js';
+
+const exec = promisify(execFile);
+
+describe('init --upgrade', () => {
+  let sandbox: string;
+
+  beforeEach(async () => {
+    sandbox = makeSandbox();
+    await exec('git', ['init', '-q'], { cwd: sandbox });
+  });
+
+  afterEach(() => cleanSandbox(sandbox));
+
+  it('errors when the repo is not initialized', async () => {
+    const result = await runCli(sandbox, ['init', '--assistants', 'claude', '--upgrade']);
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr + result.stdout).toMatch(/Not initialized/i);
+  });
+
+  it('reports nothing to do when already current', async () => {
+    await runCli(sandbox, ['init', '--assistants', 'claude']);
+    const result = await runCli(sandbox, ['init', '--assistants', 'claude', '--upgrade']);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout + result.stderr).toMatch(/Already at|Nothing to do/);
+  });
+
+  it('--upgrade --dry-run lists planned changes without writing when installed-version is older', async () => {
+    await runCli(sandbox, ['init', '--assistants', 'claude']);
+
+    // Simulate an older installed version.
+    const versionFile = join(sandbox, '.ai/.kb-builder/installed-version');
+    const installed = JSON.parse(readFileSync(versionFile, 'utf8'));
+    const beforeInstalled = installed.installed_at;
+    installed.version = '0.0.0-test-old';
+    writeFileSync(versionFile, JSON.stringify(installed, null, 2) + '\n');
+
+    const result = await runCli(sandbox, [
+      'init',
+      '--assistants',
+      'claude',
+      '--upgrade',
+      '--dry-run',
+    ]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toMatch(/Planned changes:/);
+    expect(result.stdout).toMatch(/stamp installed-version/);
+    expect(result.stdout).toMatch(/--dry-run/);
+
+    // installed-version untouched.
+    const after = JSON.parse(readFileSync(versionFile, 'utf8'));
+    expect(after.version).toBe('0.0.0-test-old');
+    expect(after.installed_at).toBe(beforeInstalled);
+  });
+
+  it('refreshes hooks but preserves a customized .config.json', async () => {
+    await runCli(sandbox, ['init', '--assistants', 'claude']);
+
+    const configFile = join(sandbox, '.ai/knowledge-base/.config.json');
+    const customized = JSON.stringify({ schema_version: 1, drainBound: 42 }, null, 2) + '\n';
+    writeFileSync(configFile, customized);
+
+    // Mark installed-version older so upgrade applies.
+    const versionFile = join(sandbox, '.ai/.kb-builder/installed-version');
+    const installed = JSON.parse(readFileSync(versionFile, 'utf8'));
+    installed.version = '0.0.0-test-old';
+    writeFileSync(versionFile, JSON.stringify(installed, null, 2) + '\n');
+
+    const result = await runCli(sandbox, ['init', '--assistants', 'claude', '--upgrade']);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toMatch(/Upgraded to/);
+
+    // .config.json untouched.
+    expect(readFileSync(configFile, 'utf8')).toBe(customized);
+
+    // Hooks present.
+    expect(existsSync(join(sandbox, '.claude/hooks/kb-capture.mjs'))).toBe(true);
+
+    // installed-version bumped to current.
+    const after = JSON.parse(readFileSync(versionFile, 'utf8'));
+    expect(after.version).not.toBe('0.0.0-test-old');
+  });
+
+  it('preserves a customized local prompt override', async () => {
+    await runCli(sandbox, ['init', '--assistants', 'claude']);
+
+    const promptFile = join(sandbox, '.ai/.kb-builder/prompts/stage-2-extract.md');
+    writeFileSync(promptFile, '# my local override\n');
+
+    const versionFile = join(sandbox, '.ai/.kb-builder/installed-version');
+    const installed = JSON.parse(readFileSync(versionFile, 'utf8'));
+    installed.version = '0.0.0-test-old';
+    writeFileSync(versionFile, JSON.stringify(installed, null, 2) + '\n');
+
+    const result = await runCli(sandbox, ['init', '--assistants', 'claude', '--upgrade']);
+    expect(result.exitCode).toBe(0);
+    expect(readFileSync(promptFile, 'utf8')).toBe('# my local override\n');
+    expect(result.stdout).toMatch(/local override preserved/);
+  });
+
+  it('re-copies a missing prompt during upgrade', async () => {
+    await runCli(sandbox, ['init', '--assistants', 'claude']);
+
+    const promptFile = join(sandbox, '.ai/.kb-builder/prompts/stage-2-extract.md');
+    rmSync(promptFile);
+
+    const versionFile = join(sandbox, '.ai/.kb-builder/installed-version');
+    const installed = JSON.parse(readFileSync(versionFile, 'utf8'));
+    installed.version = '0.0.0-test-old';
+    writeFileSync(versionFile, JSON.stringify(installed, null, 2) + '\n');
+
+    const result = await runCli(sandbox, ['init', '--assistants', 'claude', '--upgrade']);
+    expect(result.exitCode).toBe(0);
+    expect(existsSync(promptFile)).toBe(true);
+    expect(result.stdout).toMatch(/copy new prompt/);
+  });
+
+  it('creates .config.json on upgrade when missing', async () => {
+    await runCli(sandbox, ['init', '--assistants', 'claude']);
+    const configFile = join(sandbox, '.ai/knowledge-base/.config.json');
+    rmSync(configFile);
+
+    const versionFile = join(sandbox, '.ai/.kb-builder/installed-version');
+    const installed = JSON.parse(readFileSync(versionFile, 'utf8'));
+    installed.version = '0.0.0-test-old';
+    writeFileSync(versionFile, JSON.stringify(installed, null, 2) + '\n');
+
+    const result = await runCli(sandbox, ['init', '--assistants', 'claude', '--upgrade']);
+    expect(result.exitCode).toBe(0);
+    expect(existsSync(configFile)).toBe(true);
+    const body = JSON.parse(readFileSync(configFile, 'utf8'));
+    expect(body.schema_version).toBe(1);
+    expect(body.drainBound).toBe(5);
+  });
+});
+
+describe('doctor: installed-version currency', () => {
+  let sandbox: string;
+  beforeEach(async () => {
+    sandbox = makeSandbox();
+    await exec('git', ['init', '-q'], { cwd: sandbox });
+  });
+  afterEach(() => cleanSandbox(sandbox));
+
+  it('warns when installed-version is older than the package', async () => {
+    await runCli(sandbox, ['init', '--assistants', 'claude']);
+    const versionFile = join(sandbox, '.ai/.kb-builder/installed-version');
+    const installed = JSON.parse(readFileSync(versionFile, 'utf8'));
+    installed.version = '0.0.0-test-old';
+    writeFileSync(versionFile, JSON.stringify(installed, null, 2) + '\n');
+
+    const result = await runCli(sandbox, ['doctor']);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout + result.stderr).toMatch(/installed-version is current/);
+    expect(result.stdout + result.stderr).toMatch(/init --upgrade/);
+  });
+});


### PR DESCRIPTION
Ships the v1.5 backlog from IMPLEMENTATION.md §13 in four commits.

## v1.5-A — Settings file (`38b1de3`)

`.ai/knowledge-base/.config.json` (committed) with user-level overrides at `~/.config/@e0ipso/ai-knowledge-base/config.json`. Strict Zod `SettingsSchema` with `schema_version: 1`. New `src/lib/settings.ts` resolves `defaults ← user ← project`. Stage-2 drain, curate, bootstrap-incremental, index-gen, and session-start now read tunables (`drainBound`, `maxAttempts`, `stage2Timeout`, `lockTtlMs`, `indexBudgetTokens`, `curationThreshold`, `bootstrapTokenBudget`, `gitleaksRulesPath`, `logsRetentionDays`) from settings while keeping the documented constants as defaults. `init` writes a default `.config.json`; `--force` does NOT overwrite an existing one. Doctor gains a "settings file is valid" check. Docs: Reference > Settings rewritten; Customization > Tuning settings how-to added.

## v1.5-B — `init --upgrade` (`070a3de`)

`init --assistants claude --upgrade [--dry-run]` refreshes hooks, slash commands, hook registrations, and `.gitignore` block while preserving local prompt overrides under `.ai/.kb-builder/prompts/` and the existing `.config.json`. Prints a preflight changelist before applying. Doctor gains an "installed-version is current" check that warns when the stamp lags the package. Docs: Reference > CLI updated; Getting Started > Upgrading walkthrough added.

## v1.5-C — `logs prune` (`01bca21`)

`ai-knowledge-base logs prune [--older-than <duration>] [--dry-run]`. Walks `_logs/stage-2/`, `_logs/curator/`, `_logs/bootstrap-incremental/` and deletes `.jsonl` files older than the cutoff. Accepts `ms`-package style durations (`30d`, `2w`, `12h`, `45m`, `30s`, `500ms`, `1y`). Default cutoff is `settings.logsRetentionDays` (30d). Reports per-bucket counts and freed bytes. No auto-prune in v1.5. Docs: Reference > CLI entry + Troubleshooting > Pruning logs.

## v1.5-D — Real-`claude` E2E suite (`333c874`)

`tests/e2e/full-cycle.test.ts` gated behind `KB_RUN_REAL_CLAUDE=1` (skipped by default). One full cycle: bravo-insider fixture transcript → real `claude -p` stage-2 drain → real `claude -p` curate → proposals-review accept-all → INDEX rebuild → assert that a node or INDEX.md mentions "Bravo Insider". Per-stage timeout 5 minutes. `.github/workflows/e2e.yml` runs the suite on `workflow_dispatch` only; installs `@anthropic-ai/claude-code` globally and authenticates via `ANTHROPIC_API_KEY`. CONTRIBUTING.md and Architecture > Testing strategy explain the three-layer mocking strategy.

## Quality gates

- `npm test`: **182 passing + 2 skipped** (real-gitleaks gate + real-claude E2E gate)
- `npm run typecheck`: clean
- `npm run lint`: clean
- `npm run format:check`: clean

## Test plan

- [x] Unit + integration suite (`npm test`) green on every commit.
- [x] Typecheck, lint, format checks green on every commit.
- [ ] Real-claude E2E (`KB_RUN_REAL_CLAUDE=1 npx vitest run tests/e2e`) — runs manually via the new workflow_dispatch CI; not gated on this PR.
- [x] `init` on a fresh sandbox writes the default `.config.json` populated with every key.
- [x] `init --force` does not overwrite an existing `.config.json` (warns).
- [x] `init --upgrade --dry-run` lists planned changes without writing.
- [x] `init --upgrade` preserves a customized `.config.json` and a customized local prompt.
- [x] `ai-knowledge-base logs prune --dry-run` deletes nothing and reports counts.
- [x] `ai-knowledge-base logs prune --older-than 30d` removes only files older than the cutoff.
- [x] `ai-knowledge-base doctor` reports an "installed-version is current" warning when the stamp lags the package.

https://claude.ai/code/session_01GKKWH9aYXSJJoZ3fJfP4Ux

---
_Generated by [Claude Code](https://claude.ai/code/session_01GKKWH9aYXSJJoZ3fJfP4Ux)_