### PR TITLE
docs: set up documentation site to match ai-task-manager

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,42 @@
+name: Deploy Documentation
+
+on:
+  push:
+    branches: [ main ]
+    paths: [ 'docs/**' ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Build with Jekyll
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./docs
+          destination: ./_site
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,6 +1,0 @@
-source "https://rubygems.org"
-
-gem "jekyll", "~> 4.3"
-gem "just-the-docs", "~> 0.10"
-gem "jekyll-remote-theme", "~> 0.4"
-gem "jekyll-seo-tag", "~> 2.8"

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,29 +1,57 @@
 title: "@e0ipso/ai-knowledge-base"
-description: "Build and maintain a per-repo knowledge base from AI coding sessions."
-remote_theme: just-the-docs/just-the-docs
+description: Build and maintain a per-repo knowledge base from AI coding sessions.
 url: https://e0ipso.github.io
-baseurl: /ai-knowledge-base
+baseurl: "/ai-knowledge-base"
 
+# Just the Docs theme configuration
+remote_theme: just-the-docs/just-the-docs
+
+# Theme settings
 color_scheme: light
-
 search_enabled: true
 heading_anchors: true
 
+# Mermaid support (built into Just the Docs)
+mermaid:
+  version: "10.6.1"
+
+# Navigation
+nav_sort: case_sensitive
+
+# Repository link in header
 aux_links:
-  GitHub:
+  "View on GitHub":
     - "https://github.com/e0ipso/ai-knowledge-base"
-  npm:
+  "npm":
     - "https://www.npmjs.com/package/@e0ipso/ai-knowledge-base"
 
-# Top-level navigation
-nav_external_links: []
+# Make aux links open in a new tab
+aux_links_new_tab: true
 
+# SEO and social media
+author: e0ipso
+twitter:
+  username: e0ipso
+
+# Jekyll plugins
 plugins:
-  - jekyll-remote-theme
+  - jekyll-sitemap
+  - jekyll-feed
   - jekyll-seo-tag
 
+# Markdown processing
+markdown: kramdown
+highlighter: rouge
+kramdown:
+  syntax_highlighter: rouge
+
+# Exclude from processing
 exclude:
+  - README.md
   - Gemfile
   - Gemfile.lock
   - node_modules
-  - vendor
+  - vendor/bundle/
+  - vendor/cache/
+  - vendor/gems/
+  - vendor/ruby/

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,6 +1,6 @@
 title: "@e0ipso/ai-knowledge-base"
 description: Build and maintain a per-repo knowledge base from AI coding sessions.
-url: https://e0ipso.github.io
+url: https://mateuaguilo.com
 baseurl: "/ai-knowledge-base"
 
 # Just the Docs theme configuration


### PR DESCRIPTION
## Summary

- Align `docs/_config.yml` with the ai-task-manager Just the Docs setup (mermaid, `nav_sort`, aux_links style, author/twitter metadata, sitemap+feed+seo-tag plugins, kramdown/rouge, expanded excludes).
- Remove `docs/Gemfile` — `actions/jekyll-build-pages@v1` resolves dependencies itself, matching ai-task-manager.
- Add `.github/workflows/docs.yml` mirroring the ai-task-manager deploy workflow (builds `./docs` on pushes to `main` and deploys to GitHub Pages).
- Set `url: https://mateuaguilo.com` so the site is served at `https://mateuaguilo.com/ai-knowledge-base`, mirroring `https://mateuaguilo.com/ai-task-manager`.

## Test plan

- [ ] Workflow `Deploy Documentation` runs after merge to `main`.
- [ ] Site is reachable at `https://mateuaguilo.com/ai-knowledge-base/`.
- [ ] Custom-domain DNS / `CNAME` for `mateuaguilo.com` is configured for this repo's Pages (may require a follow-up).

https://claude.ai/code/session_01Wnktg8WtGizvFtZfKfTAr6

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wnktg8WtGizvFtZfKfTAr6)_