### PR TITLE
docs: add strikethroo plans 41-45 for tree-over-DAG knowledge base

### DIFF
--- a/.ai/strikethroo/plans/41--tree-storage-and-recursive-index-nodes/plan-41--tree-storage-and-recursive-index-nodes.md
+++ b/.ai/strikethroo/plans/41--tree-storage-and-recursive-index-nodes/plan-41--tree-storage-and-recursive-index-nodes.md
@@ -1,0 +1,172 @@
+---
+id: 41
+summary: "Replace the flat nodes/<kind>/ layout with a nested topical folder tree of deterministic per-folder index nodes over an id-based DAG overlay, decoupling kind from directory placement"
+created: 2026-06-05
+---
+
+# Plan: Tree storage and recursive deterministic index nodes
+
+## Original Work Order
+
+> Veer kenkeep from flat node storage toward a real tree-over-DAG knowledge base for progressive disclosure. Every document lives inside a folder, and every folder has an index.md that acts as a table-of-contents node ("index node") describing the documents in that folder and the index.md of its subfolders. The document shape and frontmatter should not change much. Keep the existing relates_to / depends_on cross references as a graph overlay so cross-cutting links survive a tree that can only give each document one parent.
+
+This is the foundational plan (1 of 5) of a program:
+
+1. **This plan**: tree storage plus recursive deterministic index nodes.
+2. Curation home-branch placement.
+3. Discovery tree descent (SessionStart injects the root index node only).
+4. Rebalance act-and-fold into curate (Phase 2, higher risk).
+5. Treeify one-time flat-to-tree migration.
+
+## Plan Clarifications
+
+| Question | Answer |
+|----------|--------|
+| Tree or graph? | Tree-over-DAG. The folder hierarchy is the containment tree. The existing `relates_to` (loose) and `depends_on` (strict) edges, referenced by id, are retained as a cross-tree overlay so cross-cutting knowledge stays linked. |
+| Two node types? | Yes. **Index node** (`index.md`, one per folder, the table-of-contents) and **leaf node** (today's node document, living inside a folder). |
+| Does `kind` still drive directory placement? | No. `kind` (map / practice) becomes a pure frontmatter facet that still drives the Conventions / Components rendering split. Folders become topical and free of `kind`. |
+| Are index nodes deterministic or curated? | This plan ships the **deterministic skeleton only**. The optional single curated "folder intent" line is out of scope (it arrives with the rebalance work). |
+| How are nodes referenced across the tree? | By `id` only. Path is presentation; index generation resolves `id` to the current path. Nothing references another node by path. |
+| Is backwards compatibility required? | No. Clean break per `practice-strict-schema-version-bump-policy`: bump `schema_version`, reader rejects the old flat layout and points the user to re-init. Actual data migration of existing nodes is deferred to Plan 5 (treeify). No migrator, no compatibility shim. |
+| Does this plan migrate existing nodes or change curation, SessionStart, or rebalance? | No. Those are Plans 2 to 5. This plan delivers the storage shape, the recursive generator, and the metrics that Plan 4 will consume. |
+
+## Executive Summary
+
+kenkeep today stores knowledge as a near-flat tree under `.ai/kenkeep/nodes/<kind>/`, where `kind` is one of two buckets (`map`, `practice`). A single deterministic `INDEX.md` catalogs every node and is injected into every session; `GRAPH.md` lists the `relates_to` / `depends_on` edges on demand. `generateIndex` and `generateGraph` in `src/lib/index-gen.ts` are pure functions, and `nodes_hash` in `src/lib/nodes.ts` is content-addressed. This flat catalog is fully injected and grows without bound, which is the discoverability and token-cost ceiling the broader program targets.
+
+This plan replaces the flat `<kind>/` layout with a nested topical folder **tree**. Every folder carries an `index.md` (an **index node**) that is a deterministic rollup of its directory: the child leaf nodes (title, summary, tags) and the child subfolders (a deterministic intent line plus rollup statistics), ordered by graph in-degree. Leaf nodes are today's documents, essentially unchanged in frontmatter, placed in topical folders rather than `kind` buckets. The `relates_to` / `depends_on` edges, always referenced by `id`, are retained as a cross-tree DAG overlay, so this is tree-over-DAG, not a pure tree.
+
+The generator generalizes from producing one root `INDEX.md` to producing one `index.md` per directory, recursively, as a pure function of the leaf set. The hard invariant is "path is presentation, id is identity": index generation resolves ids to current paths, so later relocation (Plans 4 and 5) never breaks a reference. The change bumps `schema_version` as a clean break; existing flat knowledge bases are rejected by the new reader and migrated later by Plan 5.
+
+This plan is the keystone. It delivers the storage shape, the recursive deterministic generator, and the per-folder metrics that the rebalance plan consumes, while deferring all curator, SessionStart, rebalance, and migration behavior to the later plans.
+
+## Context
+
+### Current State vs Target State
+
+| Current State | Target State | Why? |
+|---------------|--------------|------|
+| Nodes stored flat under `nodes/<kind>/` (`map`, `practice`) | Nodes stored in a nested topical folder tree; each folder has an `index.md` index node | Enables progressive disclosure by depth instead of one flat bucket |
+| `kind` determines the directory and the lint naming rule (`practice-lint-naming-rules`) | `kind` is a pure frontmatter facet driving only the Conventions / Components rendering split; folders are topical | A topic tree cannot be organized by a two-value `kind` axis |
+| One deterministic `INDEX.md` at the KB root, catalog of every node | One deterministic `index.md` per folder, each a rollup of its own directory; the root `index.md` is the top-level catalog | Recursive table-of-contents is the substrate for descent |
+| `generateIndex` returns a single body | `generateIndex` walks the tree and emits one `index.md` body per directory, pure function of the leaf set plus injected `now` | Preserves the determinism contract while generalizing the output |
+| `nodes_hash` hashes the contents of `nodes/` | `nodes_hash` hashes leaf nodes only and explicitly excludes generated `index.md` files | Generated artifacts must not feed the hash that detects source drift, or the hash becomes self-referential |
+| Cross references (`relates_to`, `depends_on`) resolved against a flat id space | Same edges, same id space, now spanning folder boundaries as the DAG overlay; index generation resolves id to current path | Tree gives one parent; the overlay keeps cross-cutting links |
+| `schema_version: 1`; lint asserts filename / id / kind / directory agreement | `schema_version` bumped; lint asserts filename / id agreement, every folder has an `index.md`, and leaves carry a stable id; kind / directory agreement dropped | `kind` semantics change from directory-determining to facet, which is a semantic change requiring a bump |
+
+### Background
+
+The relevant code and conventions:
+
+- `src/lib/index-gen.ts`: `generateIndex`, `generateGraph`, `computeInDegree`, `renderBullet`, `renderTagIndex`, all pure functions of the node set plus an injected `now`. `generateIndex` currently produces a single catalog body with `## Conventions`, `## Components`, and `## By topic` sections sorted by in-degree.
+- `src/lib/nodes.ts`: `computeNodesHash`, content-addressed and mtime-independent (`practice-determinism-contract`).
+- `src/lib/schemas.ts`: `NodeFrontmatterSchema` (`schema_version`, `id`, `title`, `kind`, `tags`, `derived_from`, `relates_to`, `depends_on`, `confidence`, `summary`) and `IndexFrontmatterSchema` / `GraphFrontmatterSchema` (`schema_version`, `nodes_hash`, `node_count`).
+- The `index rebuild` command (and `index rebuild --stage` from the project's pre-commit recipe) regenerate `INDEX.md` and `GRAPH.md` deterministically and stage them.
+- `tests/lib/index-gen.test.ts`: golden-file determinism tests.
+- KB nodes that document and constrain this area: `practice-determinism-contract`, `map-index-md`, `map-graph-md`, `map-node-frontmatter`, `map-nodes-hash`, `map-nodes-directory`, `practice-lint-naming-rules`, `practice-strict-schema-version-bump-policy`.
+
+Constraints from the kenkeep constitution (`AGENTS.md`): plain markdown in git for all knowledge data, no databases, deterministic regeneration, human-in-the-loop acceptance by git commit. The determinism contract requires byte-identical regeneration of generated artifacts for a given leaf set.
+
+A sequencing note that this plan must surface: between merging this plan and merging Plan 5 (treeify), the repository's own flat knowledge base is rejected by the new reader. This is the intended clean-break behavior, but it means Plan 5 should land close behind, or the repo's KB is temporarily unreadable by the new code path.
+
+## Architectural Approach
+
+The work is a generalization of the existing pure generator plus a structural change to where leaves live and how `kind` is interpreted. The generator becomes recursive over directories; index nodes are derived artifacts (like `INDEX.md` today) and are excluded from `nodes_hash`. In-degree is computed globally across the whole leaf set so ordering inside any folder reflects the full graph, not just local edges.
+
+```mermaid
+flowchart TD
+    A[walk nodes/ tree] --> B[collect leaf nodes<br/>parse frontmatter]
+    B --> C[compute global in-degree<br/>from relates_to edges]
+    B --> D[compute nodes_hash<br/>leaves only, exclude index.md]
+    A --> E[for each directory]
+    C --> E
+    E --> F[render index.md:<br/>child leaves title/summary/tags<br/>child subfolders intent + rollup stats<br/>sorted by in-degree]
+    E --> G[compute per-folder metrics:<br/>occupancy, tag diversity, leaf size]
+    F --> H[write index.md per folder]
+    G --> H
+    D --> I[write GRAPH.md at root<br/>full edge listing by id]
+    H --> J[index rebuild --stage:<br/>git add all generated files]
+    I --> J
+```
+
+The leaf frontmatter shape is intentionally stable: `kind` remains a field, it simply no longer maps to a directory. The schema bump is driven by the change in `kind` semantics and the layout, not by adding or removing fields. The new reader detects the old flat layout (or the old `schema_version`) and rejects it with a clear message pointing to re-init, consistent with the strict bump policy.
+
+Per-folder metrics (occupancy, tag diversity, leaf size) are computed deterministically during rebuild and recorded where Plan 4 can consume them. This plan computes and exposes them; it does not act on them.
+
+## Risk Considerations and Mitigation Strategies
+
+<details>
+<summary>Technical Risks</summary>
+
+- **`nodes_hash` self-reference.** If generated `index.md` files were hashed, every rebuild would change the hash, breaking drift detection.
+  - **Mitigation**: hash leaf nodes only; exclude all `index.md`. Add an explicit determinism test asserting the hash is stable across repeated rebuilds.
+- **Determinism regressions in the recursive generator.** More output files means more surface for nondeterminism (directory iteration order, tie-breaking).
+  - **Mitigation**: sort directory entries and bullets deterministically (in-degree then title); keep `now` injected; expand golden-file tests to the recursive layout.
+- **Empty or single-child folders.** A folder with no leaves or one leaf still needs a well-defined `index.md`.
+  - **Mitigation**: define rendering for empty and singleton folders explicitly; cover with tests. Occupancy minimums are a rebalance concern (Plan 4), not enforced here.
+</details>
+
+<details>
+<summary>Scope Risks</summary>
+
+- **Pulling in curator or rebalance behavior.** The recursive generator naturally invites "and also split big folders".
+  - **Mitigation**: this plan only computes metrics; splitting, merging, and placement are Plans 2 and 4. Index nodes here are deterministic skeletons with no curated intent line.
+</details>
+
+<details>
+<summary>Process Risks</summary>
+
+- **Repo KB unreadable between this plan and Plan 5.** The clean break rejects the existing flat KB.
+  - **Mitigation**: document the sequencing explicitly; recommend landing Plan 5 immediately after; the bundled starter nodes under `src/templates-source/kenkeep/nodes/` are regenerated to the new layout as part of this plan so fresh `init` is correct.
+</details>
+
+## Success Criteria
+
+### Primary Success Criteria
+
+1. Leaf nodes live in topical folders; every folder under `nodes/` carries a generated `index.md`. `kind` is a frontmatter facet and no longer constrains directory placement.
+2. `generateIndex` produces one deterministic `index.md` per directory as a pure function of the leaf set plus injected `now`; repeated rebuilds are byte-identical.
+3. `nodes_hash` is computed over leaf nodes only, excludes `index.md`, and is stable across repeated rebuilds.
+4. All cross references resolve by `id`; index generation renders the current path; no generated artifact or leaf references another node by path.
+5. `schema_version` is bumped; the new reader rejects the old flat layout with a message pointing to re-init; no migrator or compatibility shim exists.
+6. Per-folder metrics (occupancy, tag diversity, leaf size) are computed deterministically during rebuild and exposed for later consumption.
+7. `index rebuild` and `index rebuild --stage` produce and stage the full set of generated files; `tests/lib/index-gen.test.ts` golden tests cover the recursive layout and pass.
+8. `npm test`, `npm run typecheck`, and `npm run lint` pass.
+
+## Self Validation
+
+After all tasks complete, execute these concrete steps:
+
+1. Run `npm run build` then `npm test` from the repo root; confirm exit 0 with no failing suites, including the recursive `index-gen` determinism golden tests.
+2. Run `node dist/cli.js index rebuild` twice against a fixture KB and confirm `git status` shows no diff on the second run (byte-identical regeneration), and that an `index.md` exists in every folder.
+3. Temporarily edit one leaf's `summary`, run `index rebuild`, and confirm only the affected folder's `index.md` and `nodes_hash` change; revert.
+4. Construct a fixture with an old flat `nodes/<kind>/` layout and confirm the reader rejects it with the re-init message rather than misparsing it.
+5. Run `git grep` patterns over generated `index.md` and leaf bodies to confirm no node references another node by path (references are by id only).
+6. Run `npm run typecheck` and `npm run lint` and confirm both pass, including updated naming-lint rules.
+
+## Documentation
+
+Yes, this plan updates documentation. Required updates:
+
+- `AGENTS.md`: the Structure section and any description of `nodes/<kind>/` layout, plus the schema-version note.
+- `docs/internals/architecture.md`, `docs/internals/schemas.md`, and `docs/how-it-works.md`: the storage shape, index node concept, and `nodes_hash` exclusion of generated files.
+- KB nodes (left as uncommitted node edits for human acceptance, per the human-in-the-loop rule): `map-index-md`, `map-graph-md`, `map-nodes-directory`, `map-nodes-hash`, `map-node-frontmatter`, `practice-lint-naming-rules`, `practice-determinism-contract` to reflect the tree layout and the kind-as-facet change.
+
+## Resource Requirements
+
+### Development Skills
+
+- TypeScript, Node 22+, ESM, the `tsup` build, and `vitest`.
+- Familiarity with `src/lib/index-gen.ts`, `src/lib/nodes.ts`, `src/lib/schemas.ts`, and the `index rebuild` command.
+
+### Technical Infrastructure
+
+- Existing Node toolchain and `git`. No new runtime dependencies; the constitution forbids databases and external runtimes.
+
+## Notes
+
+- No em dashes anywhere in changed files (`practice-no-em-dashes`).
+- Conventional Commits; one logical change per PR; do not bump the npm `version` by hand.
+- Inside this source repo, run the CLI from `dist/cli.js`, not via `npx`.
+- Develop on branch `claude/cankeb-node-storage-4mgca`. Do not open a pull request.
+- This plan deliberately stops at deterministic index nodes. Curated folder-intent lines, placement, descent injection, rebalance, and migration are Plans 2 to 5.

--- a/.ai/strikethroo/plans/42--curation-home-branch-placement/plan-42--curation-home-branch-placement.md
+++ b/.ai/strikethroo/plans/42--curation-home-branch-placement/plan-42--curation-home-branch-placement.md
@@ -1,0 +1,154 @@
+---
+id: 42
+summary: "Teach the curator to place each leaf into its best existing folder by reusing the relate step to rank index nodes, writing the node id-stable into a home branch without changing tree structure"
+created: 2026-06-05
+---
+
+# Plan: Curation home-branch placement
+
+## Original Work Order
+
+> In the tree-over-DAG knowledge base, curation must decide where in the tree a new or updated leaf belongs. The relate step already finds the nearest existing notes; reuse that to also pick the home branch (the index node whose subtree is most relevant) and write the leaf into that folder. Curation must not change tree structure (no splitting, merging, or creating branches); it only writes a leaf plus its edges and names where it lives.
+
+This is Plan 2 of 5. It depends on Plan 1 (tree storage and recursive index nodes).
+
+## Plan Clarifications
+
+| Question | Answer |
+|----------|--------|
+| What chooses the home branch? | The existing `relate` reasoning in `/kk-curate`, extended to also rank existing index nodes by relevance and return the best-fitting folder. One reasoning pass, two outputs: the cross edges and the home branch. |
+| Can curation create new folders or split? | No. Placement is into an **existing** folder only. If nothing fits well, the leaf is placed at the `nodes/` root as a top-level leaf, and Plan 4 (rebalance) later relocates or creates a branch. |
+| Does the leaf id depend on placement? | No. Id is stable and independent of folder. The `node write` primitive accepts a target folder (presentation) but identity stays the id. |
+| Does dedupe change? | Dedupe now ranges over the whole tree, but the logic is unchanged: a duplicate updates the existing leaf in place at its current path (same id). |
+| Does contradiction handling change? | No. The curator still never auto-resolves; it writes one conflict file per contradiction for the human to resolve. |
+| Is backwards compatibility required? | Not applicable beyond Plan 1's clean break. This plan changes curation behavior and the curator-action shape, consistent with the new layout. |
+
+## Executive Summary
+
+Plan 1 gives kenkeep a folder tree with deterministic index nodes, but it says nothing about how a curated leaf finds its folder. Today `/kk-curate` filters non-productive candidates, dedupes against existing nodes, sets `relates_to` / `depends_on`, and writes contradictions to conflict files, then writes the node into its `kind` directory. With `kind` demoted to a facet (Plan 1), the writer no longer has a directory to target.
+
+This plan closes that gap with the smallest possible change: the `relate` step, which already has to locate the nearest existing notes, also ranks the existing index nodes and returns the best-fitting **home branch**. The curator writes the leaf into that folder. Identity remains the id, so placement is pure presentation and never disturbs cross references. Curation does not split, merge, or create folders; if no existing folder fits, the leaf lands at the root for Plan 4 to relocate.
+
+The result keeps everyday curation cheap and supervised. The human still reviews uncommitted node files by git diff and accepts by commit or rejects by restore. The only new judgment the curator makes is "which existing folder", and it makes that judgment from the same evidence it already gathers when relating a node to its neighbors.
+
+## Context
+
+### Current State vs Target State
+
+| Current State | Target State | Why? |
+|---------------|--------------|------|
+| Curator writes the node into `nodes/<kind>/` | Curator writes the leaf into a chosen home folder | `kind` no longer maps to a directory after Plan 1 |
+| `relate` returns cross edges only | `relate` returns cross edges plus a ranked home branch | Placement reuses evidence already gathered; no second reasoning pass |
+| `node write` primitive targets a `kind` directory | `node write` accepts a target folder (presentation) and keeps id as identity | Decouples placement from identity |
+| Dedupe over a flat id space | Dedupe over the whole tree, updating duplicates in place by id | Same behavior, larger search surface |
+| Curator-action schema names a target node and kind | Curator-action also names a home folder for new leaves | The action must carry placement for the writer to honor it |
+| No defined behavior when nothing fits | New leaf with no good fit lands at the `nodes/` root | Plan 4 owns structural creation and relocation; curation must not |
+
+### Background
+
+Relevant code and conventions:
+
+- `src/templates-source/skills/kk-curate/SKILL.md`: the curation skill that composes the deterministic primitives and runs the LLM reasoning in the host harness session.
+- The `node write` and `curate-dedup` primitives in `src/commands/`.
+- KB nodes: `map-curate-command`, `map-curator-action`, `map-curate-cli-conflict-resolution-output-message`, `practice-curator-never-auto-resolves-contradictions`, `practice-curator-drops-non-productive-candidates`, `practice-confidence-default-medium-bootstrap`, `map-conflict-files`.
+- Constitution: human-in-the-loop, nothing enters the KB without `/kk-curate` plus git commit. Curation is meant to be cheap, suitable for a mid-tier model at moderate effort.
+
+This plan touches the reasoning skill and the writer, not the generator. After the writer places a leaf, Plan 1's deterministic rebuild produces the index nodes; this plan relies on that and does not duplicate it.
+
+## Architectural Approach
+
+The change is concentrated in the `relate` phase of the curate skill and the `node write` primitive. The relate phase descends the existing tree (root index node, then relevant branch index nodes) to find the nearest leaves, exactly the descent Plan 3 will give the agent at discovery time, and returns both the edges and the best-fitting folder. The writer honors the named folder and stores by id.
+
+```mermaid
+flowchart TD
+    A[pending sessions: candidates] --> B{productive?}
+    B -- no --> X[drop]
+    B -- yes --> C[dedupe vs leaves across tree]
+    C -- duplicate --> U[update existing leaf in place, same id]
+    C -- novel --> R[relate]
+    R --> R1[set relates_to / depends_on by id]
+    R --> R2[rank existing index nodes -> home branch]
+    R1 --> K{contradicts a leaf?}
+    R2 --> W
+    K -- yes --> CF[write conflict file, human resolves]
+    K -- no --> W[node write into home folder, id stable]
+    W --> N[no structural change here]
+    N --> G[hand to deterministic rebuild from Plan 1]
+```
+
+If the relate phase cannot find a folder above a relevance threshold, it returns "root" and the writer places the leaf at `nodes/` top level. This is a deliberate, visible fallback that Plan 4 later cleans up; it is not an error.
+
+## Risk Considerations and Mitigation Strategies
+
+<details>
+<summary>Quality Risks</summary>
+
+- **Misplacement.** The curator picks a weak home and the leaf hides in the wrong subtree.
+  - **Mitigation**: placement is reversible (Plan 4 relocates; the human can move it by hand since id is stable). The root fallback prevents forcing a bad fit. Placement quality is reported in the curate summary for human review.
+- **Inconsistent placement across runs.** The same kind of leaf lands in different folders on different runs.
+  - **Mitigation**: relate ranks against the actual index nodes, which are deterministic, so the evidence is stable; the human review gate catches drift.
+</details>
+
+<details>
+<summary>Scope Risks</summary>
+
+- **Creeping into structural change.** "If nothing fits, just create a folder" is tempting.
+  - **Mitigation**: this plan forbids folder creation, splitting, and merging. The only structural outcome is the root fallback. Plan 4 owns all structure.
+</details>
+
+<details>
+<summary>Technical Risks</summary>
+
+- **Curator-action shape change ripples into the dedup and conflict writers.**
+  - **Mitigation**: add the home-branch field as optional in the action schema so non-placement actions (updates, conflicts) are unaffected; cover with integration tests of the curate flow.
+</details>
+
+## Success Criteria
+
+### Primary Success Criteria
+
+1. The `relate` phase returns both cross edges and a home branch in a single reasoning pass.
+2. The curator writes each novel leaf into the chosen existing folder; duplicates update in place by id; identity is independent of folder.
+3. The curator never creates, splits, or merges folders. A leaf with no good fit lands at the `nodes/` root.
+4. Contradiction handling is unchanged: one conflict file per contradiction, never auto-resolved.
+5. The curate run reports its placement decisions in the end-of-run summary for human review.
+6. After curation, Plan 1's deterministic rebuild produces correct index nodes for the touched folders; the human accepts by commit or rejects by restore.
+7. `npm test`, `npm run typecheck`, and `npm run lint` pass, including the detect-harness drift check if the curate skill heredoc is touched.
+
+## Self Validation
+
+After all tasks complete, execute these concrete steps:
+
+1. Run `npm run build` then `npm test`; confirm exit 0, including curate-flow integration tests covering placement, dedupe-update, and the root fallback.
+2. Drive a fixture curate run that produces one novel leaf with a clear home and one with no good fit; confirm the first lands in the expected folder and the second at the root, both with stable ids.
+3. Drive a curate run that updates an existing leaf; confirm it is updated in place at its current path with the same id and no relocation.
+4. Drive a curate run with a contradiction; confirm a single conflict file is written and nothing is auto-resolved.
+5. Confirm the curate end-of-run summary lists placement decisions.
+6. Run `npm run lint` (including `lint:detect-harness`) and `npm run typecheck`; confirm both pass.
+
+## Documentation
+
+Yes, this plan updates documentation. Required updates:
+
+- `docs/how-it-works.md` and `docs/daily-use.md`: the curation flow now names a home branch.
+- KB nodes (left uncommitted for human acceptance): `map-curate-command`, `map-curator-action`, and a new or updated practice node describing home-branch placement and the root fallback.
+- If the `ENV_DETECTORS` heredoc in `kk-curate/SKILL.md` is touched, mirror any harness detector changes per the existing drift rule (no detector changes are expected in this plan).
+
+## Resource Requirements
+
+### Development Skills
+
+- TypeScript and the kenkeep curate pipeline (skill plus primitives).
+- Understanding of the curator-action schema and the conflict-file flow.
+
+### Technical Infrastructure
+
+- Existing Node toolchain and `git`. No new dependencies.
+
+## Notes
+
+- No em dashes in changed files (`practice-no-em-dashes`).
+- Conventional Commits; one logical change per PR.
+- Do not run `curate` in CI; it launches the host harness and the LLM and is human-supervised by design.
+- Develop on branch `claude/cankeb-node-storage-4mgca`. Do not open a pull request.
+- Placement is the only new judgment. Structure changes belong to Plan 4.

--- a/.ai/strikethroo/plans/43--discovery-tree-descent/plan-43--discovery-tree-descent.md
+++ b/.ai/strikethroo/plans/43--discovery-tree-descent/plan-43--discovery-tree-descent.md
@@ -1,0 +1,144 @@
+---
+id: 43
+summary: "Change SessionStart to inject only the root index node and rewrite the navigation directive from grep-the-flat-catalog to descend-the-tree, so the agent enters at the root and pulls deeper on demand"
+created: 2026-06-05
+---
+
+# Plan: Discovery tree descent
+
+## Original Work Order
+
+> With the tree-over-DAG store in place, the agent should enter the knowledge base at the root index node and descend on demand. SessionStart should inject only the root index.md (bounded, independent of KB size) instead of the entire flat catalog. The navigation guidance must change from "grep the flat catalog" to "read the root, pick relevant branches, descend their index nodes, pull only the leaves you need, follow cross edges". Multiple index nodes may be relevant; the agent decides how deep to go.
+
+This is Plan 3 of 5. It depends on Plan 1 (tree storage and recursive index nodes).
+
+## Plan Clarifications
+
+| Question | Answer |
+|----------|--------|
+| What is injected at SessionStart? | Only the root `index.md` (the top-level catalog of branches and root-level leaves). Not the whole tree. |
+| What replaces the current grep recipe? | A descent directive: read the root index node, select one or more relevant branches, read those branch index nodes, descend further as needed, pull only the leaves required, and follow `relates_to` / `depends_on` cross edges to jump branches. |
+| Does staleness detection change? | No. The `nodes_hash` drift check stays; it now compares against the root index node's frontmatter hash. |
+| Does the AGENTS.md pointer change? | Yes. The static `kenkeep:kk-index` pointer block injected by init and upgrade is updated to describe entering at the root index node and descending. |
+| Does this change curation, rebalance, or storage? | No. This is the discovery surface only. |
+| Is backwards compatibility required? | Not applicable beyond Plan 1's clean break. |
+
+## Executive Summary
+
+Plan 1 builds the recursive index nodes; this plan changes how the agent meets them. Today the SessionStart hook (`src/lib/session-start.ts`) injects the entire `INDEX.md` catalog into every session and appends a navigation directive that tells the agent to consult the catalog and then `grep -C 2 <term> nodes/` for candidate slugs. That directive is correct for a flat bucket and wrong for a tree: it ignores the index nodes and the descent they enable.
+
+This plan injects only the root index node, a bounded payload that does not grow with the knowledge base, and rewrites the directive to describe descent: read the root, choose relevant branches, read their index nodes, go as deep as the task needs, pull only the leaves required, and follow cross edges across branches. The staleness check (`nodes_hash` drift), the curation-queue nudge, and the lint summary line are preserved unchanged; only the injected body and the navigation text change. The static AGENTS.md pointer block that init and upgrade write is updated to match.
+
+The payoff is the program's headline benefit realized at the discovery surface: always-on cost becomes bounded and independent of KB size, disclosure becomes logarithmic in the tree depth rather than linear in the node count, and the agent controls depth per branch. The one cost, acknowledged here, is that discoverability now depends on index-node summary quality; this plan relies on Plan 1's deterministic rollups and does not add curated summaries (that is later work).
+
+## Context
+
+### Current State vs Target State
+
+| Current State | Target State | Why? |
+|---------------|--------------|------|
+| SessionStart injects the entire `INDEX.md` catalog | SessionStart injects only the root `index.md` | Bounded always-on cost, independent of KB size |
+| Navigation directive: consult catalog, then `grep -C 2 <term> nodes/` | Navigation directive: read root, pick branches, descend index nodes, pull needed leaves, follow cross edges | Grep-the-flat-catalog ignores the tree; descent is the new model |
+| Staleness compares the flat `INDEX.md` frontmatter hash to the live hash | Same drift check against the root index node's frontmatter hash | Drift detection is still meaningful and unchanged in spirit |
+| AGENTS.md pointer block: "consult INDEX.md" | AGENTS.md pointer block: "enter at the root index node and descend" | The static pointer must match the new discovery model |
+| Curation-queue nudge and lint summary appended | Same, unchanged | Those surfaces are orthogonal to the discovery model |
+
+### Background
+
+Relevant code and conventions:
+
+- `src/lib/session-start.ts`: `buildSessionStartContext` loads `INDEX.md`, appends the snapshot-verification note, the navigation directive, the staleness line, the curation-queue nudge, and the lint summary. On OpenCode the injection is written to `.opencode/AGENTS.md` rather than `additionalContext`.
+- The static AGENTS.md pointer injection performed by init and upgrade (KB node `practice-init-and-upgrade-inject-a-static-kk-index-pointer-into-agents-md` and `map-update-agents-md-kk-index-pointer-injection-into-agents-md`).
+- The navigation directive history (archive plan 27, kb-navigation-directive) and the Cursor caveat that `sessionStart` additional_context is silently dropped (`practice-cursor-sessionstart-additional-context-is-silently-dropped`).
+- KB nodes: `map-session-start-hook`, `map-index-md`, `map-claude-harness` and the other harness maps for per-runtime injection channels.
+
+This plan is the only one that changes what the host harness sees at the start of a session. It must respect each adapter's injection channel without translating event names (`practice-no-event-translation-across-adapters`) and must keep the Cursor caveat in mind (Cursor relays the nudge differently).
+
+## Architectural Approach
+
+The change is localized to the injection builder and the static pointer writer. `buildSessionStartContext` loads and injects the root `index.md` body instead of the flat catalog, keeps the existing drift, nudge, and lint logic, and swaps the navigation directive text. The directive is the behavioral core: it must make descent the obvious path and make clear that several branches can be relevant and that the agent chooses depth.
+
+```mermaid
+flowchart TD
+    A[SessionStart fires] --> B[load root index.md body]
+    B --> C[append snapshot-verification note]
+    C --> D[append DESCENT navigation directive]
+    D --> E[append staleness line if nodes_hash drift]
+    E --> F[append curation-queue nudge if threshold]
+    F --> G[append lint summary if findings]
+    G --> H{harness injection channel}
+    H -- Claude/Codex/Copilot --> I[additionalContext]
+    H -- OpenCode --> J[write .opencode/AGENTS.md]
+    H -- Cursor --> K[relay per existing caveat]
+```
+
+The descent directive replaces the grep recipe. It instructs: read the injected root index node; identify the branches whose intent and tags match the task; read those branch index nodes; descend further only where the task needs it; open only the leaves that are confirmed relevant; and follow `relates_to` / `depends_on` to reach related leaves in other branches. The static AGENTS.md pointer block is updated to the same framing for the always-on file surface.
+
+## Risk Considerations and Mitigation Strategies
+
+<details>
+<summary>Quality Risks</summary>
+
+- **Under-disclosure.** With only the root injected, the agent may fail to descend into a relevant branch whose root-level summary is thin.
+  - **Mitigation**: rely on Plan 1's deterministic rollups (child counts, top tags, in-degree) to give the root index node real signal; make the directive explicit that multiple branches can be relevant and that descending is expected, not optional. Richer curated intent lines are deliberately later work.
+- **Directive drift across harnesses.** The directive text could diverge between the hook and the static AGENTS.md pointer.
+  - **Mitigation**: source the directive text once and reuse it for both surfaces.
+</details>
+
+<details>
+<summary>Technical Risks</summary>
+
+- **Cursor silently drops additional_context.** A naive injection is lost on Cursor.
+  - **Mitigation**: preserve the existing Cursor relay behavior; cover with the existing per-harness tests.
+- **OpenCode writes to a file rather than a channel.** The root-only change must apply there too.
+  - **Mitigation**: route the same root body through the OpenCode path; test the written `.opencode/AGENTS.md`.
+</details>
+
+## Success Criteria
+
+### Primary Success Criteria
+
+1. SessionStart injects only the root `index.md` body; the payload does not grow with total node count.
+2. The navigation directive describes descent (read root, pick branches, descend, pull needed leaves, follow cross edges) and states that multiple branches can be relevant and the agent chooses depth.
+3. The `nodes_hash` drift check, the curation-queue nudge, and the lint summary are preserved and behave as before.
+4. The static AGENTS.md pointer block written by init and upgrade is updated to the descent framing, sharing one directive source with the hook.
+5. Per-harness injection channels are respected without event-name translation; the Cursor relay caveat and the OpenCode file path are honored.
+6. `npm test`, `npm run typecheck`, and `npm run lint` pass, including per-harness SessionStart tests.
+
+## Self Validation
+
+After all tasks complete, execute these concrete steps:
+
+1. Run `npm run build` then `npm test`; confirm exit 0, including SessionStart injection tests for each harness.
+2. Run the SessionStart hook against a fixture tree KB and confirm the injected payload contains only the root index node body plus the directive, nudge, and staleness lines, and grows by a fixed amount as leaves are added to deep folders.
+3. Induce `nodes_hash` drift in the fixture and confirm the staleness line still appears.
+4. Run init and upgrade against a fixture repo and confirm the AGENTS.md pointer block contains the descent framing and matches the hook directive text.
+5. Confirm the OpenCode path writes the root-only body to `.opencode/AGENTS.md` and the Cursor path relays per the existing caveat.
+6. Run `npm run typecheck` and `npm run lint`; confirm both pass.
+
+## Documentation
+
+Yes, this plan updates documentation. Required updates:
+
+- `AGENTS.md`: the description of the injected pointer and the navigation model.
+- `docs/how-it-works.md` and `docs/internals/hooks.md`: SessionStart now injects the root index node and the descent directive.
+- KB nodes (left uncommitted for human acceptance): `map-session-start-hook`, the navigation-directive practice node, and `map-index-md` to reflect root-only injection.
+
+## Resource Requirements
+
+### Development Skills
+
+- TypeScript and the SessionStart hook plus per-harness injection channels.
+- Awareness of the Cursor additional_context caveat and the OpenCode file injection.
+
+### Technical Infrastructure
+
+- Existing Node toolchain and `git`. No new dependencies.
+
+## Notes
+
+- No em dashes in changed files (`practice-no-em-dashes`).
+- Conventional Commits; one logical change per PR.
+- Hook behavior changes must be applied consistently across all harness adapters (`practice-hook-behavior-changes-must-be-applied-to-all-four-harness-adapters`).
+- Develop on branch `claude/cankeb-node-storage-4mgca`. Do not open a pull request.
+- Discoverability now rides on index-node summary quality; this plan uses Plan 1's deterministic rollups and does not add curated summaries.

--- a/.ai/strikethroo/plans/44--rebalance-act-and-fold-into-curate/plan-44--rebalance-act-and-fold-into-curate.md
+++ b/.ai/strikethroo/plans/44--rebalance-act-and-fold-into-curate/plan-44--rebalance-act-and-fold-into-curate.md
@@ -1,0 +1,169 @@
+---
+id: 44
+summary: "Add a rebalance phase that folds into curate, fired by a deterministic hysteresis-gated trigger over Plan 1 metrics, performing id-stable split/merge/create-branch moves as git renames in the same reviewable diff"
+created: 2026-06-05
+---
+
+# Plan: Rebalance act-and-fold into curate
+
+## Original Work Order
+
+> The knowledge tree must stay balanced without adding any chore to the user. Rebalance is not a separate command the user runs; it folds into `/kk-curate` as its last phase. A deterministic, LLM-free trigger over the per-folder metrics decides whether structural work is warranted, with enough hysteresis margin that the tree does not thrash run to run. When warranted, the LLM performs split folder, split leaf, merge, or create branch on the affected branches only. All changes land in the same working-tree diff (act-and-fold): the human accepts by git commit and rejects by git restore. Moves preserve content byte-for-byte so git records renames, ids stay stable, and a structural summary is emitted at the end of the run.
+
+This is Plan 4 of 5 and the highest-risk plan. It depends on Plans 1, 2, and 3.
+
+## Plan Clarifications
+
+| Question | Answer |
+|----------|--------|
+| Who runs rebalance? | Nobody new. It is the last phase of `/kk-curate`, the command the user already runs. No second command, no second nudge. |
+| What triggers it? | A deterministic, LLM-free check over the per-folder occupancy / diversity / leaf-size metrics from Plan 1, gated by hysteresis so borderline cases do not oscillate. If nothing trips, the LLM phase is skipped entirely (zero added cost). |
+| What operations exist? | Split folder, split leaf (document becomes a folder of an index node plus two or more documents), merge (collapse sparse or redundant), and create branch (novel top-level topic). |
+| Act-and-fold or pause-to-confirm? | Act-and-fold. Structural changes land in the same diff as the curation changes; review is the existing git commit / git restore gate. |
+| How are moves kept reviewable? | Content is preserved byte-for-byte on relocation so git records a rename, not delete-plus-add. Ids are stable so no referencing file is rewritten. A structural summary maps the diff. |
+| What about a bad structural call? | `git restore` is path-scoped; the human can reject just the rebalance moves and keep the leaf writes. |
+| Is backwards compatibility required? | Not applicable beyond Plan 1's clean break. |
+
+## Executive Summary
+
+Plans 1 to 3 give kenkeep a tree, place leaves into it, and let the agent descend it. Over time, curation alone makes the tree lopsided: folders grow too large, a single leaf accretes several concepts, branches go sparse, and genuinely new topics have no home. Left unattended, the tree degrades into a flat bucket with extra steps. This plan adds the homeostasis layer that keeps it healthy, with the explicit constraint that it adds no burden to the user.
+
+Rebalance folds into `/kk-curate` as its final phase. A deterministic, LLM-free trigger reads the per-folder metrics that Plan 1 already computes during rebuild and decides, with hysteresis margin, whether structural work is warranted. Most curate runs add a leaf or two, trip nothing, and skip the expensive phase entirely. When a threshold trips, the LLM reasons over the affected branches only and performs split folder, split leaf, merge, or create branch. All changes, curation and structure, land in one working-tree diff. The human's existing review (git diff, then commit to accept or restore to reject) is the only gate.
+
+Two properties make act-and-fold safe to review. Moves preserve file content byte-for-byte, so git records renames rather than churn, and a reviewer can tell a content change from a relocation at a glance. Ids are stable across moves, so cross references resolve and no referencing file is rewritten; a split leaf mints new ids for its parts and leaves a redirect in history. Because there is no human checkpoint inside the run, the deterministic trigger carries real hysteresis margin so the tree settles instead of oscillating.
+
+## Context
+
+### Current State vs Target State
+
+| Current State | Target State | Why? |
+|---------------|--------------|------|
+| Curation places leaves but never restructures; the tree degrades over time | A rebalance phase keeps the tree balanced as part of curate | Without homeostasis the tree decays toward a flat bucket |
+| No structural operations exist | Split folder, split leaf, merge, create branch | The four moves a growing knowledge tree needs |
+| No trigger | Deterministic, LLM-free trigger over Plan 1 metrics with hysteresis | Cheap when balanced; structural reasoning only when warranted |
+| N/A | Act-and-fold: structure lands in the same diff as curation | No second command, no second nudge, no extra burden |
+| N/A | Moves are git renames (content byte-stable); ids stable; split-leaf mints new ids plus redirect | Reviewable diffs; cross references survive relocation |
+| Curate emits a content summary | Curate also emits a structural summary of rebalance actions | The human needs a legend for the structural diff |
+
+### Background
+
+Relevant code and conventions:
+
+- Plan 1 computes per-folder occupancy / tag diversity / leaf-size metrics during rebuild; this plan consumes them.
+- `src/templates-source/skills/kk-curate/SKILL.md`: the curate skill that this plan extends with a final rebalance phase.
+- The deterministic primitives in `src/commands/` (the trigger and the move operation should be deterministic primitives; the structural decision is the LLM step inside the skill).
+- KB nodes: `map-curate-command`, `practice-curator-never-auto-resolves-contradictions`, `practice-review-nodes-via-git`, `practice-determinism-contract`, `map-nodes-hash`, `map-index-md`, and the bootstrap nodes that model supervised structural changes (`practice-bootstrap-never-overwrites-existing-nodes`).
+- Constitution: no daemons or background services (rebalance is part of a one-shot curate invocation), plain markdown in git, deterministic regeneration, human-in-the-loop by git commit. Do not run curate in CI.
+
+This is the only plan that performs non-deterministic structural decisions. They are quarantined: the trigger is deterministic, the regeneration after a move is deterministic, and the human reviews the resulting diff. The non-determinism lives only in the clustering decision of split and merge, behind the deterministic trigger and the commit gate.
+
+## Architectural Approach
+
+The rebalance phase runs after the curator has written leaves and before (or as part of) the final deterministic rebuild. The deterministic trigger evaluates the metrics with hysteresis. If nothing trips, the phase is a no-op and the run ends as today. If a threshold trips, the LLM proposes structural operations for the affected branches; a deterministic move primitive applies them as content-preserving renames; then the deterministic rebuild regenerates the affected index nodes and `nodes_hash`. Everything is left uncommitted for the human.
+
+```mermaid
+flowchart TD
+    A[curation wrote leaves] --> B[deterministic trigger reads metrics]
+    B --> C{threshold tripped<br/>past hysteresis margin?}
+    C -- no --> Z[no structural change, end run as today]
+    C -- yes --> D[LLM proposes ops on affected branches only]
+    D --> E1[split folder: cluster children -> subfolders]
+    D --> E2[split leaf: doc -> folder of index + 2+ docs]
+    D --> E3[merge: collapse sparse / redundant]
+    D --> E4[create branch: novel top-level topic]
+    E1 --> F[apply moves as git renames<br/>content byte-stable, ids stable]
+    E2 --> F
+    E3 --> F
+    E4 --> F
+    F --> G[deterministic rebuild of affected index.md + nodes_hash]
+    G --> H[emit structural summary]
+    H --> I[all changes uncommitted in one diff]
+    I --> J{human review}
+    J -- commit --> K[accept]
+    J -- restore --> L[reject, path-scoped]
+```
+
+Hysteresis is the safety mechanism that replaces the missing human checkpoint inside the run. A split fires only when a folder is well past its maximum, and a merge only when a branch is well below its minimum, with a gap between the two so a single borderline leaf cannot tip a folder back and forth across consecutive runs. Split leaf fires only when a single leaf clearly covers two or more distinct concepts and has grown past a size threshold.
+
+## Risk Considerations and Mitigation Strategies
+
+<details>
+<summary>Quality Risks</summary>
+
+- **Tree thrash.** Without an in-run checkpoint, structural decisions could oscillate.
+  - **Mitigation**: hysteresis margins with a gap between split and merge thresholds; the trigger is deterministic and testable; thrash is asserted against in tests by running curate twice on a borderline fixture and confirming the second run is a structural no-op.
+- **Bad clustering.** The LLM splits along a poor axis.
+  - **Mitigation**: act-and-fold leaves the result uncommitted; `git restore` is path-scoped so the human can reject only the structural moves; the structural summary makes the decision legible.
+- **Noisy diffs.** Relocations look like mass churn.
+  - **Mitigation**: preserve content byte-for-byte so git records renames; stable ids mean no referencing file is rewritten.
+</details>
+
+<details>
+<summary>Technical Risks</summary>
+
+- **Determinism contract violation.** The structural decision is non-deterministic.
+  - **Mitigation**: quarantine non-determinism to the clustering step; keep the trigger and the post-move rebuild deterministic; the determinism golden tests cover regeneration after a fixed move.
+- **Id collisions on split leaf.** New sub-leaf ids could collide.
+  - **Mitigation**: reuse the existing `ensureUniqueId` mint; record a redirect from the old id in history.
+</details>
+
+<details>
+<summary>Scope Risks</summary>
+
+- **Rebalance creeping into every run.** Running structural reasoning unconditionally would make curate expensive and burdensome.
+  - **Mitigation**: the deterministic trigger skips the LLM phase entirely when nothing trips; this is asserted in tests.
+- **Becoming a second command or nudge.** That would add the burden this plan exists to avoid.
+  - **Mitigation**: rebalance is only a phase of curate. An explicit `kenkeep rebalance` power-user command is optional and out of scope here.
+</details>
+
+## Success Criteria
+
+### Primary Success Criteria
+
+1. Rebalance runs only as the final phase of `/kk-curate`; there is no new required command and no new nudge.
+2. The trigger is deterministic and LLM-free; when no metric trips past the hysteresis margin, the LLM phase is skipped and curate ends as before with zero added cost.
+3. The four operations (split folder, split leaf, merge, create branch) are implemented and operate on affected branches only.
+4. Moves preserve file content byte-for-byte so git records renames; ids are stable across moves; split leaf mints new ids and leaves a redirect.
+5. All structural and curation changes land in one uncommitted working-tree diff; commit accepts, path-scoped restore rejects just the structural moves.
+6. The curate run emits a structural summary mapping the diff.
+7. Running curate twice on a borderline fixture yields a structural no-op on the second run (no thrash).
+8. The post-move deterministic rebuild is byte-stable; `npm test`, `npm run typecheck`, and `npm run lint` pass.
+
+## Self Validation
+
+After all tasks complete, execute these concrete steps:
+
+1. Run `npm run build` then `npm test`; confirm exit 0, including rebalance trigger, operation, and no-thrash tests.
+2. Drive a curate run on a balanced fixture and confirm `git status` shows only curation changes and the structural summary reports no actions (LLM phase skipped).
+3. Drive a curate run on an over-full folder fixture and confirm a split occurs, the diff records renames (`git diff --summary` shows R entries), ids are unchanged for moved leaves, and the affected index nodes regenerate.
+4. Drive a split-leaf fixture (one bloated leaf) and confirm it becomes a folder with an index node plus two or more documents, with new ids and a redirect recorded.
+5. Run curate twice on a borderline fixture and confirm the second run performs no structural change.
+6. Reject a structural result with a path-scoped `git restore` and confirm the curation leaf writes remain.
+7. Run `index rebuild` after a move and confirm byte-stable regeneration; run `npm run typecheck` and `npm run lint`.
+
+## Documentation
+
+Yes, this plan updates documentation. Required updates:
+
+- `docs/how-it-works.md` and `docs/daily-use.md`: rebalance as the final phase of curate, act-and-fold, and the review model.
+- `AGENTS.md`: the capture / curation / rebalance / discovery pipeline description.
+- KB nodes (left uncommitted for human acceptance): a new practice node for the rebalance trigger and hysteresis, a new map node for the rebalance phase and the move primitive, and updates to `map-curate-command` and `practice-review-nodes-via-git`.
+
+## Resource Requirements
+
+### Development Skills
+
+- TypeScript, the curate skill and primitives, and `git` rename semantics.
+- Judgment about clustering and threshold calibration; the determinism contract.
+
+### Technical Infrastructure
+
+- Existing Node toolchain and `git`. No new dependencies; no daemons or background services.
+
+## Notes
+
+- No em dashes in changed files (`practice-no-em-dashes`).
+- Conventional Commits; one logical change per PR.
+- Do not run curate (and therefore rebalance) in CI; it is human-supervised and launches the LLM.
+- If smaller review surface is desired, this plan can be executed as two task groups: the deterministic trigger and metrics consumer first, then the structural operations.
+- Develop on branch `claude/cankeb-node-storage-4mgca`. Do not open a pull request.

--- a/.ai/strikethroo/plans/45--treeify-flat-to-tree-migration/plan-45--treeify-flat-to-tree-migration.md
+++ b/.ai/strikethroo/plans/45--treeify-flat-to-tree-migration/plan-45--treeify-flat-to-tree-migration.md
@@ -1,0 +1,156 @@
+---
+id: 45
+summary: "Add a one-time supervised treeify command that clusters an existing flat knowledge base into the tree layout, preserving ids and bumping schema_version, so existing KBs need not be re-bootstrapped from scratch"
+created: 2026-06-05
+---
+
+# Plan: Treeify flat-to-tree migration
+
+## Original Work Order
+
+> Plan 1 is a clean break: the new reader rejects the old flat nodes/<kind>/ layout. Existing knowledge bases, including this repository's own 56 nodes, must not be lost or re-bootstrapped from documentation (which cannot reconstruct curated nodes). Provide a one-time, supervised treeify command that clusters the existing flat leaves into the new topical tree, creates the index nodes, preserves ids, and bumps schema_version. It is supervised like bootstrap: the human reviews the result on disk and accepts by git commit or rejects by git restore.
+
+This is Plan 5 of 5. It depends on Plan 1 (tree storage and recursive index nodes) and shares clustering judgment with Plan 4.
+
+## Plan Clarifications
+
+| Question | Answer |
+|----------|--------|
+| Why is this needed if Plan 1 is a clean break? | The clean break refers to no migrator in the runtime reader. Treeify is a separate, explicit, one-time supervised migration command, not a silent compatibility shim. It exists so curated knowledge survives the layout change. |
+| What does treeify do? | Read the existing flat leaves, cluster them into topical folders, write the leaves into those folders preserving ids, bump `schema_version`, and let Plan 1's rebuild generate the index nodes. |
+| Is it supervised? | Yes, like bootstrap. It writes node files to disk; the human reviews by git diff and accepts by commit or rejects by restore. It never overwrites without review and never commits on its own. |
+| Does it preserve ids and edges? | Yes. Ids are preserved so `relates_to` / `depends_on` keep resolving; only folder placement and `schema_version` change. |
+| Is it idempotent or repeatable? | It is a one-time migration. Run against an already-migrated tree, it detects the new layout and refuses, pointing the user to curate or rebalance instead. |
+| Is backwards compatibility required? | No. This is the migration itself; there is no ongoing dual-layout support. |
+
+## Executive Summary
+
+Plan 1 changes the storage layout and bumps `schema_version`, so the new reader rejects the old flat `nodes/<kind>/` knowledge base. That is the intended clean break for the runtime, but it would strand every existing knowledge base, including this repository's own curated nodes, which cannot be reconstructed by re-running bootstrap from documentation. This plan provides the one-time, supervised migration that carries curated knowledge across the break.
+
+Treeify reads the existing flat leaves, clusters them into topical folders, and writes each leaf into its folder with its id and edges intact, bumping `schema_version` to the new value. It then relies on Plan 1's deterministic rebuild to generate the index nodes and `GRAPH.md`. The operation is supervised exactly like bootstrap: it writes files to disk and stops, leaving the human to review by git diff and accept by commit or reject by restore. It never overwrites without review and never commits.
+
+Because clustering is the same judgment the rebalance plan makes, treeify reuses that reasoning to choose the initial folders. It is explicitly one-time: run against an already-migrated tree, it detects the new layout and refuses rather than reshuffling. This plan closes the sequencing gap opened by Plan 1, so the program can land end to end without losing the knowledge it was built to preserve.
+
+## Context
+
+### Current State vs Target State
+
+| Current State | Target State | Why? |
+|---------------|--------------|------|
+| After Plan 1, the new reader rejects the old flat KB; no path forward for existing nodes | A one-time `treeify` command migrates the flat KB into the tree layout | Curated knowledge cannot be reconstructed from docs; it must be migrated, not re-bootstrapped |
+| Bootstrap seeds an empty KB from documentation | Treeify reorganizes an existing populated KB; it does not read documentation | Different input (existing nodes) and goal (relayout, not seeding) |
+| Ids tied to flat `kind` directories | Ids preserved; only placement and `schema_version` change | Edges must keep resolving; identity is independent of placement |
+| Index nodes do not exist for the old KB | Plan 1's rebuild generates index nodes after treeify writes the leaves | Treeify writes leaves; generation is Plan 1's deterministic job |
+| No guard against re-running on a migrated tree | Treeify detects the new layout and refuses | A one-time migration must not reshuffle an established tree |
+
+### Background
+
+Relevant code and conventions:
+
+- The bootstrap launcher and skill model for supervised, on-disk, human-reviewed knowledge writes: `map-kk-bootstrap-skill`, `map-bootstrap-incremental-command`, `practice-bootstrap-never-overwrites-existing-nodes`, `practice-bootstrap-is-supervised-and-judgmental`.
+- The CLI launcher / primitive split: launchers exec the host harness in `-p` mode for LLM work; primitives are deterministic (`map-kenkeep-package`, the curate and bootstrap maps). Treeify clustering is LLM work (a launcher); writing and `schema_version` bumping are deterministic primitives.
+- Plan 1's reader, layout, and deterministic rebuild; Plan 4's clustering judgment.
+- The recursion guard: launchers that exec the host harness must set `KENKEEP_BUILDER_INTERNAL=1` on the child (`practice-recursion-guard-kenkeep-builder-internal`).
+- Constitution: plain markdown in git, human-in-the-loop acceptance by git commit, no databases. Do not run treeify in CI.
+
+This plan should land immediately after Plan 1 so the repository's own knowledge base, and any user's, can cross the break without loss.
+
+## Architectural Approach
+
+Treeify is a supervised launcher plus deterministic write primitives, mirroring bootstrap. The launcher reads the flat leaves, clusters them into an initial topical folder structure (reusing Plan 4's clustering judgment), and proposes placements. A deterministic primitive writes each leaf into its target folder preserving id and edges, bumps `schema_version`, and then Plan 1's rebuild generates the index nodes. The human reviews and accepts or rejects.
+
+```mermaid
+flowchart TD
+    A[treeify launcher] --> B{detect layout}
+    B -- already tree --> R[refuse: point to curate / rebalance]
+    B -- flat KB --> C[read flat leaves, ids + edges]
+    C --> D[LLM clusters leaves -> topical folders]
+    D --> E[deterministic write: place leaves by id,<br/>bump schema_version, preserve edges]
+    E --> F[Plan 1 deterministic rebuild:<br/>generate index.md + GRAPH.md + nodes_hash]
+    F --> G[leaves and generated files uncommitted]
+    G --> H{human review}
+    H -- commit --> I[accept migration]
+    H -- restore --> J[reject, KB unchanged]
+```
+
+Treeify never overwrites an existing tree and never commits. Its supervision model is the bootstrap model: write to disk, report what was placed where, and stop. Ids are the migration's anchor; nothing about a leaf changes except its folder and `schema_version`.
+
+## Risk Considerations and Mitigation Strategies
+
+<details>
+<summary>Quality Risks</summary>
+
+- **Poor initial clustering.** The one-time layout could be awkward.
+  - **Mitigation**: supervised review before commit; the human can move leaves by hand (ids are stable) or reject and re-run; Plan 4 rebalances over time. The treeify report lists every placement.
+- **Edge breakage.** A migration that altered ids would break `relates_to` / `depends_on`.
+  - **Mitigation**: ids are preserved by construction; a validation step (reuse `doctor --verbose` dangling-ref detection) confirms no edge dangles after migration.
+</details>
+
+<details>
+<summary>Technical Risks</summary>
+
+- **Running on an already-migrated tree.** Re-running could reshuffle an established layout.
+  - **Mitigation**: detect the new layout (or `schema_version`) and refuse with a clear message.
+- **Partial migration on interruption.** A half-written tree could be ambiguous.
+  - **Mitigation**: write to disk then stop for review (no commit); a partial result is visible in git status and can be discarded with restore.
+- **Recursion when the launcher execs the host harness.**
+  - **Mitigation**: set `KENKEEP_BUILDER_INTERNAL=1` on the child per the recursion guard.
+</details>
+
+<details>
+<summary>Scope Risks</summary>
+
+- **Becoming an ongoing dual-layout shim.** That would contradict the clean-break policy.
+  - **Mitigation**: treeify is explicitly one-time and refuses on a migrated tree; there is no runtime dual-layout support.
+</details>
+
+## Success Criteria
+
+### Primary Success Criteria
+
+1. `treeify` migrates an existing flat KB into the tree layout, clustering leaves into topical folders.
+2. Every leaf keeps its id and its `relates_to` / `depends_on` edges; only folder placement and `schema_version` change.
+3. After treeify writes the leaves, Plan 1's deterministic rebuild generates the index nodes, `GRAPH.md`, and `nodes_hash`; no edge dangles (verified by doctor).
+4. Treeify is supervised: it writes to disk and stops; the human accepts by commit or rejects by restore; it never overwrites without review and never commits.
+5. Run against an already-migrated tree, treeify detects the layout and refuses with a clear message.
+6. The migration report lists every leaf and its assigned folder.
+7. The repository's own flat KB migrates successfully and reads correctly under the new code path; `npm test`, `npm run typecheck`, and `npm run lint` pass.
+
+## Self Validation
+
+After all tasks complete, execute these concrete steps:
+
+1. Run `npm run build` then `npm test`; confirm exit 0, including treeify migration and refuse-on-migrated tests.
+2. Run `treeify` against a flat-KB fixture and confirm every leaf is placed in a folder, all ids are unchanged (`git diff` shows renames and frontmatter `schema_version` bumps, not id changes), and the migration report lists placements.
+3. Run `node dist/cli.js doctor --verbose` after migration and confirm no dangling references.
+4. Run Plan 1's `index rebuild` after migration and confirm index nodes and `GRAPH.md` are generated and byte-stable on a second run.
+5. Run `treeify` again on the migrated tree and confirm it refuses with the expected message and makes no changes.
+6. Migrate the repository's own `.ai/kenkeep/nodes/` on a scratch copy and confirm the new reader and SessionStart hook read it correctly.
+7. Run `npm run typecheck` and `npm run lint`; confirm both pass.
+
+## Documentation
+
+Yes, this plan updates documentation. Required updates:
+
+- `docs/installation.md` and `docs/troubleshooting.md`: how to migrate an existing KB with treeify, and that it is one-time and supervised.
+- `AGENTS.md`: note the migration path for the layout change introduced in Plan 1.
+- KB nodes (left uncommitted for human acceptance): a new map node for the treeify command and a practice node mirroring the bootstrap supervision and never-overwrite rules for migration.
+
+## Resource Requirements
+
+### Development Skills
+
+- TypeScript, the bootstrap launcher / primitive pattern, and the host-harness `-p` invocation with the recursion guard.
+- Clustering judgment shared with Plan 4; the determinism contract for the post-write rebuild.
+
+### Technical Infrastructure
+
+- Existing Node toolchain, the host harness for the LLM clustering step, and `git`. No new dependencies.
+
+## Notes
+
+- No em dashes in changed files (`practice-no-em-dashes`).
+- Conventional Commits; one logical change per PR.
+- Do not run treeify in CI; it launches the host harness and the LLM and is human-supervised.
+- Land this plan immediately after Plan 1 to close the window in which the repo's own flat KB is unreadable by the new code path.
+- Develop on branch `claude/cankeb-node-storage-4mgca`. Do not open a pull request.


### PR DESCRIPTION
Five-plan program to veer kenkeep from flat node storage to a
tree-over-DAG knowledge base with progressive disclosure:

- 41: tree storage + recursive deterministic index nodes (keystone)
- 42: curation home-branch placement
- 43: discovery tree descent (root-only SessionStart injection)
- 44: rebalance act-and-fold into curate (Phase 2)
- 45: treeify one-time flat-to-tree migration

PRDs only (no tasks/phases per PRE_PLAN); each carries a Self
Validation section and a documentation answer per POST_PLAN.

https://claude.ai/code/session_01NZUD6gbKfKQgwVi4XudePP