### PR TITLE
docs(readme): add comparison with claude-mem

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,29 @@ npx @e0ipso/ai-knowledge-base bootstrap-incremental --from docs/
 
 Two cooperating pieces. The **builder tool** (this npm package) installs hooks under `.claude/` and a knowledge directory under `.ai/knowledge-base/`. Hooks capture redacted session slices, an async proposal extractor turns them into structured candidates, and the curator writes new knowledge nodes directly under `nodes/`. You review the diff and commit (or restore) like any other code change; a pre-commit hook keeps `INDEX.md`/`GRAPH.md` in lockstep. A `SessionStart` hook injects the current `INDEX.md` into every new AI session. The KB itself is plain markdown - readable, diffable, reviewable like code.
 
+## Compared to claude-mem
+
+[claude-mem](https://github.com/thedotmack/claude-mem) is the most visible project in this space and solves a different problem than this one. If you have already evaluated claude-mem, here is an honest read of the tradeoffs in both directions.
+
+**Where claude-mem is the better fit**
+
+- **Search.** claude-mem ships SQLite with FTS5 plus a vector index, so you can ask fuzzy semantic questions across past sessions and get ranked results. This tool relies on the AI agent reading `INDEX.md` and grepping markdown — fine for an LLM, not a substitute for a real search engine.
+- **Zero-friction capture.** claude-mem captures observations automatically across the full session lifecycle, with no curation step. This tool deliberately puts a human in the loop between capture and merge — fewer entries land, but every entry is something a teammate signed off on.
+- **Integration surface.** claude-mem advertises support for a wider set of harnesses and agents. This tool currently targets Claude Code, OpenAI Codex CLI, and OpenCode.
+
+**Where this tool is differentiated**
+
+- **Team-shared by default.** Knowledge lives in `nodes/` inside your repo, not in a per-user database at `~/.claude-mem/`. Distribution is `git pull`; a new teammate gets the full KB from a fresh clone.
+- **PR-reviewable.** Every new knowledge entry is a markdown file in a commit. Reviewers see additions in `git diff`, comment in PRs, and reject with `git restore` — the same workflow as code.
+- **No daemons, no external services.** No background worker, no local HTTP port, no vector DB, no second runtime. Just Node and git. Works in airgapped environments and behind corporate proxies without extra plumbing.
+- **Lintable, named-node graph.** Nodes have stable ids and structured `relates_to` / `depends_on` edges. `npx @e0ipso/ai-knowledge-base lint` catches dangling references, naming drift, tag near-duplicates, and orphans before review.
+- **Plain markdown outlives the tool.** If this package disappears tomorrow, you still have a tree of human-readable markdown files in your repo. Nothing is locked inside a database file or vector index format.
+
+**Pick the one that matches your situation**
+
+- Solo developer, want zero curation overhead and strong cross-session search of your own activity → **claude-mem**.
+- Team that wants accumulated project knowledge to live in the repo, be reviewed like code, and be reproducible from a fresh `git clone` → **this tool**.
+
 ## CLI reference
 
 ### `npx @e0ipso/ai-knowledge-base lint`

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,5 +1,5 @@
 title: '@e0ipso/ai-knowledge-base'
-description: Build and maintain a per-repo knowledge base from AI coding sessions.
+description: A team-shared, git-native knowledge base for AI coding sessions. No daemons, no services — just Node and git.
 url: https://mateuaguilo.com
 baseurl: '/ai-knowledge-base'
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,11 @@ nav_order: 1
 
 # @e0ipso/ai-knowledge-base
 
-A per-repo knowledge base built from your [Claude Code](https://docs.claude.com/en/docs/claude-code) sessions. Your AI conversations produce project-specific knowledge - conventions, gotchas, named modules - and most of it evaporates when the session ends. This tool captures it, lets you review it, and injects it back into every future session.
+A **team-shared, git-native knowledge base** for AI coding sessions on [Claude Code](https://docs.claude.com/en/docs/claude-code), [OpenAI Codex CLI](https://developers.openai.com/codex/cli/), and [OpenCode](https://opencode.ai/). Knowledge lives in your repo as plain markdown — not in a per-user database on one developer's laptop — so it propagates to teammates through `git pull` and is **reviewable like code** in PR diffs and commit history.
+
+No daemons. No services. No external runtimes. Just Node + git.
+
+Your AI conversations produce a steady stream of project-specific knowledge — conventions, gotchas, named modules, decision rationale — and most of it evaporates when the session ends. This tool captures it, asks a human to curate it, commits it to the repo, and injects it back into every future session.
 
 ## Quick start
 
@@ -16,6 +20,29 @@ npx @e0ipso/ai-knowledge-base doctor
 ```
 
 Then code normally. When you want to turn captured material into knowledge nodes, run `/kb-curate` inside a Claude Code session (or `npx @e0ipso/ai-knowledge-base curate` in a shell). New nodes appear in `nodes/`; review with `git diff` and commit the ones you want to keep.
+
+## Compared to claude-mem
+
+[claude-mem](https://github.com/thedotmack/claude-mem) is the most visible project in this space and solves a different problem than this one. If you have already evaluated claude-mem, here is an honest read of the tradeoffs in both directions.
+
+**Where claude-mem is the better fit**
+
+- **Search.** claude-mem ships SQLite with FTS5 plus a vector index, so you can ask fuzzy semantic questions across past sessions and get ranked results. This tool relies on the AI agent reading `INDEX.md` and grepping markdown — fine for an LLM, not a substitute for a real search engine.
+- **Zero-friction capture.** claude-mem captures observations automatically across the full session lifecycle, with no curation step. This tool deliberately puts a human in the loop between capture and merge — fewer entries land, but every entry is something a teammate signed off on.
+- **Integration surface.** claude-mem advertises support for a wider set of harnesses and agents. This tool currently targets Claude Code, OpenAI Codex CLI, and OpenCode.
+
+**Where this tool is differentiated**
+
+- **Team-shared by default.** Knowledge lives in `nodes/` inside your repo, not in a per-user database at `~/.claude-mem/`. Distribution is `git pull`; a new teammate gets the full KB from a fresh clone.
+- **PR-reviewable.** Every new knowledge entry is a markdown file in a commit. Reviewers see additions in `git diff`, comment in PRs, and reject with `git restore` — the same workflow as code.
+- **No daemons, no external services.** No background worker, no local HTTP port, no vector DB, no second runtime. Just Node and git. Works in airgapped environments and behind corporate proxies without extra plumbing.
+- **Lintable, named-node graph.** Nodes have stable ids and structured `relates_to` / `depends_on` edges. `npx @e0ipso/ai-knowledge-base lint` catches dangling references, naming drift, tag near-duplicates, and orphans before review.
+- **Plain markdown outlives the tool.** If this package disappears tomorrow, you still have a tree of human-readable markdown files in your repo. Nothing is locked inside a database file or vector index format.
+
+**Pick the one that matches your situation**
+
+- Solo developer, want zero curation overhead and strong cross-session search of your own activity → **claude-mem**.
+- Team that wants accumulated project knowledge to live in the repo, be reviewed like code, and be reproducible from a fresh `git clone` → **this tool**.
 
 ## Read next
 


### PR DESCRIPTION
## Summary

- Adds a "Compared to claude-mem" section to the README between "How it works" and "CLI reference".
- Concedes claude-mem's strengths (FTS5 + vector search, fully automatic capture, broader harness coverage) and articulates this project's differentiation (team-shared via git, PR-reviewable, no daemons, lintable named-node graph, plain markdown that outlives the tool).
- Closes with a "pick the one that matches your situation" guide so readers self-select.

Tone is factual and non-disparaging per the issue's acceptance criteria — no mention of the \$CMEM token situation; that would read as competitor takedown rather than informed comparison.

Closes #28

## Test plan

- [ ] Render the README on GitHub and confirm the new section sits between "How it works" and "CLI reference".
- [ ] Verify the claude-mem link resolves to https://github.com/thedotmack/claude-mem.
- [ ] Re-read the section for any unintentionally disparaging phrasing before merging.