### PR TITLE
feat: relocate state dir to .ai/knowledge-base/.state/ (closes #9)

### DIFF
--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -46,7 +46,7 @@ Modeled on `e0ipso/ai-task-manager`:
 
 - Published as an npm package (`@e0ipso/ai-knowledge-base`).
 - Initialized per repo via `npx @e0ipso/ai-knowledge-base init --assistants claude`. The `--assistants` flag accepts a list and exists for forward-compatibility, but only `claude` is supported in v1.
-- The `init` command copies template files (hooks, skills, prompts) from the package's `templates/` directory into the consuming repo's `.claude/` and `.ai/knowledge-base/`. It also writes `.ai/.kb-builder/installed-version` recording which package version produced the templates — needed by future `init --upgrade` work even though upgrade itself is deferred to v2.
+- The `init` command copies template files (hooks, skills, prompts) from the package's `templates/` directory into the consuming repo's `.claude/` and `.ai/knowledge-base/`. It also writes `.ai/knowledge-base/.state/installed-version` recording which package version produced the templates — needed by future `init --upgrade` work even though upgrade itself is deferred to v2.
 - TypeScript codebase, semantic-release for versioning, MIT license.
 
 CLI surface:
@@ -101,17 +101,18 @@ In-session UX (Claude Code skills installed by `init` under `.claude/skills/<nam
 │   │   │   ├── additions/
 │   │   │   ├── modifications/
 │   │   │   └── contradictions/
-│   │   └── _logs/                  # stream-json traces of LLM runs (gitignored)
-│   │       ├── stage-2/
-│   │       │   └── <session-id>__<timestamp>.jsonl
-│   │       ├── curator/
-│   │       │   └── <run-id>__<timestamp>.jsonl
-│   │       └── bootstrap-incremental/
-│   │           └── <run-id>__<timestamp>.jsonl
-│   └── .kb-builder/
-│       ├── installed-version       # template version recording (committed)
-│       ├── state.json              # last_nudged_at, lock info (gitignored)
-│       └── bootstrap-state.json    # source-doc content hashes (gitignored)
+│   │   ├── _logs/                  # stream-json traces of LLM runs (gitignored)
+│   │   │   ├── stage-2/
+│   │   │   │   └── <session-id>__<timestamp>.jsonl
+│   │   │   ├── curator/
+│   │   │   │   └── <run-id>__<timestamp>.jsonl
+│   │   │   └── bootstrap-incremental/
+│   │   │       └── <run-id>__<timestamp>.jsonl
+│   │   └── .state/                 # tool state (replaces legacy .ai/.kb-builder/)
+│   │       ├── installed-version   # template version recording (committed)
+│   │       ├── state.json          # last_nudged_at, lock info (gitignored)
+│   │       ├── bootstrap-state.json # source-doc content hashes (gitignored)
+│   │       └── prompts/            # local prompt overrides (committed)
 ├── .gitignore                       # contains _sessions/, _logs/, state.json
 ├── .pre-commit-config.yaml          # gitleaks hook
 └── package.json                     # may add @e0ipso/ai-knowledge-base as devDependency for CI
@@ -267,7 +268,7 @@ Behavior:
 - On success: the session log is updated with `stage_2_status: done`, `stage_2_log` set to the log filename, `proposals` populated.
 - On failure (parse error, schema mismatch, non-zero exit): `stage_2_status: failed`, `stage_2_error` recorded, queue entry retained for retry. After 3 failed attempts, marked `skipped` and removed from queue.
 - The `KB_BUILDER_INTERNAL=1` env var is checked by all of our own hooks (`kb-capture`, `kb-stage2-drain`, `kb-session-start`); if set, they exit immediately. This prevents the spawned `claude -p` process from triggering recursive stage-2/capture work on its own startup.
-- Concurrency on drain: the drain acquires a lock under `.ai/.kb-builder/state.json` (PID + 30-min TTL). If two SessionStart events fire concurrently (two terminals, same repo), the second waits or skips.
+- Concurrency on drain: the drain acquires a lock under `.ai/knowledge-base/.state/state.json` (PID + 30-min TTL). If two SessionStart events fire concurrently (two terminals, same repo), the second waits or skips.
 - Drain bound: by default the drain processes at most 5 queue entries per invocation; the rest are deferred to subsequent sessions. Configurable in settings.
 
 Authentication: the spawned `claude -p` inherits the user's Claude Code authentication (OAuth or API key). No separate setup. We deliberately do **not** use `--bare`, because `--bare` requires `ANTHROPIC_API_KEY` and would not work for users on Claude.ai subscriptions. The `KB_BUILDER_INTERNAL` env-var guard substitutes for `--bare`'s hook-suppression behavior.
@@ -350,7 +351,7 @@ The curator is a graph-merge problem on top of stage-2 outputs. It also runs as 
 
 Triggered by `/kb-curate` slash command or `npx @e0ipso/ai-knowledge-base curate` CLI. The threshold nudge is a **passive notification, not a trigger** — it tells the user to run curate; nothing runs automatically.
 
-Acquires `.ai/.kb-builder/state.json` lock with PID + 30-minute TTL. Concurrent invocations block on the lock or abort with a clear message.
+Acquires `.ai/knowledge-base/.state/state.json` lock with PID + 30-minute TTL. Concurrent invocations block on the lock or abort with a clear message.
 
 ### 6.2 Inputs
 
@@ -479,7 +480,7 @@ Skill body lives in `templates/claude/skills/kb-bootstrap/SKILL.md`. When invoke
    - `proposal.rationale: "bootstrap: <source-doc-path>"`
    - `derived_from: [<source-doc-path>]` (paths relative to repo root, committed to repo, so provenance always resolves)
    - `confidence: medium` (existing docs may be stale, contradictory, or aspirational; force reviewer judgment)
-6. Update `.ai/.kb-builder/bootstrap-state.json` with content hashes of every doc read.
+6. Update `.ai/knowledge-base/.state/bootstrap-state.json` with content hashes of every doc read.
 7. Report a summary: how many proposals produced, which docs were read, which were skipped and why.
 
 The agent runs in the user's existing session — no `claude -p` subprocess. The user supervises and can intervene mid-run. The skill's `allowed-tools` frontmatter restricts the agent to `Read`, `Glob`, `Grep`, `Write` (for proposals and state file only), and a narrow `Bash` allow-list for `shasum`/`sha256sum`/`mkdir`.
@@ -501,7 +502,7 @@ Behavior:
 
 1. Walk `--from` recursively, respecting `.gitignore` and `--include`/`--exclude` globs.
 2. For each markdown file, compute SHA-256 of file contents.
-3. Read `.ai/.kb-builder/bootstrap-state.json`. Skip files whose hash matches the recorded hash. Process files that are new or whose hash changed.
+3. Read `.ai/knowledge-base/.state/bootstrap-state.json`. Skip files whose hash matches the recorded hash. Process files that are new or whose hash changed.
 4. Chunk the to-process set into batches sized by token budget (~10K tokens per batch; same chunking pattern as the curator).
 5. For each batch: spawn a `claude -p` subprocess with the bootstrap-incremental prompt and stream-json verbose output to `.ai/knowledge-base/_logs/bootstrap-incremental/<run-id>__<timestamp>.jsonl`. Include `KB_BUILDER_INTERNAL=1` for recursion safety.
 6. Parse output, validate against the same proposal schema as the curator, write to `_proposed/additions/`.
@@ -514,7 +515,7 @@ The bootstrap-incremental prompt is in `templates/prompts/bootstrap-incremental.
 
 #### 6.10.3 Bootstrap state file schema
 
-`.ai/.kb-builder/bootstrap-state.json` (gitignored, JSON, validated with Zod):
+`.ai/knowledge-base/.state/bootstrap-state.json` (gitignored, JSON, validated with Zod):
 
 ```json
 {
@@ -548,7 +549,7 @@ Two hooks fire on `SessionStart`, with different sync/async modes:
 1. **`kb-stage2-drain.mjs`** — `async: true`. Drains the stage-2 queue (§5.2) without blocking session start.
 2. **`kb-session-start.mjs`** — sync. Handles injection and nudge:
    - Read `INDEX.md`. If missing, generate a stub ("KB is empty").
-   - Read `.ai/.kb-builder/state.json` for `last_nudged_at`.
+   - Read `.ai/knowledge-base/.state/state.json` for `last_nudged_at`.
    - Count session logs with `stage_2_status: done` not yet referenced by any proposal. If count ≥ threshold AND now − `last_nudged_at` ≥ 1 hour, append nudge line and update `last_nudged_at`.
    - Emit INDEX content + optional nudge as injected context.
 
@@ -807,7 +808,7 @@ export interface Adapter {
 
 ### 11.15 Hourly nudge throttle
 
-**Decision.** Once threshold is exceeded, nudge on next `SessionStart` and at most once per hour after that. Tracked via `last_nudged_at` in `.ai/.kb-builder/state.json`.
+**Decision.** Once threshold is exceeded, nudge on next `SessionStart` and at most once per hour after that. Tracked via `last_nudged_at` in `.ai/knowledge-base/.state/state.json`.
 
 **Why.** Hourly handles bursty session starts without becoming wallpaper.
 
@@ -861,7 +862,7 @@ The policy is documented in the project's CONTRIBUTING.md so future schema autho
 
 Each phase shippable on its own.
 
-**M0 — Project skeleton + secret scanning + docs foundation.** npm package, TS+ESM build, `init` command that copies stub `.ai/knowledge-base/` and `.claude/`, installs the gitleaks pre-commit hook, writes `.ai/.kb-builder/installed-version`. `ai-knowledge-base doctor` checks gitleaks, Node version, and `claude` CLI availability. Documentation foundation ships here too: minimal top-level `README.md`, `CONTRIBUTING.md` skeleton, in-KB `README.md` template that `init` copies, and the Jekyll/Just-the-Docs site skeleton (Home + Getting Started shell, deployed to GitHub Pages). No KB functionality yet, but the security guarantee and documentation scaffolding are in place from day 1.
+**M0 — Project skeleton + secret scanning + docs foundation.** npm package, TS+ESM build, `init` command that copies stub `.ai/knowledge-base/` and `.claude/`, installs the gitleaks pre-commit hook, writes `.ai/knowledge-base/.state/installed-version`. `ai-knowledge-base doctor` checks gitleaks, Node version, and `claude` CLI availability. Documentation foundation ships here too: minimal top-level `README.md`, `CONTRIBUTING.md` skeleton, in-KB `README.md` template that `init` copies, and the Jekyll/Just-the-Docs site skeleton (Home + Getting Started shell, deployed to GitHub Pages). No KB functionality yet, but the security guarantee and documentation scaffolding are in place from day 1.
 
 **M1 — Stage 1 capture for all three triggers.** `Stop`, `SessionEnd`, and `PreCompact` hooks ship together. Dedup, gitleaks redaction, write session logs, append to `.queue.json`. Stress-test PreCompact on long sessions during this phase.
 

--- a/PRD.md
+++ b/PRD.md
@@ -140,7 +140,7 @@ Every node carries a `derived_from` list pointing to session log filenames. **Ca
 ### 8.1 First-time setup
 
 1. A contributor runs `npx <pkg> init --assistants claude`.
-2. The installer creates `.ai/knowledge-base/` with starter structure (including `_logs/` and `_sessions/` both gitignored), registers hooks under `.claude/`, adds a pre-commit hook for secret scanning, writes `.ai/.kb-builder/installed-version`.
+2. The installer creates `.ai/knowledge-base/` with starter structure (including `_logs/` and `_sessions/` both gitignored), registers hooks under `.claude/`, adds a pre-commit hook for secret scanning, writes `.ai/knowledge-base/.state/installed-version`.
 3. The contributor commits. KB is live but empty.
 
 ### 8.2 Daily session capture (automatic)

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -90,10 +90,10 @@ The two CLI shapes:
 | `.ai/knowledge-base/_proposed/{additions,modifications,contradictions}/` | curator + node-add + bootstrap | Pending proposals awaiting review. |
 | `.ai/knowledge-base/nodes/{practice,map}/` | proposals review | Canonical, accepted knowledge. The only thing the assistant sees via INDEX. |
 | `.ai/knowledge-base/INDEX.md`, `GRAPH.md` | curator + index-rebuild | Deterministic outputs derived from `nodes/`. INDEX is token-budgeted; GRAPH is the full edge listing. |
-| `.ai/.kb-builder/installed-version` | init | Marker recording package version + selected assistants. Committed. |
-| `.ai/.kb-builder/state.json` | drain + curator + bootstrap + consume | Single shared state file. `lock` (one at a time) + `last_nudged_at`. Gitignored. |
-| `.ai/.kb-builder/bootstrap-state.json` | bootstrap | SHA-256 of every doc the bootstrap pipelines have processed. Gitignored. |
-| `.ai/.kb-builder/prompts/*` | init | Local overrides for the three shipped prompts. Committed. |
+| `.ai/knowledge-base/.state/installed-version` | init | Marker recording package version + selected assistants. Committed. |
+| `.ai/knowledge-base/.state/state.json` | drain + curator + bootstrap + consume | Single shared state file. `lock` (one at a time) + `last_nudged_at`. Gitignored. |
+| `.ai/knowledge-base/.state/bootstrap-state.json` | bootstrap | SHA-256 of every doc the bootstrap pipelines have processed. Gitignored. |
+| `.ai/knowledge-base/.state/prompts/*` | init | Local overrides for the three shipped prompts. Committed. |
 
 ## Locking
 
@@ -200,7 +200,7 @@ These are constraints, not omissions. Each one trades expressiveness for "the co
 
 | You want to… | Look at… |
 |---|---|
-| Change extraction behavior | `templates-source/prompts/stage-2-extract.md` (project-tunable copy at `.ai/.kb-builder/prompts/stage-2-extract.md`). |
+| Change extraction behavior | `templates-source/prompts/stage-2-extract.md` (project-tunable copy at `.ai/knowledge-base/.state/prompts/stage-2-extract.md`). |
 | Change curator behavior | `templates-source/prompts/curator.md`. Tighten the dedup or contradiction logic in `src/lib/curate.ts`. |
 | Change bootstrap behavior | `templates-source/prompts/bootstrap-incremental.md` for the CLI prompt; `templates-source/claude/skills/kb-bootstrap/SKILL.md` for the in-session agent. |
 | Add a new CLI subcommand | `src/commands/<name>.ts` + wire it in `src/cli.ts`. Add doc to `docs/reference/cli.md`. |

--- a/docs/bootstrap/first-time-bootstrap.md
+++ b/docs/bootstrap/first-time-bootstrap.md
@@ -41,7 +41,7 @@ The default scan covers `docs/`, top-level `README.md`, `CONTRIBUTING.md`, `ARCH
 3. **Samples and follows references.** Skims long reference docs (skipping auto-generated tables), follows explicit cross-references like "see `docs/architecture/auth.md` for the auth design."
 4. **Splits candidates by kind.** Imperative guidance ("always use X") becomes a **practice** proposal; named entities ("Bravo Cards is our personalization module") become **map** proposals. Content that has both aspects is split across the two.
 5. **Writes proposals.** Each candidate is written under `.ai/knowledge-base/_proposed/additions/<kind>-<slug>.md` with `proposal.rationale: "bootstrap: <source-doc>"` and `derived_from: [<source-doc>]`. Confidence defaults to `medium`.
-6. **Updates state.** For every doc the agent read (even ones that produced zero candidates), `.ai/.kb-builder/bootstrap-state.json` gets a SHA-256 + timestamp entry. This lets future `bootstrap-incremental` runs skip unchanged files.
+6. **Updates state.** For every doc the agent read (even ones that produced zero candidates), `.ai/knowledge-base/.state/bootstrap-state.json` gets a SHA-256 + timestamp entry. This lets future `bootstrap-incremental` runs skip unchanged files.
 7. **Reports back.** A summary lists docs read, docs skipped (and why), proposal counts by kind, cross-references the agent noticed but did not follow, and any contradictions worth your attention.
 
 After the agent finishes, run `ai-knowledge-base proposals review` to step through the proposals interactively.

--- a/docs/bootstrap/incremental-bootstrap.md
+++ b/docs/bootstrap/incremental-bootstrap.md
@@ -6,7 +6,7 @@ nav_order: 2
 
 # Incremental bootstrap (`bootstrap-incremental`)
 
-A deterministic, hash-aware CLI for re-bootstrapping the knowledge base after source docs are added or modified. It reads `.ai/.kb-builder/bootstrap-state.json`, walks `--from`, skips files whose SHA-256 matches the recorded hash, chunks the remainder, and runs `claude -p` on each chunk with the [bootstrap-incremental prompt](../customization/bootstrap-incremental-prompt.md).
+A deterministic, hash-aware CLI for re-bootstrapping the knowledge base after source docs are added or modified. It reads `.ai/knowledge-base/.state/bootstrap-state.json`, walks `--from`, skips files whose SHA-256 matches the recorded hash, chunks the remainder, and runs `claude -p` on each chunk with the [bootstrap-incremental prompt](../customization/bootstrap-incremental-prompt.md).
 
 Idempotent and safe to re-run. No supervision required.
 
@@ -44,7 +44,7 @@ Glob syntax: `**` matches any number of path segments; `*` matches anything with
 
 ## Locking
 
-`bootstrap-incremental` shares the `.ai/.kb-builder/state.json` lock file with `kb-stage2-drain` and `curate`, but takes its own named lock (`name: bootstrap-incremental`, PID + 30-minute TTL). If a concurrent bootstrap is running, the new invocation exits with `locked` and does no work. If a stage-2 drain or curator run holds an unrelated lock, the bootstrap waits for nothing — the locks are name-scoped.
+`bootstrap-incremental` shares the `.ai/knowledge-base/.state/state.json` lock file with `kb-stage2-drain` and `curate`, but takes its own named lock (`name: bootstrap-incremental`, PID + 30-minute TTL). If a concurrent bootstrap is running, the new invocation exits with `locked` and does no work. If a stage-2 drain or curator run holds an unrelated lock, the bootstrap waits for nothing — the locks are name-scoped.
 
 ## Overlap with existing nodes
 
@@ -81,7 +81,7 @@ You can wire `bootstrap-incremental --dry-run` into CI to alert when docs change
 ## After a run
 
 - `ai-knowledge-base proposals review` — accept or reject the new proposals.
-- `cat .ai/.kb-builder/bootstrap-state.json` — inspect the recorded hashes and timestamps.
+- `cat .ai/knowledge-base/.state/bootstrap-state.json` — inspect the recorded hashes and timestamps.
 - `ls .ai/knowledge-base/_logs/bootstrap-incremental/` — find the stream-JSON trace of every batch (filenames sort by ULID, so newest is last).
 
 ## State file schema

--- a/docs/customization/bootstrap-incremental-prompt.md
+++ b/docs/customization/bootstrap-incremental-prompt.md
@@ -17,7 +17,7 @@ Two copies of the template:
 | Location | Used by | When edited |
 |---|---|---|
 | `templates/prompts/bootstrap-incremental.md` (inside the npm package) | Fallback if no per-repo override exists. | Edit upstream and bump the package version. |
-| `.ai/.kb-builder/prompts/bootstrap-incremental.md` (inside your repo, copied by `init`) | The CLI prefers this copy. | Edit locally to tune per-project extraction. |
+| `.ai/knowledge-base/.state/prompts/bootstrap-incremental.md` (inside your repo, copied by `init`) | The CLI prefers this copy. | Edit locally to tune per-project extraction. |
 
 When `bootstrap-incremental` spawns `claude -p`, it loads the override copy if present and falls back to the bundled template otherwise. The override is plain markdown — commit it like any other project asset.
 
@@ -56,7 +56,7 @@ A reasonable workflow when tuning:
 2. Run `bootstrap-incremental --from <subset> --dry-run` to confirm chunking looks right.
 3. Run without `--dry-run`. Review the proposals with `ai-knowledge-base proposals review`.
 4. Note the false positives (proposals you'd reject) and false negatives (knowledge in the docs that didn't surface). Adjust the prompt's "trigger patterns" and "what to skip" sections.
-5. Delete `.ai/.kb-builder/bootstrap-state.json` (so the next run re-processes those files) and re-run.
+5. Delete `.ai/knowledge-base/.state/bootstrap-state.json` (so the next run re-processes those files) and re-run.
 6. Repeat until the ratio of accepted proposals to total proposals is in the 60–80% range. Pushing higher tends to also drop true positives.
 
 ## Common edits

--- a/docs/customization/curator-prompt.md
+++ b/docs/customization/curator-prompt.md
@@ -13,9 +13,9 @@ The curator decides what happens to every stage-2 candidate that lands in the qu
 | Location | Used by | When edited |
 |---|---|---|
 | `src/templates-source/prompts/curator.md` | The package itself | Edit here if you maintain `@e0ipso/ai-knowledge-base` |
-| `.ai/.kb-builder/prompts/curator.md` | The curator subprocess at runtime | Edit here in a consumer repo to override the prompt locally |
+| `.ai/knowledge-base/.state/prompts/curator.md` | The curator subprocess at runtime | Edit here in a consumer repo to override the prompt locally |
 
-`ai-knowledge-base init` copies the shipped template into `.ai/.kb-builder/prompts/`. The `ai-knowledge-base curate` command prefers the local copy if it exists.
+`ai-knowledge-base init` copies the shipped template into `.ai/knowledge-base/.state/prompts/`. The `ai-knowledge-base curate` command prefers the local copy if it exists.
 
 ## Version comment
 

--- a/docs/customization/index.md
+++ b/docs/customization/index.md
@@ -14,4 +14,4 @@ Pages:
 - [Editing the bootstrap-incremental prompt](bootstrap-incremental-prompt.md) — tune the chunked extraction for `bootstrap-incremental`.
 - [Tuning settings](tuning-settings.md) — recipes for the most common `.config.json` changes; trade-offs explained.
 
-Prompts are copied to `.ai/.kb-builder/prompts/` during `init` so you can override locally; hooks pick up the local copy if present and fall back to the bundled template. Reference settings live under [Reference > Settings](../reference/settings.md).
+Prompts are copied to `.ai/knowledge-base/.state/prompts/` during `init` so you can override locally; hooks pick up the local copy if present and fall back to the bundled template. Reference settings live under [Reference > Settings](../reference/settings.md).

--- a/docs/customization/stage-2-prompt.md
+++ b/docs/customization/stage-2-prompt.md
@@ -15,7 +15,7 @@ Two copies of the prompt template exist:
 | Location | Used by | When edited |
 |---|---|---|
 | `templates/prompts/stage-2-extract.md` (inside the npm package) | First-time fallback if no per-repo override exists. | Edit upstream and bump the package version. |
-| `.ai/.kb-builder/prompts/stage-2-extract.md` (inside your repo, copied by `init`) | The stage-2 drain hook prefers this copy. | Edit locally to tune the extractor for your project's vocabulary. |
+| `.ai/knowledge-base/.state/prompts/stage-2-extract.md` (inside your repo, copied by `init`) | The stage-2 drain hook prefers this copy. | Edit locally to tune the extractor for your project's vocabulary. |
 
 When the drain hook spawns `claude -p`, it loads the override copy if present and falls back to the bundled template otherwise. The override is plain markdown — commit it like any other project asset.
 
@@ -49,4 +49,4 @@ Output shape must continue to match `Stage2OutputSchema` (see `src/lib/schemas.t
 
 ## Reverting
 
-The drain hook always prefers the override copy. To revert to the bundled prompt without re-running `init`, delete `.ai/.kb-builder/prompts/stage-2-extract.md`. The next drain will load the package's bundled version.
+The drain hook always prefers the override copy. To revert to the bundled prompt without re-running `init`, delete `.ai/knowledge-base/.state/prompts/stage-2-extract.md`. The next drain will load the package's bundled version.

--- a/docs/getting-started/ci-recipe.md
+++ b/docs/getting-started/ci-recipe.md
@@ -28,7 +28,6 @@ on:
   pull_request:
     paths:
       - '.ai/knowledge-base/**'
-      - '.ai/.kb-builder/**'
       - '.claude/**'
       - '.pre-commit-config.yaml'
 
@@ -84,7 +83,6 @@ kb_validate:
   rules:
     - changes:
         - .ai/knowledge-base/**/*
-        - .ai/.kb-builder/**/*
         - .claude/**/*
         - .pre-commit-config.yaml
 ```

--- a/docs/getting-started/first-capture.md
+++ b/docs/getting-started/first-capture.md
@@ -35,7 +35,7 @@ ai-knowledge-base curate
 
 The curator:
 
-- Acquires the `.ai/.kb-builder/state.json` lock (`name: curator`, 30-min TTL).
+- Acquires the `.ai/knowledge-base/.state/state.json` lock (`name: curator`, 30-min TTL).
 - Batches every `stage_2_status: done` session log that has not been curated yet.
 - Spawns `claude -p` per batch with the curator prompt.
 - Writes proposals into `.ai/knowledge-base/_proposed/{additions,modifications,contradictions}/`.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -31,7 +31,7 @@ This will:
 2. Create `.claude/` with the bootstrap slash command and the compiled stage-1 capture hook (`kb-capture.mjs`). The hook is registered against `Stop`, `SessionEnd`, and `PreCompact` in `.claude/settings.json`. See [Reference > Hook events](../reference/hook-events.md) for what each one does.
 3. Create or extend `.gitignore` to keep `_sessions/` and `_logs/` out of git by default.
 4. Drop a `.pre-commit-config.yaml` with a [gitleaks](https://github.com/gitleaks/gitleaks) hook (or merge entry if you already have one).
-5. Write `.ai/.kb-builder/installed-version` recording which package version produced the templates.
+5. Write `.ai/knowledge-base/.state/installed-version` recording which package version produced the templates.
 
 Commit everything `init` created.
 
@@ -44,7 +44,7 @@ Commit everything `init` created.
 - `gitleaks` on PATH (warning if missing — install via your package manager)
 - `installed-version` marker present
 - `.pre-commit-config.yaml` present and contains a gitleaks entry
-- `.gitignore` contains the kb-builder block
+- `.gitignore` contains the ai-knowledge-base block
 
 A clean run exits 0 with no errors or warnings.
 

--- a/docs/getting-started/upgrading.md
+++ b/docs/getting-started/upgrading.md
@@ -26,8 +26,8 @@ ai-knowledge-base doctor
 | `.gitignore` | Managed block is refreshed in place. New entries appear; existing user entries outside the block are untouched. |
 | `.pre-commit-config.yaml` | Created only if missing. |
 | `.ai/knowledge-base/.config.json` | Created only if missing. An existing file is never overwritten, regardless of `--force` or `--upgrade`. |
-| `.ai/.kb-builder/prompts/*.md` | Copied only when missing locally. If a prompt already exists, it is preserved (the upgrade preflight reports it as a "local override preserved" line). |
-| `.ai/.kb-builder/installed-version` | Stamped with the new package version. |
+| `.ai/knowledge-base/.state/prompts/*.md` | Copied only when missing locally. If a prompt already exists, it is preserved (the upgrade preflight reports it as a "local override preserved" line). |
+| `.ai/knowledge-base/.state/installed-version` | Stamped with the new package version. |
 
 ## Preflight first
 
@@ -49,7 +49,7 @@ Planned changes:
   • [hook-script]         refresh .claude/hooks/kb-stage2-drain.mjs
   • [skill]               refresh .claude/skills/kb-bootstrap/
   • [legacy-command-cleanup] remove legacy .claude/commands/kb-bootstrap.md
-  • [prompt-preserved]    local override preserved: .ai/.kb-builder/prompts/curator.md
+  • [prompt-preserved]    local override preserved: .ai/knowledge-base/.state/prompts/curator.md
   • [hook-registration]   refresh ai-knowledge-base hook entries in .claude/settings.json
   • [installed-version]   stamp installed-version: 1.0.0 → 1.5.0
 
@@ -92,3 +92,11 @@ The check is a warning, not an error — the previous templates keep working unt
 | Pairs with `--dry-run` | no | yes |
 
 Use `--upgrade` when bumping to a new package version. Use `--force` only when you've deliberately broken something and want to restore the original templates (it overwrites your local prompt customizations).
+
+## State-layout migration (legacy `.ai/.kb-builder/`)
+
+Older installs stored tool state under `.ai/.kb-builder/`. Starting with the layout-version-2 release, state lives under `.ai/knowledge-base/.state/` so the entire tool footprint sits beneath the knowledge-base root.
+
+The migration is automatic and idempotent: every `init`, `init --upgrade`, `doctor`, and CLI command (curate, bootstrap-incremental, status, …) checks for a legacy directory and moves its contents into the new location on the first run. There is nothing to do manually — but if you want to drive it explicitly, run `ai-knowledge-base doctor`, which prints a one-line confirmation when it migrates.
+
+The `installed-version` marker carries a `layout_version` field (`2` for the new layout); the absence of that field is treated as layout 1. Commit the moved files in your next change.

--- a/docs/reference/bootstrap-state.md
+++ b/docs/reference/bootstrap-state.md
@@ -8,7 +8,7 @@ nav_order: 5
 
 `bootstrap-state.json` records the SHA-256 of every doc the bootstrap pipelines have already processed. Both `/kb-bootstrap` (the agent-driven first-time pass, shipped as a Claude Code skill) and `ai-knowledge-base bootstrap-incremental` (the CLI for re-runs) read and write this file. Hash-equal docs are skipped on subsequent runs.
 
-- **Path:** `.ai/.kb-builder/bootstrap-state.json`
+- **Path:** `.ai/knowledge-base/.state/bootstrap-state.json`
 - **Gitignored:** yes (the gitignore block written by `init` covers it).
 - **Schema version:** `1`.
 - **Validator:** `BootstrapStateSchema` in `src/lib/schemas.ts`.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -14,13 +14,13 @@ The package installs an `ai-knowledge-base` binary. After `npm install -g @e0ips
 ai-knowledge-base init --assistants <list> [--force] [--upgrade [--dry-run]]
 ```
 
-First-time setup for a repo. Copies the directory skeleton, the Claude Code skills (`kb-add`, `kb-bootstrap`, `kb-curate`), hook scripts, and pre-commit config; registers the capture hook against three Claude Code events; writes `.ai/.kb-builder/installed-version`. If the repo carries legacy `.claude/commands/kb-{add,bootstrap,curate}.md` files from an older install, those are removed (user-authored slash commands in `.claude/commands/` are left untouched).
+First-time setup for a repo. Copies the directory skeleton, the Claude Code skills (`kb-add`, `kb-bootstrap`, `kb-curate`), hook scripts, and pre-commit config; registers the capture hook against three Claude Code events; writes `.ai/knowledge-base/.state/installed-version`. If the repo carries legacy `.claude/commands/kb-{add,bootstrap,curate}.md` files from an older install, those are removed (user-authored slash commands in `.claude/commands/` are left untouched).
 
 Flags:
 
 - `-a, --assistants <list>` (required) — comma-separated list of AI assistants to wire up. v1 supports `claude` only; the list form exists for forward compatibility.
 - `-f, --force` — overwrite existing files. Without this flag, re-running `init` on an already-initialized repo exits with a notice and does nothing. `--force` does **not** overwrite an existing `.ai/knowledge-base/.config.json` (use the file's own editor) and is incompatible with `--upgrade` (use one or the other).
-- `-u, --upgrade` — refresh hooks, skills, prompts, and hook registrations to match the current package version, while preserving local prompt overrides under `.ai/.kb-builder/prompts/` and the existing `.config.json`. Also removes legacy `.claude/commands/kb-{add,bootstrap,curate}.md` files left by older installs. Prints a preflight changelist, then applies. Combine with `--dry-run` to print the preflight only.
+- `-u, --upgrade` — refresh hooks, skills, prompts, and hook registrations to match the current package version, while preserving local prompt overrides under `.ai/knowledge-base/.state/prompts/` and the existing `.config.json`. Also removes legacy `.claude/commands/kb-{add,bootstrap,curate}.md` files left by older installs. Prints a preflight changelist, then applies. Combine with `--dry-run` to print the preflight only.
 - `--dry-run` — only meaningful with `--upgrade`. Lists planned changes without writing.
 
 See [Getting Started > Upgrading](../getting-started/upgrading.md) for a walkthrough.
@@ -31,8 +31,8 @@ What `init` writes:
 - `.claude/skills/{kb-add,kb-bootstrap,kb-curate}/SKILL.md` — the three Claude Code skills that drive the in-session knowledge-base UX.
 - `.claude/hooks/kb-capture.mjs` — compiled stage-1 capture script (Stop / SessionEnd / PreCompact).
 - `.claude/settings.json` — registers the three hooks; merges with any existing user-defined hooks.
-- `.ai/.kb-builder/installed-version` — JSON marker recording the package version and selected assistants.
-- `.ai/.kb-builder/prompts/` — copy of the shipped prompts so you can review or override them locally.
+- `.ai/knowledge-base/.state/installed-version` — JSON marker recording the package version and selected assistants.
+- `.ai/knowledge-base/.state/prompts/` — copy of the shipped prompts so you can review or override them locally.
 - `.gitignore` — appends a managed block listing `_sessions/`, `_logs/`, and state files.
 - `.pre-commit-config.yaml` — gitleaks hook (only if no config exists; otherwise the file is left alone with a warning).
 
@@ -45,7 +45,7 @@ ai-knowledge-base doctor [--verbose]
 Verify the installation. Checks:
 
 - Node ≥ 22, `claude` CLI on PATH, gitleaks on PATH.
-- `.ai/.kb-builder/installed-version` marker.
+- `.ai/knowledge-base/.state/installed-version` marker.
 - `.pre-commit-config.yaml` present with a gitleaks entry.
 - `.gitignore` carries the managed ai-knowledge-base block.
 - Every `derived_from` reference under `nodes/` resolves on disk (session log filename, repo-relative path, or absolute path). Dangling references are a warning, not an error — the consume path silently ignores them. `--verbose` prints the offending references after the check summary.
@@ -68,7 +68,7 @@ ai-knowledge-base curate [--batch-size <n>] [--token-budget <n>] [--timeout <ms>
 
 Run the curator non-interactively over every session log with `stage_2_status: done` that has not yet been curated. The command:
 
-1. Acquires the curator lock on `.ai/.kb-builder/state.json` (`name: curator`, PID + 30-minute TTL). If another curate run holds the lock, exits with `locked` and no work done.
+1. Acquires the curator lock on `.ai/knowledge-base/.state/state.json` (`name: curator`, PID + 30-minute TTL). If another curate run holds the lock, exits with `locked` and no work done.
 2. Batches pending session logs by count (`--batch-size`, default 10) and an estimated token budget (`--token-budget`, default 50000).
 3. Spawns one `claude -p` subprocess per batch with the curator prompt, streaming JSON output to `.ai/knowledge-base/_logs/curator/<ulid>__<timestamp>.jsonl`.
 4. Writes one proposal per non-drop action under `.ai/knowledge-base/_proposed/{additions,modifications,contradictions}/`.
@@ -115,11 +115,11 @@ ai-knowledge-base bootstrap-incremental --from <path> \
   [--dry-run] [--token-budget <n>] [--timeout <ms>]
 ```
 
-Re-bootstrap the KB from markdown documentation under `--from`. Hash-aware: processes only files whose SHA-256 changed since the last run (recorded in `.ai/.kb-builder/bootstrap-state.json`). The command:
+Re-bootstrap the KB from markdown documentation under `--from`. Hash-aware: processes only files whose SHA-256 changed since the last run (recorded in `.ai/knowledge-base/.state/bootstrap-state.json`). The command:
 
 1. Walks `--from` recursively, applying `.gitignore`, `--include`, and `--exclude` filters. Paths are matched relative to the repo root with posix separators.
 2. Computes SHA-256 for each remaining file and compares it against `bootstrap-state.json`. Unchanged files are reported and skipped.
-3. Acquires the `bootstrap-incremental` lock on `.ai/.kb-builder/state.json` (PID + 30-minute TTL). If another bootstrap is running, exits with `locked` and no work done.
+3. Acquires the `bootstrap-incremental` lock on `.ai/knowledge-base/.state/state.json` (PID + 30-minute TTL). If another bootstrap is running, exits with `locked` and no work done.
 4. Chunks the to-process set into batches sized by `--token-budget` (~4 chars per token; default `10000`).
 5. Spawns one `claude -p` subprocess per batch with the [bootstrap-incremental prompt](../customization/bootstrap-incremental-prompt.md), streaming JSON output to `.ai/knowledge-base/_logs/bootstrap-incremental/<ulid>__<timestamp>.jsonl`.
 6. Writes one `addition` proposal per LLM-emitted candidate under `.ai/knowledge-base/_proposed/additions/`, with `proposal.rationale: "bootstrap: <source-doc>"`, `derived_from: [<source-doc>]`, and `confidence: medium` by default.

--- a/docs/reference/hook-events.md
+++ b/docs/reference/hook-events.md
@@ -49,8 +49,8 @@ If you wrap the `claude` CLI in a script that spawns sessions for any reason, se
 The drain hook is async, so the user does not wait on it. Per invocation:
 
 1. **Recursion guard.** Exits immediately if `KB_BUILDER_INTERNAL=1` is set (the env var the drain itself sets on the children it spawns).
-2. **Lock.** Acquires the stage-2 lock in `.ai/.kb-builder/state.json` (PID + 30-minute TTL). If another drain is already running, this invocation exits without doing anything. Stale locks are reclaimed after TTL.
-3. **Load the prompt.** Prefers the per-repo override at `.ai/.kb-builder/prompts/stage-2-extract.md` (written by `init`); falls back to the version bundled with the package.
+2. **Lock.** Acquires the stage-2 lock in `.ai/knowledge-base/.state/state.json` (PID + 30-minute TTL). If another drain is already running, this invocation exits without doing anything. Stale locks are reclaimed after TTL.
+3. **Load the prompt.** Prefers the per-repo override at `.ai/knowledge-base/.state/prompts/stage-2-extract.md` (written by `init`); falls back to the version bundled with the package.
 4. **Iterate the queue.** Up to `drainBound` (default 5) entries per invocation. The rest are deferred to subsequent sessions.
 5. **Per entry:** loads the session log, extracts the redacted transcript slice, substitutes it into the prompt, spawns `claude -p --allowedTools '' --output-format stream-json --verbose`, and writes the full stream into `.ai/knowledge-base/_logs/stage-2/<session-id>__<timestamp>.jsonl`.
 6. **Parse the final result message.** Validated against the stage-2 Zod schema. On success: the session log's frontmatter is updated with `stage_2_status: done`, the log path, the populated `proposals.{practice,map}` arrays, and a deduped `topics` list.

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -47,7 +47,7 @@ A malformed user file is not fatal — `resolveSettings()` emits a warning to th
 | `drainBound` | int > 0 | `5` | Maximum number of stage-2 queue entries the async drain processes per `SessionStart`. Remaining entries are deferred to the next session. Keeps a long backlog from blocking a quick session start. |
 | `maxAttempts` | int > 0 | `3` | A failed stage-2 entry (parse error, schema mismatch, timeout, non-zero exit) is rotated to the back of the queue with `attempts` incremented. After this many failures the session log is marked `stage_2_status: skipped` and the entry is removed. |
 | `stage2Timeout` | int > 0 (ms) | `60000` | Per-entry wall-clock deadline for the spawned `claude -p` stage-2 subprocess. A timeout counts as a failed attempt for retry purposes. |
-| `lockTtlMs` | int > 0 (ms) | `1800000` (30 min) | TTL for the `.ai/.kb-builder/state.json` lock. A lock older than its TTL is treated as stale and reclaimed, preventing a crashed run from blocking subsequent invocations. Applies to the stage-2 drain, curator, and bootstrap-incremental locks. |
+| `lockTtlMs` | int > 0 (ms) | `1800000` (30 min) | TTL for the `.ai/knowledge-base/.state/state.json` lock. A lock older than its TTL is treated as stale and reclaimed, preventing a crashed run from blocking subsequent invocations. Applies to the stage-2 drain, curator, and bootstrap-incremental locks. |
 | `indexBudgetTokens` | int > 0 | `2000` | INDEX.md token budget (~4 chars/token). Per-kind sections trim oldest entries until the rendered body fits; trimmed counts go into a "_N additional nodes hidden by token budget_" footer. |
 | `curationThreshold` | int > 0 | `5` | Number of pending session logs that triggers the curate-nudge on the next `SessionStart`. The nudge is throttled to at most once per hour. |
 | `bootstrapTokenBudget` | int > 0 | `10000` | Approximate per-batch token budget for `ai-knowledge-base bootstrap-incremental`. Docs are atomic — a single oversized doc lands in its own batch. |
@@ -60,7 +60,7 @@ Per-command flags (`--batch-size`, `--token-budget`, `--timeout`, `--budget-toke
 
 ## Lock state
 
-`.ai/.kb-builder/state.json` carries `{ schema_version: 1, lock?: { name, pid, acquired_at, ttl_ms }, last_nudged_at? }`. The lock guards against concurrent stage-2 drains, curate runs, and bootstrap-incremental runs. Field reference:
+`.ai/knowledge-base/.state/state.json` carries `{ schema_version: 1, lock?: { name, pid, acquired_at, ttl_ms }, last_nudged_at? }`. The lock guards against concurrent stage-2 drains, curate runs, and bootstrap-incremental runs. Field reference:
 
 | Field | Purpose |
 |---|---|

--- a/docs/reference/skills.md
+++ b/docs/reference/skills.md
@@ -43,7 +43,7 @@ What the agent does:
 3. Samples representative content and follows cross-references; skips auto-generated reference tables.
 4. Splits candidates by kind — imperative guidance → practice; named entities → map.
 5. Writes proposals under `.ai/knowledge-base/_proposed/additions/<kind>-<slug>.md` with `proposal.rationale: "bootstrap: <source-doc>"` and `derived_from: [<source-doc>]`. Confidence defaults to `medium`.
-6. Updates `.ai/.kb-builder/bootstrap-state.json` with the SHA-256 and timestamp of every doc it read.
+6. Updates `.ai/knowledge-base/.state/bootstrap-state.json` with the SHA-256 and timestamp of every doc it read.
 7. Reports back with proposal counts, docs skipped (and why), and any contradictions worth your attention.
 
 Bootstrap is supervised: the agent never writes to `nodes/` directly, never auto-resolves contradictions, and stops to ask if it suspects it's over-extracting. For unsupervised re-runs after the first pass, use the CLI:

--- a/docs/troubleshooting/common-issues.md
+++ b/docs/troubleshooting/common-issues.md
@@ -27,7 +27,7 @@ Stage-2 runs on the next `SessionStart`, asynchronously. So:
 
 1. **Start a new session.** The `kb-stage2-drain.mjs` hook fires on session start. If the drain succeeds, the log moves to `stage_2_status: done` and proposals get populated.
 2. **Check `_logs/stage-2/<session-id>__<ts>.jsonl`.** If the file exists but the session is still `pending` or moved to `failed`, the drain ran but encountered an error. Read [Reading stage-2 logs](reading-stage-2-logs.md).
-3. **Check the lock.** `cat .ai/.kb-builder/state.json`. If `lock.name: stage2-drain` with a stale PID, the previous drain crashed — the lock will be reclaimed after 30 minutes, or you can delete the `lock` field manually.
+3. **Check the lock.** `cat .ai/knowledge-base/.state/state.json`. If `lock.name: stage2-drain` with a stale PID, the previous drain crashed — the lock will be reclaimed after 30 minutes, or you can delete the `lock` field manually.
 4. **Verify `claude` is on PATH** in the same shell environment Claude Code uses to spawn hooks. `ai-knowledge-base doctor` runs `claude --version` and reports.
 
 ## "Curate writes no proposals."
@@ -42,7 +42,7 @@ Stage-2 runs on the next `SessionStart`, asynchronously. So:
 Most of the time this is prompt drift. Two things to do:
 
 1. **Read the run log.** `_logs/curator/<run-id>__<ts>.jsonl` has the full stream-json trace. See [Reading curator logs](reading-curator-logs.md) for how to parse it.
-2. **Tune the curator prompt.** Edit `.ai/.kb-builder/prompts/curator.md` (your local override). Bump the `Version: N` comment when you change behavior. The calibration loop is documented in [Editing the curator prompt](../customization/curator-prompt.md).
+2. **Tune the curator prompt.** Edit `.ai/knowledge-base/.state/prompts/curator.md` (your local override). Bump the `Version: N` comment when you change behavior. The calibration loop is documented in [Editing the curator prompt](../customization/curator-prompt.md).
 
 ## "INDEX.md is stale."
 
@@ -72,9 +72,9 @@ Contradiction proposals require a `suggested_resolution` (`supersede`, `keep_bot
 
 ## "Bootstrap re-processes docs I've already done."
 
-`.ai/.kb-builder/bootstrap-state.json` records SHA-256 of every processed doc. If a re-run is processing them again:
+`.ai/knowledge-base/.state/bootstrap-state.json` records SHA-256 of every processed doc. If a re-run is processing them again:
 
-1. **The file was deleted.** Check `cat .ai/.kb-builder/bootstrap-state.json`. If missing, the next run starts fresh.
+1. **The file was deleted.** Check `cat .ai/knowledge-base/.state/bootstrap-state.json`. If missing, the next run starts fresh.
 2. **The file is malformed.** Doctor doesn't currently check the bootstrap state file — if it's hand-edited to an invalid shape, the runtime falls back to an empty state. Fix the JSON.
 3. **The doc actually changed.** Even whitespace counts. `git diff` against the last bootstrap-commit timestamp to see what shifted.
 
@@ -82,12 +82,12 @@ Contradiction proposals require a `suggested_resolution` (`supersede`, `keep_bot
 
 Tune the INDEX token budget. `ai-knowledge-base index rebuild --budget-tokens 1000` re-renders INDEX at a tighter budget; oldest entries per kind get trimmed and a footer reports the hidden count. The full edge listing is still in `GRAPH.md` for the assistant to read explicitly.
 
-If the noise is in the content itself (proposals that should never have been written), tighten the prompts in `.ai/.kb-builder/prompts/`. The "what to skip" sections in [stage-2](../customization/stage-2-prompt.md), [curator](../customization/curator-prompt.md), and [bootstrap-incremental](../customization/bootstrap-incremental-prompt.md) prompts are the right levers.
+If the noise is in the content itself (proposals that should never have been written), tighten the prompts in `.ai/knowledge-base/.state/prompts/`. The "what to skip" sections in [stage-2](../customization/stage-2-prompt.md), [curator](../customization/curator-prompt.md), and [bootstrap-incremental](../customization/bootstrap-incremental-prompt.md) prompts are the right levers.
 
 ## When all else fails
 
 1. `ai-knowledge-base doctor --verbose` — comprehensive checks.
-2. `cat .ai/.kb-builder/state.json` — current lock + last_nudged_at.
+2. `cat .ai/knowledge-base/.state/state.json` — current lock + last_nudged_at.
 3. `cat .ai/knowledge-base/_sessions/.queue.json` — pending stage-2 entries.
 4. `ls .ai/knowledge-base/_logs/*/` — find the most recent run log; read it.
 5. File an issue at [the GitHub repo](https://github.com/e0ipso/ai-knowledge-base/issues) with the doctor output and the relevant log snippets.

--- a/src/commands/bootstrap-incremental.ts
+++ b/src/commands/bootstrap-incremental.ts
@@ -7,7 +7,7 @@ import {
   type BootstrapRunner,
 } from '../lib/bootstrap.js';
 import { log } from '../lib/log.js';
-import { findRepoRoot, packageTemplatesDir, repoPaths } from '../lib/paths.js';
+import { ensureStateLayout, findRepoRoot, packageTemplatesDir, repoPaths } from '../lib/paths.js';
 import { resolveSettings } from '../lib/settings.js';
 
 export interface BootstrapIncrementalOptions {
@@ -24,6 +24,7 @@ export async function runBootstrapIncrementalCommand(
 ): Promise<number> {
   const root = findRepoRoot();
   const paths = repoPaths(root);
+  ensureStateLayout(paths);
 
   if (!existsSync(paths.installedVersionFile)) {
     log.error(
@@ -38,7 +39,7 @@ export async function runBootstrapIncrementalCommand(
     return 1;
   }
 
-  const promptTemplate = loadBootstrapPrompt(paths.builderDir);
+  const promptTemplate = loadBootstrapPrompt(paths.stateDir);
   if (!promptTemplate) {
     log.error('Bootstrap-incremental prompt template not found.');
     return 1;
@@ -57,8 +58,8 @@ export async function runBootstrapIncrementalCommand(
     kbDir: paths.kbDir,
     proposedDir: paths.proposedDir,
     logsDir: paths.logsDir,
-    stateFile: join(paths.builderDir, 'state.json'),
-    bootstrapStateFile: join(paths.builderDir, 'bootstrap-state.json'),
+    stateFile: join(paths.stateDir, 'state.json'),
+    bootstrapStateFile: join(paths.stateDir, 'bootstrap-state.json'),
     promptTemplate,
     runner,
     tokenBudget: settings.bootstrapTokenBudget,
@@ -112,8 +113,8 @@ export async function runBootstrapIncrementalCommand(
   }
 }
 
-function loadBootstrapPrompt(builderDir: string): string | null {
-  const local = join(builderDir, 'prompts', 'bootstrap-incremental.md');
+function loadBootstrapPrompt(stateDir: string): string | null {
+  const local = join(stateDir, 'prompts', 'bootstrap-incremental.md');
   if (existsSync(local)) return readFileSync(local, 'utf8');
   const fallback = join(packageTemplatesDir(), 'prompts', 'bootstrap-incremental.md');
   if (existsSync(fallback)) return readFileSync(fallback, 'utf8');

--- a/src/commands/curate.ts
+++ b/src/commands/curate.ts
@@ -3,7 +3,7 @@ import { join } from 'node:path';
 import { ClaudeAdapter } from '../adapters/claude.js';
 import { runCurate, type CuratorRunner } from '../lib/curate.js';
 import { log } from '../lib/log.js';
-import { findRepoRoot, packageTemplatesDir, repoPaths } from '../lib/paths.js';
+import { ensureStateLayout, findRepoRoot, packageTemplatesDir, repoPaths } from '../lib/paths.js';
 import { resolveSettings } from '../lib/settings.js';
 
 export interface CurateCommandOptions {
@@ -15,6 +15,7 @@ export interface CurateCommandOptions {
 export async function runCurateCommand(opts: CurateCommandOptions = {}): Promise<number> {
   const root = findRepoRoot();
   const paths = repoPaths(root);
+  ensureStateLayout(paths);
 
   if (!existsSync(paths.installedVersionFile)) {
     log.error(
@@ -23,7 +24,7 @@ export async function runCurateCommand(opts: CurateCommandOptions = {}): Promise
     return 1;
   }
 
-  const promptTemplate = loadCuratorPrompt(paths.builderDir);
+  const promptTemplate = loadCuratorPrompt(paths.stateDir);
   if (!promptTemplate) {
     log.error('Curator prompt template not found.');
     return 1;
@@ -42,7 +43,7 @@ export async function runCurateCommand(opts: CurateCommandOptions = {}): Promise
     nodesDir: paths.nodesDir,
     proposedDir: paths.proposedDir,
     logsDir: paths.logsDir,
-    stateFile: join(paths.builderDir, 'state.json'),
+    stateFile: join(paths.stateDir, 'state.json'),
     promptTemplate,
     runner,
     lockTtlMs: settings.lockTtlMs,
@@ -72,8 +73,8 @@ export async function runCurateCommand(opts: CurateCommandOptions = {}): Promise
   }
 }
 
-function loadCuratorPrompt(builderDir: string): string | null {
-  const local = join(builderDir, 'prompts', 'curator.md');
+function loadCuratorPrompt(stateDir: string): string | null {
+  const local = join(stateDir, 'prompts', 'curator.md');
   if (existsSync(local)) return readFileSync(local, 'utf8');
   const fallback = join(packageTemplatesDir(), 'prompts', 'curator.md');
   if (existsSync(fallback)) return readFileSync(fallback, 'utf8');

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -5,7 +5,7 @@ import { promisify } from 'node:util';
 import matter from 'gray-matter';
 import { log } from '../lib/log.js';
 import { computeNodesHash, readAllNodes } from '../lib/nodes.js';
-import { findRepoRoot, repoPaths } from '../lib/paths.js';
+import { ensureStateLayout, findRepoRoot, repoPaths } from '../lib/paths.js';
 import { IndexFrontmatterSchema, SettingsSchema } from '../lib/schemas.js';
 import { packageVersion } from '../lib/version.js';
 
@@ -28,13 +28,26 @@ export async function runDoctor(opts: DoctorOptions): Promise<number> {
   const root = findRepoRoot();
   const paths = repoPaths(root);
 
+  // Auto-migrate legacy `.ai/.kb-builder/` state to the new layout. Surface
+  // a notice so the user knows what happened.
+  const migration = ensureStateLayout(paths);
+  if (migration.migrated) {
+    log.success(
+      `state layout migrated: .ai/.kb-builder/ → .ai/knowledge-base/.state/ (${migration.movedEntries.length} entr${migration.movedEntries.length === 1 ? 'y' : 'ies'})`,
+    );
+  }
+
   const checks: NamedCheck[] = [];
   checks.push({ name: 'Node.js >= 22', result: checkNodeVersion() });
   checks.push({ name: 'claude CLI on PATH', result: await checkClaude() });
   checks.push({ name: 'gitleaks on PATH', result: await checkGitleaks() });
   checks.push({
-    name: '.ai/.kb-builder/installed-version',
+    name: '.ai/knowledge-base/.state/installed-version',
     result: checkInstalledVersion(paths.installedVersionFile),
+  });
+  checks.push({
+    name: 'no legacy .ai/.kb-builder/ directory',
+    result: checkLegacyStateDir(paths.legacyStateDir),
   });
   checks.push({
     name: 'installed-version is current',
@@ -63,7 +76,7 @@ export async function runDoctor(opts: DoctorOptions): Promise<number> {
   });
   checks.push({
     name: 'shipped prompts present',
-    result: checkPrompts(paths.builderDir),
+    result: checkPrompts(paths.stateDir),
   });
   checks.push({
     name: 'settings file is valid',
@@ -347,9 +360,22 @@ function checkLegacyKbCommands(commandsDir: string): CheckResult {
   };
 }
 
-function checkPrompts(builderDir: string): CheckResult {
+function checkLegacyStateDir(legacyDir: string): CheckResult {
+  if (!existsSync(legacyDir)) {
+    return { ok: true, detail: 'legacy directory not present' };
+  }
+  return {
+    ok: false,
+    level: 'warn',
+    detail:
+      `legacy .ai/.kb-builder/ still on disk. The auto-migration moves state into .ai/knowledge-base/.state/; ` +
+      'a leftover here usually means a manual mv left an empty husk. Safe to `rm -rf .ai/.kb-builder/`.',
+  };
+}
+
+function checkPrompts(stateDir: string): CheckResult {
   const expected = ['stage-2-extract.md', 'curator.md', 'bootstrap-incremental.md'];
-  const missing = expected.filter((p) => !existsSync(join(builderDir, 'prompts', p)));
+  const missing = expected.filter((p) => !existsSync(join(stateDir, 'prompts', p)));
   if (missing.length === 0) {
     return { ok: true, detail: 'stage-2, curator, bootstrap-incremental' };
   }

--- a/src/commands/index-rebuild.ts
+++ b/src/commands/index-rebuild.ts
@@ -2,7 +2,7 @@ import { existsSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { generateGraph, generateIndex, writeGraph, writeIndex } from '../lib/index-gen.js';
 import { log } from '../lib/log.js';
-import { findRepoRoot, repoPaths } from '../lib/paths.js';
+import { ensureStateLayout, findRepoRoot, repoPaths } from '../lib/paths.js';
 import { resolveSettings } from '../lib/settings.js';
 
 export interface IndexRebuildOptions {
@@ -19,6 +19,7 @@ export interface IndexRebuildOptions {
 export async function runIndexRebuild(opts: IndexRebuildOptions = {}): Promise<number> {
   const root = findRepoRoot();
   const paths = repoPaths(root);
+  ensureStateLayout(paths);
 
   if (!existsSync(paths.installedVersionFile)) {
     log.error(

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -11,7 +11,7 @@ import {
 import { join } from 'node:path';
 import { ClaudeAdapter } from '../adapters/claude.js';
 import { log } from '../lib/log.js';
-import { findRepoRoot, packageTemplatesDir, repoPaths } from '../lib/paths.js';
+import { ensureStateLayout, findRepoRoot, packageTemplatesDir, repoPaths } from '../lib/paths.js';
 import { defaultProjectConfigBody } from '../lib/settings.js';
 import { packageVersion } from '../lib/version.js';
 
@@ -22,12 +22,20 @@ export interface InitOptions {
   dryRun?: boolean;
 }
 
+/**
+ * Layout versions:
+ *   1 = legacy `.ai/.kb-builder/` for state, alongside `.ai/knowledge-base/`.
+ *   2 = state co-located under `.ai/knowledge-base/.state/`.
+ */
+export const CURRENT_LAYOUT_VERSION = 2;
+
 interface InstalledVersion {
   schema_version: 1;
   package: string;
   version: string;
   installed_at: string;
   assistants: string[];
+  layout_version?: number;
 }
 
 const GITIGNORE_BLOCK_START = '# >>> @e0ipso/ai-knowledge-base >>>';
@@ -36,8 +44,8 @@ const GITIGNORE_BLOCK_END = '# <<< @e0ipso/ai-knowledge-base <<<';
 const GITIGNORE_LINES = [
   '.ai/knowledge-base/_sessions/',
   '.ai/knowledge-base/_logs/',
-  '.ai/.kb-builder/state.json',
-  '.ai/.kb-builder/bootstrap-state.json',
+  '.ai/knowledge-base/.state/state.json',
+  '.ai/knowledge-base/.state/bootstrap-state.json',
 ];
 
 const SUPPORTED_ASSISTANTS = new Set(['claude']);
@@ -51,6 +59,15 @@ export async function runInit(opts: InitOptions): Promise<void> {
   if (!existsSync(templatesDir)) {
     throw new Error(
       `Templates directory not found at ${templatesDir}. Run \`npm run build\` if developing locally.`,
+    );
+  }
+
+  // Migrate any legacy `.ai/.kb-builder/` state inline so the rest of the
+  // command sees a single canonical layout.
+  const migration = ensureStateLayout(paths);
+  if (migration.migrated) {
+    log.info(
+      `Migrated legacy state from .ai/.kb-builder/ → .ai/knowledge-base/.state/ (${migration.movedEntries.length} entr${migration.movedEntries.length === 1 ? 'y' : 'ies'}).`,
     );
   }
 
@@ -78,10 +95,10 @@ export async function runInit(opts: InitOptions): Promise<void> {
   // 2. Claude-specific files (commands + settings + hooks).
   await installClaude(opts.assistants, templatesDir, paths.claudeDir, root);
 
-  // 3. Prompts under .ai/.kb-builder/prompts (for local override).
+  // 3. Prompts under .ai/knowledge-base/.state/prompts (for local override).
   const promptsSrc = join(templatesDir, 'prompts');
   if (existsSync(promptsSrc)) {
-    copyTree(promptsSrc, join(paths.builderDir, 'prompts'));
+    copyTree(promptsSrc, join(paths.stateDir, 'prompts'));
   }
 
   // 4. Pre-commit secret-scan config (only if not already present).
@@ -102,7 +119,7 @@ export async function runInit(opts: InitOptions): Promise<void> {
   }
 
   // 7. Write installed-version marker.
-  writeInstalledVersion(paths.installedVersionFile, paths.builderDir, opts.assistants);
+  writeInstalledVersion(paths.installedVersionFile, paths.stateDir, opts.assistants);
 
   log.success('Initialized.');
   log.plain('');
@@ -228,7 +245,7 @@ async function runUpgrade(
   await installClaude(opts.assistants, templatesDir, paths.claudeDir, root);
 
   // Prompts: copy only those missing locally, preserve customized ones.
-  copyPromptsPreservingLocal(join(templatesDir, 'prompts'), join(paths.builderDir, 'prompts'));
+  copyPromptsPreservingLocal(join(templatesDir, 'prompts'), join(paths.stateDir, 'prompts'));
 
   // Gitignore: idempotent block update covers new lines.
   updateGitignore(paths.gitignoreFile);
@@ -242,8 +259,8 @@ async function runUpgrade(
     writeFileSync(paths.projectConfigFile, defaultProjectConfigBody());
   }
 
-  // Stamp the new installed-version.
-  writeInstalledVersion(paths.installedVersionFile, paths.builderDir, opts.assistants);
+  // Stamp the new installed-version (and current layout version).
+  writeInstalledVersion(paths.installedVersionFile, paths.stateDir, opts.assistants);
 
   log.success(`Upgraded to ${current}.`);
   log.plain('Run `ai-knowledge-base doctor` to verify.');
@@ -303,13 +320,16 @@ function collectUpgradeChanges(ctx: UpgradeContext): UpgradeChange[] {
   const promptSrc = join(ctx.templatesDir, 'prompts');
   if (existsSync(promptSrc)) {
     for (const name of readdirSync(promptSrc)) {
-      const dst = join(ctx.paths.builderDir, 'prompts', name);
+      const dst = join(ctx.paths.stateDir, 'prompts', name);
       if (!existsSync(dst)) {
-        out.push({ kind: 'prompt-new', detail: `copy new prompt .ai/.kb-builder/prompts/${name}` });
+        out.push({
+          kind: 'prompt-new',
+          detail: `copy new prompt .ai/knowledge-base/.state/prompts/${name}`,
+        });
       } else if (!filesEqual(join(promptSrc, name), dst)) {
         out.push({
           kind: 'prompt-preserved',
-          detail: `local override preserved: .ai/.kb-builder/prompts/${name}`,
+          detail: `local override preserved: .ai/knowledge-base/.state/prompts/${name}`,
         });
       }
     }
@@ -332,6 +352,11 @@ function collectUpgradeChanges(ctx: UpgradeContext): UpgradeChange[] {
       kind: 'gitignore',
       detail: `add missing .gitignore lines: ${gitignoreState.missingLines.join(', ')}`,
     });
+  } else if (gitignoreState.staleLegacyLines.length > 0) {
+    out.push({
+      kind: 'gitignore',
+      detail: `drop stale legacy lines: ${gitignoreState.staleLegacyLines.join(', ')}`,
+    });
   }
 
   // .config.json: create only if absent.
@@ -347,12 +372,17 @@ function collectUpgradeChanges(ctx: UpgradeContext): UpgradeChange[] {
     out.push({ kind: 'pre-commit-config', detail: 'create .pre-commit-config.yaml' });
   }
 
-  // installed-version stamp.
-  if (ctx.installed.version !== ctx.current) {
-    out.push({
-      kind: 'installed-version',
-      detail: `stamp installed-version: ${ctx.installed.version} → ${ctx.current}`,
-    });
+  // installed-version stamp (version bump or layout_version bump).
+  const installedLayout = ctx.installed.layout_version ?? 1;
+  if (ctx.installed.version !== ctx.current || installedLayout !== CURRENT_LAYOUT_VERSION) {
+    const parts: string[] = [];
+    if (ctx.installed.version !== ctx.current) {
+      parts.push(`version ${ctx.installed.version} → ${ctx.current}`);
+    }
+    if (installedLayout !== CURRENT_LAYOUT_VERSION) {
+      parts.push(`layout_version ${installedLayout} → ${CURRENT_LAYOUT_VERSION}`);
+    }
+    out.push({ kind: 'installed-version', detail: `stamp installed-version: ${parts.join(', ')}` });
   }
 
   return out;
@@ -361,7 +391,15 @@ function collectUpgradeChanges(ctx: UpgradeContext): UpgradeChange[] {
 interface GitignoreState {
   blockPresent: boolean;
   missingLines: string[];
+  staleLegacyLines: string[];
 }
+
+// Lines that used to be inside the managed block but no longer apply.
+// They're scrubbed on `updateGitignore`.
+const STALE_LEGACY_GITIGNORE_LINES = [
+  '.ai/.kb-builder/state.json',
+  '.ai/.kb-builder/bootstrap-state.json',
+];
 
 const EXPECTED_HOOK_COMMANDS: Array<{ event: string; command: string; async?: boolean }> = [
   { event: 'Stop', command: 'KB_BUILDER_HOOK=Stop node .claude/hooks/kb-capture.mjs' },
@@ -400,11 +438,14 @@ function hookRegistrationsNeedRefresh(settingsFile: string): boolean {
 }
 
 function inspectGitignore(file: string): GitignoreState {
-  if (!existsSync(file)) return { blockPresent: false, missingLines: GITIGNORE_LINES.slice() };
+  if (!existsSync(file)) {
+    return { blockPresent: false, missingLines: GITIGNORE_LINES.slice(), staleLegacyLines: [] };
+  }
   const body = readFileSync(file, 'utf8');
   const blockPresent = body.includes(GITIGNORE_BLOCK_START);
   const missing = GITIGNORE_LINES.filter((line) => !body.includes(line));
-  return { blockPresent, missingLines: missing };
+  const stale = STALE_LEGACY_GITIGNORE_LINES.filter((line) => body.includes(line));
+  return { blockPresent, missingLines: missing, staleLegacyLines: stale };
 }
 
 function skillDirsEqual(src: string, dst: string): boolean {
@@ -479,15 +520,16 @@ async function installClaude(
   ]);
 }
 
-function writeInstalledVersion(file: string, builderDir: string, assistants: string[]): void {
+function writeInstalledVersion(file: string, stateDir: string, assistants: string[]): void {
   const installed: InstalledVersion = {
     schema_version: 1,
     package: '@e0ipso/ai-knowledge-base',
     version: packageVersion(),
     installed_at: new Date().toISOString(),
     assistants,
+    layout_version: CURRENT_LAYOUT_VERSION,
   };
-  mkdirSync(builderDir, { recursive: true });
+  mkdirSync(stateDir, { recursive: true });
   writeFileSync(file, `${JSON.stringify(installed, null, 2)}\n`);
 }
 
@@ -513,7 +555,7 @@ function installPreCommitConfig(target: string, templatesDir: string): void {
 function updateGitignore(file: string): void {
   const existing = existsSync(file) ? readFileSync(file, 'utf8') : '';
   if (existing.includes(GITIGNORE_BLOCK_START)) {
-    // Update in place.
+    // Update in place: replace the managed block entirely.
     const before = existing.slice(0, existing.indexOf(GITIGNORE_BLOCK_START));
     const afterStart = existing.indexOf(GITIGNORE_BLOCK_END);
     const after = afterStart >= 0 ? existing.slice(afterStart + GITIGNORE_BLOCK_END.length) : '';

--- a/src/commands/logs-prune.ts
+++ b/src/commands/logs-prune.ts
@@ -1,7 +1,7 @@
 import { existsSync } from 'node:fs';
 import { log } from '../lib/log.js';
 import { LOG_BUCKETS, formatBytes, parseDurationMs, pruneLogs } from '../lib/logs-prune.js';
-import { findRepoRoot, repoPaths } from '../lib/paths.js';
+import { ensureStateLayout, findRepoRoot, repoPaths } from '../lib/paths.js';
 import { resolveSettings } from '../lib/settings.js';
 
 export interface LogsPruneOptions {
@@ -12,6 +12,7 @@ export interface LogsPruneOptions {
 export async function runLogsPrune(opts: LogsPruneOptions = {}): Promise<number> {
   const root = findRepoRoot();
   const paths = repoPaths(root);
+  ensureStateLayout(paths);
 
   if (!existsSync(paths.installedVersionFile)) {
     log.error(

--- a/src/commands/node-add.ts
+++ b/src/commands/node-add.ts
@@ -9,7 +9,7 @@ import {
   readAllNodes,
   writeProposalFile,
 } from '../lib/nodes.js';
-import { findRepoRoot, repoPaths } from '../lib/paths.js';
+import { ensureStateLayout, findRepoRoot, repoPaths } from '../lib/paths.js';
 import type { Confidence, NodeKind, ProposalFrontmatter } from '../lib/schemas.js';
 
 export interface NodeAddOptions {
@@ -30,6 +30,7 @@ export interface NodeAddOptions {
 export async function runNodeAdd(opts: NodeAddOptions = {}): Promise<number> {
   const root = findRepoRoot();
   const paths = repoPaths(root);
+  ensureStateLayout(paths);
   if (!existsSync(paths.installedVersionFile)) {
     log.error(
       'ai-knowledge-base is not initialized in this repo. Run `ai-knowledge-base init --assistants claude`.',

--- a/src/commands/proposals-review.ts
+++ b/src/commands/proposals-review.ts
@@ -4,7 +4,7 @@ import matter from 'gray-matter';
 import { confirm, select } from '@inquirer/prompts';
 import { log } from '../lib/log.js';
 import { listProposalFiles, readProposalFile } from '../lib/nodes.js';
-import { findRepoRoot, repoPaths } from '../lib/paths.js';
+import { ensureStateLayout, findRepoRoot, repoPaths } from '../lib/paths.js';
 import { ProposalFrontmatterSchema, type ProposalFrontmatter } from '../lib/schemas.js';
 
 export interface ProposalsReviewOptions {
@@ -30,6 +30,7 @@ interface DiscoveredProposal {
 export async function runProposalsReview(opts: ProposalsReviewOptions = {}): Promise<number> {
   const root = findRepoRoot();
   const paths = repoPaths(root);
+  ensureStateLayout(paths);
 
   const discovered = discoverProposals(paths.proposedDir);
   if (discovered.length === 0) {

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -2,7 +2,7 @@ import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 import matter from 'gray-matter';
 import { log } from '../lib/log.js';
-import { findRepoRoot, repoPaths } from '../lib/paths.js';
+import { ensureStateLayout, findRepoRoot, repoPaths } from '../lib/paths.js';
 
 interface QueueFile {
   entries?: Array<{ session_id: string; attempts?: number }>;
@@ -11,6 +11,7 @@ interface QueueFile {
 export async function runStatus(): Promise<void> {
   const root = findRepoRoot();
   const paths = repoPaths(root);
+  ensureStateLayout(paths);
 
   if (!existsSync(paths.installedVersionFile)) {
     log.warn(

--- a/src/hooks/kb-capture.ts
+++ b/src/hooks/kb-capture.ts
@@ -7,7 +7,7 @@
  * blocking session shutdown.
  */
 import { captureSession, type HookInput } from '../lib/capture.js';
-import { findRepoRoot, repoPaths } from '../lib/paths.js';
+import { ensureStateLayout, findRepoRoot, repoPaths } from '../lib/paths.js';
 
 const HARD_DEADLINE_MS = 1000;
 const PACKAGE_TAG = '[ai-knowledge-base]';
@@ -36,6 +36,7 @@ async function main(): Promise<void> {
     typeof input.cwd === 'string' && input.cwd.length > 0 ? input.cwd : process.cwd();
   const root = findRepoRoot(startCwd);
   const paths = repoPaths(root);
+  ensureStateLayout(paths);
 
   try {
     const result = await captureSession(input, { sessionsDir: paths.sessionsDir });

--- a/src/hooks/kb-session-start.ts
+++ b/src/hooks/kb-session-start.ts
@@ -13,7 +13,7 @@
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { buildSessionStartContext } from '../lib/session-start.js';
-import { findRepoRoot, repoPaths } from '../lib/paths.js';
+import { ensureStateLayout, findRepoRoot, repoPaths } from '../lib/paths.js';
 import { resolveSettings } from '../lib/settings.js';
 
 const PACKAGE_TAG = '[ai-knowledge-base]';
@@ -43,6 +43,7 @@ async function main(): Promise<void> {
     typeof input.cwd === 'string' && input.cwd.length > 0 ? input.cwd : process.cwd();
   const root = findRepoRoot(startCwd);
   const paths = repoPaths(root);
+  ensureStateLayout(paths);
   if (!existsSync(paths.installedVersionFile)) return;
 
   try {
@@ -51,7 +52,7 @@ async function main(): Promise<void> {
       kbDir: paths.kbDir,
       nodesDir: paths.nodesDir,
       sessionsDir: paths.sessionsDir,
-      stateFile: join(paths.builderDir, 'state.json'),
+      stateFile: join(paths.stateDir, 'state.json'),
       threshold: settings.curationThreshold,
     });
     process.stdout.write(

--- a/src/hooks/kb-stage2-drain.ts
+++ b/src/hooks/kb-stage2-drain.ts
@@ -12,7 +12,7 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { runHeadlessClaude } from '../lib/headless.js';
-import { findRepoRoot, packageTemplatesDir, repoPaths } from '../lib/paths.js';
+import { ensureStateLayout, findRepoRoot, packageTemplatesDir, repoPaths } from '../lib/paths.js';
 import { resolveSettings } from '../lib/settings.js';
 import { drainStage2Queue, type Stage2Runner } from '../lib/stage2-drain.js';
 
@@ -37,9 +37,10 @@ async function main(): Promise<void> {
     typeof input.cwd === 'string' && input.cwd.length > 0 ? input.cwd : process.cwd();
   const root = findRepoRoot(startCwd);
   const paths = repoPaths(root);
+  ensureStateLayout(paths);
   if (!existsSync(paths.installedVersionFile)) return;
 
-  const promptTemplate = loadStage2Prompt(root);
+  const promptTemplate = loadStage2Prompt(paths.stateDir);
   if (!promptTemplate) {
     process.stderr.write(`${PACKAGE_TAG} stage-2 prompt template not found; skipping drain\n`);
     return;
@@ -53,7 +54,7 @@ async function main(): Promise<void> {
     const summary = await drainStage2Queue({
       sessionsDir: paths.sessionsDir,
       logsDir: paths.logsDir,
-      stateFile: join(paths.builderDir, 'state.json'),
+      stateFile: join(paths.stateDir, 'state.json'),
       promptTemplate,
       runner,
       maxEntries: settings.drainBound,
@@ -80,10 +81,10 @@ async function main(): Promise<void> {
   }
 }
 
-function loadStage2Prompt(repoRoot: string): string | null {
+function loadStage2Prompt(stateDir: string): string | null {
   // Prefer the per-repo override written by `init`; fall back to the
   // template bundled with the npm package.
-  const override = join(repoRoot, '.ai/.kb-builder/prompts/stage-2-extract.md');
+  const override = join(stateDir, 'prompts/stage-2-extract.md');
   if (existsSync(override)) return readFileSync(override, 'utf8');
   const bundled = join(packageTemplatesDir(), 'prompts/stage-2-extract.md');
   if (existsSync(bundled)) return readFileSync(bundled, 'utf8');

--- a/src/lib/bootstrap.ts
+++ b/src/lib/bootstrap.ts
@@ -45,9 +45,9 @@ export interface BootstrapContext {
   proposedDir: string;
   /** `_logs/` directory. */
   logsDir: string;
-  /** Path to `.ai/.kb-builder/state.json`. */
+  /** Path to `.ai/knowledge-base/.state/state.json`. */
   stateFile: string;
-  /** Path to `.ai/.kb-builder/bootstrap-state.json`. */
+  /** Path to `.ai/knowledge-base/.state/bootstrap-state.json`. */
   bootstrapStateFile: string;
   /** Bootstrap-incremental prompt body. */
   promptTemplate: string;

--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -1,4 +1,13 @@
-import { existsSync, readFileSync } from 'node:fs';
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  statSync,
+} from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -17,14 +26,16 @@ export function packageTemplatesDir(): string {
 
 /**
  * Walks upward from `from` looking for a directory containing a `.git`
- * folder (or the marker file `.ai/.kb-builder/installed-version`). Falls
- * back to `from` if neither is found.
+ * folder or either of the package's install markers (new layout under
+ * `.ai/knowledge-base/.state/` or legacy under `.ai/.kb-builder/`).
+ * Falls back to `from` if none are found.
  */
 export function findRepoRoot(from: string = process.cwd()): string {
   let cur = resolve(from);
   while (true) {
     if (
       existsSync(join(cur, '.git')) ||
+      existsSync(join(cur, '.ai/knowledge-base/.state/installed-version')) ||
       existsSync(join(cur, '.ai/.kb-builder/installed-version'))
     ) {
       return cur;
@@ -39,8 +50,19 @@ export interface RepoPaths {
   root: string;
   aiDir: string;
   kbDir: string;
-  builderDir: string;
+  /**
+   * State directory under the KB root: `.ai/knowledge-base/.state/`.
+   * Holds the installed-version marker, lock/nudge state, bootstrap state,
+   * and local prompt overrides.
+   */
+  stateDir: string;
+  /**
+   * Legacy state directory `.ai/.kb-builder/` — only used for detection
+   * and migration. New installs never write here.
+   */
+  legacyStateDir: string;
   installedVersionFile: string;
+  legacyInstalledVersionFile: string;
   projectConfigFile: string;
   sessionsDir: string;
   proposedDir: string;
@@ -58,14 +80,17 @@ export interface RepoPaths {
 export function repoPaths(root: string): RepoPaths {
   const aiDir = join(root, '.ai');
   const kbDir = join(aiDir, 'knowledge-base');
-  const builderDir = join(aiDir, '.kb-builder');
+  const stateDir = join(kbDir, '.state');
+  const legacyStateDir = join(aiDir, '.kb-builder');
   const claudeDir = join(root, '.claude');
   return {
     root,
     aiDir,
     kbDir,
-    builderDir,
-    installedVersionFile: join(builderDir, 'installed-version'),
+    stateDir,
+    legacyStateDir,
+    installedVersionFile: join(stateDir, 'installed-version'),
+    legacyInstalledVersionFile: join(legacyStateDir, 'installed-version'),
     projectConfigFile: join(kbDir, '.config.json'),
     sessionsDir: join(kbDir, '_sessions'),
     proposedDir: join(kbDir, '_proposed'),
@@ -84,4 +109,88 @@ export function repoPaths(root: string): RepoPaths {
 export function readJsonIfExists<T = unknown>(file: string): T | null {
   if (!existsSync(file)) return null;
   return JSON.parse(readFileSync(file, 'utf8')) as T;
+}
+
+export interface MigrationResult {
+  migrated: boolean;
+  movedEntries: string[];
+}
+
+/**
+ * Idempotently migrates a legacy `.ai/.kb-builder/` install to the new
+ * `.ai/knowledge-base/.state/` layout. Safe to call on every CLI/hook
+ * entry — returns `{ migrated: false }` quickly when nothing to do.
+ *
+ * Behavior:
+ *   - If the legacy directory does not exist, no-op.
+ *   - Otherwise: moves every entry into `stateDir` (creating it if needed).
+ *     If both old and new versions of a file/dir exist, the new one wins
+ *     (caller is mid-migration and has fresher data).
+ *   - Removes the now-empty legacy directory.
+ */
+export function migrateLegacyState(paths: RepoPaths): MigrationResult {
+  if (!existsSync(paths.legacyStateDir)) {
+    return { migrated: false, movedEntries: [] };
+  }
+  const entries = readdirSync(paths.legacyStateDir);
+  if (entries.length === 0) {
+    // Empty legacy dir — just remove the husk.
+    try {
+      rmSync(paths.legacyStateDir, { recursive: true, force: true });
+    } catch {
+      // ignore — best-effort cleanup
+    }
+    return { migrated: false, movedEntries: [] };
+  }
+  mkdirSync(paths.stateDir, { recursive: true });
+  const moved: string[] = [];
+  for (const name of entries) {
+    const src = join(paths.legacyStateDir, name);
+    const dst = join(paths.stateDir, name);
+    if (existsSync(dst)) {
+      // New location already has this entry — keep the newer one, drop the legacy.
+      try {
+        rmSync(src, { recursive: true, force: true });
+      } catch {
+        // ignore
+      }
+      continue;
+    }
+    try {
+      renameSync(src, dst);
+    } catch {
+      // Cross-device or other rename failure — fall back to copy+remove.
+      try {
+        cpSync(src, dst, { recursive: true });
+        rmSync(src, { recursive: true, force: true });
+      } catch {
+        continue;
+      }
+    }
+    moved.push(name);
+  }
+  try {
+    rmSync(paths.legacyStateDir, { recursive: true, force: true });
+  } catch {
+    // ignore — best-effort
+  }
+  return { migrated: moved.length > 0, movedEntries: moved };
+}
+
+/**
+ * Returns the resolved state directory. Performs an inline migration if
+ * legacy state exists. Cheap when nothing to migrate.
+ */
+export function ensureStateLayout(paths: RepoPaths): MigrationResult {
+  return migrateLegacyState(paths);
+}
+
+// Re-export for convenience: callers usually want a `statSync` check on
+// directory existence rather than importing fs themselves.
+export function isDir(p: string): boolean {
+  try {
+    return statSync(p).isDirectory();
+  } catch {
+    return false;
+  }
 }

--- a/src/templates-source/claude/skills/kb-bootstrap/SKILL.md
+++ b/src/templates-source/claude/skills/kb-bootstrap/SKILL.md
@@ -106,7 +106,7 @@ If a candidate is sourced from multiple docs (you found the same convention disc
 
 ### 6. Track state
 
-After writing proposals, update `.ai/.kb-builder/bootstrap-state.json`. For every doc you read (even ones that produced zero candidates), record its content SHA-256 and the timestamp. This lets future `bootstrap-incremental` runs skip unchanged files.
+After writing proposals, update `.ai/knowledge-base/.state/bootstrap-state.json`. For every doc you read (even ones that produced zero candidates), record its content SHA-256 and the timestamp. This lets future `bootstrap-incremental` runs skip unchanged files.
 
 Schema:
 

--- a/src/templates-source/claude/skills/kb-curate/SKILL.md
+++ b/src/templates-source/claude/skills/kb-curate/SKILL.md
@@ -11,7 +11,7 @@ Run the curator over pending session logs and turn them into reviewable proposal
 ## What to do
 
 1. Run `ai-knowledge-base curate` in the project root. The command:
-   - Acquires the curator lock (`.ai/.kb-builder/state.json`, name=`curator`, PID + 30-min TTL).
+   - Acquires the curator lock (`.ai/knowledge-base/.state/state.json`, name=`curator`, PID + 30-min TTL).
    - Batches every session log whose `stage_2_status: done` and which has not yet been curated.
    - Spawns `claude -p` per batch with the curator prompt (no recursion: `KB_BUILDER_INTERNAL=1`).
    - Writes proposals under `.ai/knowledge-base/_proposed/{additions,modifications,contradictions}/`.

--- a/tests/commands/node-add.test.ts
+++ b/tests/commands/node-add.test.ts
@@ -16,9 +16,9 @@ import { runNodeAdd } from '../../src/commands/node-add.js';
 function sandbox(): string {
   const root = mkdtempSync(join(tmpdir(), 'kb-nodeadd-'));
   mkdirSync(join(root, '.git'), { recursive: true });
-  mkdirSync(join(root, '.ai/.kb-builder'), { recursive: true });
+  mkdirSync(join(root, '.ai/knowledge-base/.state'), { recursive: true });
   writeFileSync(
-    join(root, '.ai/.kb-builder/installed-version'),
+    join(root, '.ai/knowledge-base/.state/installed-version'),
     JSON.stringify({
       schema_version: 1,
       package: '@e0ipso/ai-knowledge-base',

--- a/tests/commands/proposals-review.test.ts
+++ b/tests/commands/proposals-review.test.ts
@@ -17,9 +17,9 @@ import type { ProposalFrontmatter } from '../../src/lib/schemas.js';
 function sandbox(): string {
   const root = mkdtempSync(join(tmpdir(), 'kb-review-'));
   mkdirSync(join(root, '.git'), { recursive: true });
-  mkdirSync(join(root, '.ai/.kb-builder'), { recursive: true });
+  mkdirSync(join(root, '.ai/knowledge-base/.state'), { recursive: true });
   writeFileSync(
-    join(root, '.ai/.kb-builder/installed-version'),
+    join(root, '.ai/knowledge-base/.state/installed-version'),
     JSON.stringify({
       schema_version: 1,
       package: '@e0ipso/ai-knowledge-base',

--- a/tests/e2e/full-cycle.test.ts
+++ b/tests/e2e/full-cycle.test.ts
@@ -51,7 +51,7 @@ describe.skipIf(!ENABLED)('e2e: full capture → drain → curate → review cyc
       const logsDir = join(kbDir, '_logs');
       const proposedDir = join(kbDir, '_proposed');
       const nodesDir = join(kbDir, 'nodes');
-      const stateFile = join(sandbox, '.ai/.kb-builder/state.json');
+      const stateFile = join(sandbox, '.ai/knowledge-base/.state/state.json');
 
       // 1. Plant a session log + queue entry pointing at the bravo-insider fixture.
       const transcript = readFileSync(fixtureTranscriptPath, 'utf8');
@@ -112,7 +112,7 @@ describe.skipIf(!ENABLED)('e2e: full capture → drain → curate → review cyc
         adapter.runHeadless(prompt, stdin, schema, opts);
 
       const stage2Prompt = readFileSync(
-        join(sandbox, '.ai/.kb-builder/prompts/stage-2-extract.md'),
+        join(sandbox, '.ai/knowledge-base/.state/prompts/stage-2-extract.md'),
         'utf8',
       );
 
@@ -137,7 +137,7 @@ describe.skipIf(!ENABLED)('e2e: full capture → drain → curate → review cyc
       const curatorRunner: CuratorRunner = (prompt, stdin, schema, opts) =>
         adapter.runHeadless(prompt, stdin, schema, opts);
       const curatorPrompt = readFileSync(
-        join(sandbox, '.ai/.kb-builder/prompts/curator.md'),
+        join(sandbox, '.ai/knowledge-base/.state/prompts/curator.md'),
         'utf8',
       );
 

--- a/tests/init.test.ts
+++ b/tests/init.test.ts
@@ -42,10 +42,10 @@ describe('init', () => {
       '.claude/hooks/kb-capture.mjs',
       '.claude/hooks/kb-stage2-drain.mjs',
       '.claude/hooks/kb-session-start.mjs',
-      '.ai/.kb-builder/installed-version',
-      '.ai/.kb-builder/prompts/stage-2-extract.md',
-      '.ai/.kb-builder/prompts/curator.md',
-      '.ai/.kb-builder/prompts/bootstrap-incremental.md',
+      '.ai/knowledge-base/.state/installed-version',
+      '.ai/knowledge-base/.state/prompts/stage-2-extract.md',
+      '.ai/knowledge-base/.state/prompts/curator.md',
+      '.ai/knowledge-base/.state/prompts/bootstrap-incremental.md',
       '.ai/knowledge-base/.config.json',
       '.pre-commit-config.yaml',
       '.gitignore',
@@ -61,7 +61,7 @@ describe('init', () => {
     expect(result.exitCode).toBe(0);
 
     const installed = JSON.parse(
-      readFileSync(join(sandbox, '.ai/.kb-builder/installed-version'), 'utf8'),
+      readFileSync(join(sandbox, '.ai/knowledge-base/.state/installed-version'), 'utf8'),
     );
     expect(installed.schema_version).toBe(1);
     expect(installed.package).toBe('@e0ipso/ai-knowledge-base');
@@ -69,6 +69,7 @@ describe('init', () => {
     expect(installed.version.length).toBeGreaterThan(0);
     expect(installed.assistants).toEqual(['claude']);
     expect(typeof installed.installed_at).toBe('string');
+    expect(installed.layout_version).toBe(2);
   });
 
   it('appends an idempotent block to .gitignore', async () => {
@@ -180,11 +181,7 @@ describe('init', () => {
 
   it('ships the rename — no references to the old `kb-builder` binary in copied prompts', async () => {
     await runCli(sandbox, ['init', '--assistants', 'claude']);
-    const skill = readFileSync(
-      join(sandbox, '.claude/skills/kb-bootstrap/SKILL.md'),
-      'utf8',
-    );
-    // The on-disk dir `.ai/.kb-builder/` is kept; only the command name was renamed.
+    const skill = readFileSync(join(sandbox, '.claude/skills/kb-bootstrap/SKILL.md'), 'utf8');
     expect(skill).not.toMatch(/\bkb-builder proposals/);
     expect(skill).toContain('ai-knowledge-base proposals review');
   });
@@ -213,5 +210,56 @@ describe('init', () => {
     expect(existsSync(join(sandbox, '.claude/skills/kb-add/SKILL.md'))).toBe(true);
     expect(existsSync(join(sandbox, '.claude/skills/kb-bootstrap/SKILL.md'))).toBe(true);
     expect(existsSync(join(sandbox, '.claude/skills/kb-curate/SKILL.md'))).toBe(true);
+  });
+
+  it('does not create the legacy `.ai/.kb-builder/` directory for fresh installs', async () => {
+    await runCli(sandbox, ['init', '--assistants', 'claude']);
+    expect(existsSync(join(sandbox, '.ai/.kb-builder'))).toBe(false);
+    expect(existsSync(join(sandbox, '.ai/knowledge-base/.state'))).toBe(true);
+  });
+
+  it('migrates a legacy `.ai/.kb-builder/` install to `.ai/knowledge-base/.state/`', async () => {
+    // Simulate a legacy install: state files live under .ai/.kb-builder/.
+    const { mkdirSync } = await import('node:fs');
+    mkdirSync(join(sandbox, '.ai/.kb-builder/prompts'), { recursive: true });
+    writeFileSync(
+      join(sandbox, '.ai/.kb-builder/installed-version'),
+      JSON.stringify(
+        {
+          schema_version: 1,
+          package: '@e0ipso/ai-knowledge-base',
+          version: '0.0.0-test-legacy',
+          installed_at: '2026-01-01T00:00:00Z',
+          assistants: ['claude'],
+        },
+        null,
+        2,
+      ),
+    );
+    writeFileSync(
+      join(sandbox, '.ai/.kb-builder/state.json'),
+      JSON.stringify({ schema_version: 1, last_nudged_at: '2026-01-01T00:00:00Z' }),
+    );
+    writeFileSync(
+      join(sandbox, '.ai/.kb-builder/bootstrap-state.json'),
+      JSON.stringify({ schema_version: 1, docs: {} }),
+    );
+    writeFileSync(join(sandbox, '.ai/.kb-builder/prompts/curator.md'), '# legacy local override\n');
+
+    // Doctor auto-migrates.
+    const result = await runCli(sandbox, ['doctor']);
+    // Exit code is non-fatal (warnings only); migration message present.
+    expect(result.stdout + result.stderr).toMatch(/state layout migrated/i);
+
+    // New layout exists.
+    expect(existsSync(join(sandbox, '.ai/knowledge-base/.state/installed-version'))).toBe(true);
+    expect(existsSync(join(sandbox, '.ai/knowledge-base/.state/state.json'))).toBe(true);
+    expect(existsSync(join(sandbox, '.ai/knowledge-base/.state/bootstrap-state.json'))).toBe(true);
+    expect(
+      readFileSync(join(sandbox, '.ai/knowledge-base/.state/prompts/curator.md'), 'utf8'),
+    ).toBe('# legacy local override\n');
+
+    // Legacy directory is removed.
+    expect(existsSync(join(sandbox, '.ai/.kb-builder'))).toBe(false);
   });
 });

--- a/tests/lib/bootstrap.test.ts
+++ b/tests/lib/bootstrap.test.ts
@@ -48,8 +48,8 @@ function makeHarness(): Harness {
   const kbDir = join(root, '.ai/knowledge-base');
   const proposedDir = join(kbDir, '_proposed');
   const logsDir = join(kbDir, '_logs');
-  const stateFile = join(root, '.ai/.kb-builder/state.json');
-  const bootstrapStateFile = join(root, '.ai/.kb-builder/bootstrap-state.json');
+  const stateFile = join(root, '.ai/knowledge-base/.state/state.json');
+  const bootstrapStateFile = join(root, '.ai/knowledge-base/.state/bootstrap-state.json');
   mkdirSync(sourceDir, { recursive: true });
   mkdirSync(proposedDir, { recursive: true });
   mkdirSync(logsDir, { recursive: true });

--- a/tests/lib/curate.test.ts
+++ b/tests/lib/curate.test.ts
@@ -40,7 +40,7 @@ function makeHarness(): Harness {
   const nodesDir = join(kbDir, 'nodes');
   const proposedDir = join(kbDir, '_proposed');
   const logsDir = join(kbDir, '_logs');
-  const stateFile = join(root, '.ai/.kb-builder/state.json');
+  const stateFile = join(root, '.ai/knowledge-base/.state/state.json');
   mkdirSync(sessionsDir, { recursive: true });
   mkdirSync(nodesDir, { recursive: true });
   mkdirSync(proposedDir, { recursive: true });

--- a/tests/lib/paths.test.ts
+++ b/tests/lib/paths.test.ts
@@ -1,0 +1,74 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { ensureStateLayout, migrateLegacyState, repoPaths } from '../../src/lib/paths.js';
+
+describe('paths: state layout migration', () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'kb-paths-'));
+  });
+
+  afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+  it('is a no-op when no legacy directory exists', () => {
+    const paths = repoPaths(root);
+    const result = ensureStateLayout(paths);
+    expect(result.migrated).toBe(false);
+    expect(result.movedEntries).toEqual([]);
+    expect(existsSync(paths.stateDir)).toBe(false);
+  });
+
+  it('moves every legacy entry to the new state dir', () => {
+    const paths = repoPaths(root);
+    mkdirSync(paths.legacyStateDir, { recursive: true });
+    writeFileSync(paths.legacyInstalledVersionFile, '{"version":"x"}');
+    writeFileSync(join(paths.legacyStateDir, 'state.json'), '{"schema_version":1}');
+    mkdirSync(join(paths.legacyStateDir, 'prompts'), { recursive: true });
+    writeFileSync(join(paths.legacyStateDir, 'prompts/curator.md'), '# local\n');
+
+    const result = ensureStateLayout(paths);
+    expect(result.migrated).toBe(true);
+    expect(result.movedEntries.sort()).toEqual(
+      ['installed-version', 'prompts', 'state.json'].sort(),
+    );
+    expect(existsSync(paths.legacyStateDir)).toBe(false);
+    expect(readFileSync(paths.installedVersionFile, 'utf8')).toBe('{"version":"x"}');
+    expect(readFileSync(join(paths.stateDir, 'prompts/curator.md'), 'utf8')).toBe('# local\n');
+  });
+
+  it('prefers existing entries in the new state dir over legacy duplicates', () => {
+    const paths = repoPaths(root);
+    mkdirSync(paths.stateDir, { recursive: true });
+    writeFileSync(paths.installedVersionFile, '{"version":"new"}');
+    mkdirSync(paths.legacyStateDir, { recursive: true });
+    writeFileSync(paths.legacyInstalledVersionFile, '{"version":"old"}');
+
+    const result = migrateLegacyState(paths);
+    // Nothing was moved because the new file already exists; legacy is dropped.
+    expect(result.movedEntries).toEqual([]);
+    expect(readFileSync(paths.installedVersionFile, 'utf8')).toBe('{"version":"new"}');
+    expect(existsSync(paths.legacyStateDir)).toBe(false);
+  });
+
+  it('removes an empty legacy directory', () => {
+    const paths = repoPaths(root);
+    mkdirSync(paths.legacyStateDir, { recursive: true });
+    const result = migrateLegacyState(paths);
+    expect(result.migrated).toBe(false);
+    expect(existsSync(paths.legacyStateDir)).toBe(false);
+  });
+
+  it('is idempotent: running twice is safe', () => {
+    const paths = repoPaths(root);
+    mkdirSync(paths.legacyStateDir, { recursive: true });
+    writeFileSync(paths.legacyInstalledVersionFile, '{"version":"x"}');
+    ensureStateLayout(paths);
+    const second = ensureStateLayout(paths);
+    expect(second.migrated).toBe(false);
+    expect(second.movedEntries).toEqual([]);
+    expect(existsSync(paths.installedVersionFile)).toBe(true);
+  });
+});

--- a/tests/lib/session-start.test.ts
+++ b/tests/lib/session-start.test.ts
@@ -24,7 +24,7 @@ function makeHarness(): Harness {
   const kbDir = join(root, '.ai/knowledge-base');
   const nodesDir = join(kbDir, 'nodes');
   const sessionsDir = join(kbDir, '_sessions');
-  const stateFile = join(root, '.ai/.kb-builder/state.json');
+  const stateFile = join(root, '.ai/knowledge-base/.state/state.json');
   mkdirSync(join(nodesDir, 'practice'), { recursive: true });
   mkdirSync(join(nodesDir, 'map'), { recursive: true });
   mkdirSync(sessionsDir, { recursive: true });

--- a/tests/lib/stage2-drain.test.ts
+++ b/tests/lib/stage2-drain.test.ts
@@ -24,7 +24,7 @@ function makeHarness(): Harness {
   const root = mkdtempSync(join(tmpdir(), 'kb-drain-'));
   const sessionsDir = join(root, '.ai/knowledge-base/_sessions');
   const logsDir = join(root, '.ai/knowledge-base/_logs');
-  const stateFile = join(root, '.ai/.kb-builder/state.json');
+  const stateFile = join(root, '.ai/knowledge-base/.state/state.json');
   mkdirSync(sessionsDir, { recursive: true });
   mkdirSync(logsDir, { recursive: true });
   mkdirSync(dirname(stateFile), { recursive: true });

--- a/tests/lib/state.test.ts
+++ b/tests/lib/state.test.ts
@@ -10,7 +10,7 @@ describe('state.json lock', () => {
 
   beforeEach(() => {
     dir = mkdtempSync(join(tmpdir(), 'kb-state-'));
-    file = join(dir, '.kb-builder', 'state.json');
+    file = join(dir, '.state', 'state.json');
   });
 
   afterEach(() => rmSync(dir, { recursive: true, force: true }));

--- a/tests/upgrade.test.ts
+++ b/tests/upgrade.test.ts
@@ -34,7 +34,7 @@ describe('init --upgrade', () => {
     await runCli(sandbox, ['init', '--assistants', 'claude']);
 
     // Simulate an older installed version.
-    const versionFile = join(sandbox, '.ai/.kb-builder/installed-version');
+    const versionFile = join(sandbox, '.ai/knowledge-base/.state/installed-version');
     const installed = JSON.parse(readFileSync(versionFile, 'utf8'));
     const beforeInstalled = installed.installed_at;
     installed.version = '0.0.0-test-old';
@@ -66,7 +66,7 @@ describe('init --upgrade', () => {
     writeFileSync(configFile, customized);
 
     // Mark installed-version older so upgrade applies.
-    const versionFile = join(sandbox, '.ai/.kb-builder/installed-version');
+    const versionFile = join(sandbox, '.ai/knowledge-base/.state/installed-version');
     const installed = JSON.parse(readFileSync(versionFile, 'utf8'));
     installed.version = '0.0.0-test-old';
     writeFileSync(versionFile, JSON.stringify(installed, null, 2) + '\n');
@@ -89,10 +89,10 @@ describe('init --upgrade', () => {
   it('preserves a customized local prompt override', async () => {
     await runCli(sandbox, ['init', '--assistants', 'claude']);
 
-    const promptFile = join(sandbox, '.ai/.kb-builder/prompts/stage-2-extract.md');
+    const promptFile = join(sandbox, '.ai/knowledge-base/.state/prompts/stage-2-extract.md');
     writeFileSync(promptFile, '# my local override\n');
 
-    const versionFile = join(sandbox, '.ai/.kb-builder/installed-version');
+    const versionFile = join(sandbox, '.ai/knowledge-base/.state/installed-version');
     const installed = JSON.parse(readFileSync(versionFile, 'utf8'));
     installed.version = '0.0.0-test-old';
     writeFileSync(versionFile, JSON.stringify(installed, null, 2) + '\n');
@@ -106,10 +106,10 @@ describe('init --upgrade', () => {
   it('re-copies a missing prompt during upgrade', async () => {
     await runCli(sandbox, ['init', '--assistants', 'claude']);
 
-    const promptFile = join(sandbox, '.ai/.kb-builder/prompts/stage-2-extract.md');
+    const promptFile = join(sandbox, '.ai/knowledge-base/.state/prompts/stage-2-extract.md');
     rmSync(promptFile);
 
-    const versionFile = join(sandbox, '.ai/.kb-builder/installed-version');
+    const versionFile = join(sandbox, '.ai/knowledge-base/.state/installed-version');
     const installed = JSON.parse(readFileSync(versionFile, 'utf8'));
     installed.version = '0.0.0-test-old';
     writeFileSync(versionFile, JSON.stringify(installed, null, 2) + '\n');
@@ -125,7 +125,7 @@ describe('init --upgrade', () => {
     const configFile = join(sandbox, '.ai/knowledge-base/.config.json');
     rmSync(configFile);
 
-    const versionFile = join(sandbox, '.ai/.kb-builder/installed-version');
+    const versionFile = join(sandbox, '.ai/knowledge-base/.state/installed-version');
     const installed = JSON.parse(readFileSync(versionFile, 'utf8'));
     installed.version = '0.0.0-test-old';
     writeFileSync(versionFile, JSON.stringify(installed, null, 2) + '\n');
@@ -149,7 +149,7 @@ describe('doctor: installed-version currency', () => {
 
   it('warns when installed-version is older than the package', async () => {
     await runCli(sandbox, ['init', '--assistants', 'claude']);
-    const versionFile = join(sandbox, '.ai/.kb-builder/installed-version');
+    const versionFile = join(sandbox, '.ai/knowledge-base/.state/installed-version');
     const installed = JSON.parse(readFileSync(versionFile, 'utf8'));
     installed.version = '0.0.0-test-old';
     writeFileSync(versionFile, JSON.stringify(installed, null, 2) + '\n');


### PR DESCRIPTION
Closes #9.

## Summary
- Moves tool state from `.ai/.kb-builder/` to `.ai/knowledge-base/.state/` so the entire footprint lives under the knowledge-base root.
- Adds `layout_version: 2` to `installed-version` (absent ⇒ layout 1).
- Auto-migrates legacy installs idempotently at every CLI/hook entry; `doctor` prints a one-line confirmation when it migrates.
- Updates `.gitignore` block, gitignored state files now point at `.state/state.json` and `.state/bootstrap-state.json`; stale legacy lines are scrubbed on upgrade.
- All hooks and commands resolve paths through `paths.stateDir`.
- Docs + slash-command templates updated; `docs/getting-started/upgrading.md` documents the migration.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm test` — 189 passed (incl. new `tests/lib/paths.test.ts` and a legacy → new migration test in `tests/init.test.ts`)


---
_Generated by [Claude Code](https://claude.ai/code/session_01FHLzM8cZ3K8eUutsoH8Uao)_