### PR TITLE
fix: use correct launch argv for codex and opencode

### DIFF
--- a/src/harnesses/claude/index.ts
+++ b/src/harnesses/claude/index.ts
@@ -84,6 +84,7 @@ async function claudeListMemoryFiles(opts: { timeoutMs?: number } = {}): Promise
 export const claudeAdapter: HarnessAdapter = {
   id: 'claude',
   launchBinary: 'claude',
+  launchArgsPrefix: ['-p'],
   hooks: CLAUDE_HOOK_SPECS,
   paths: claudePaths,
   install: opts => installClaude(opts),

--- a/src/harnesses/codex/index.ts
+++ b/src/harnesses/codex/index.ts
@@ -29,6 +29,7 @@ function codexPaths(root: string): HarnessPaths {
 export const codexAdapter: HarnessAdapter = {
   id: 'codex',
   launchBinary: 'codex',
+  launchArgsPrefix: ['exec'],
   hooks: codexHookSpecs,
   paths: codexPaths,
   install: opts => installCodex(opts),

--- a/src/harnesses/copilot/index.ts
+++ b/src/harnesses/copilot/index.ts
@@ -35,6 +35,7 @@ function copilotAdapterPaths(root: string): HarnessPaths {
 export const copilotAdapter: HarnessAdapter = {
   id: 'copilot',
   launchBinary: 'copilot',
+  launchArgsPrefix: ['-p'],
   hooks: copilotHookSpecs,
   paths: copilotAdapterPaths,
   install: opts => installCopilot(opts),

--- a/src/harnesses/cursor/index.ts
+++ b/src/harnesses/cursor/index.ts
@@ -32,6 +32,7 @@ function cursorPaths(root: string): HarnessPaths {
 export const cursorAdapter: HarnessAdapter = {
   id: 'cursor',
   launchBinary: 'agent',
+  launchArgsPrefix: ['-p'],
   hooks: cursorHookSpecs,
   paths: cursorPaths,
   install: opts => installCursor(opts),

--- a/src/harnesses/opencode/index.ts
+++ b/src/harnesses/opencode/index.ts
@@ -32,6 +32,7 @@ function openCodePaths(root: string): HarnessPaths {
 export const openCodeAdapter: HarnessAdapter = {
   id: 'opencode',
   launchBinary: 'opencode',
+  launchArgsPrefix: ['run'],
   hooks: openCodeHookSpecs,
   paths: openCodePaths,
   install: opts => installOpenCode(opts),

--- a/src/harnesses/types.ts
+++ b/src/harnesses/types.ts
@@ -127,11 +127,19 @@ export interface HarnessAdapter {
   /**
    * Name of the executable the CLI launcher commands (`bootstrap`,
    * `curate`, `node add`) should `spawn` to dispatch a slash-command into
-   * this harness via its non-interactive (`-p "/kk-…"`) entrypoint. Looked
-   * up on `PATH`. Examples: `claude`, `codex`, `agent` (Cursor),
-   * `opencode`.
+   * this harness. Looked up on `PATH`. Examples: `claude`, `codex`,
+   * `agent` (Cursor), `opencode`.
    */
   readonly launchBinary: string;
+
+  /**
+   * Prefix argv elements the launcher prepends before the slash-command
+   * payload when spawning the harness binary. The harness-neutral launcher
+   * appends the slash payload (e.g. `/kk-curate`) as the final positional.
+   * Examples: `['-p']` (Claude, Cursor, Copilot), `['exec']` (Codex),
+   * `['run']` (OpenCode).
+   */
+  readonly launchArgsPrefix: readonly string[];
 
   /** Hook lifecycle declarations this adapter actually registers. */
   readonly hooks: readonly HookSpec[];

--- a/src/lib/launch-skill.ts
+++ b/src/lib/launch-skill.ts
@@ -42,6 +42,22 @@ export interface LaunchSkillOptions {
 }
 
 /**
+ * Builds the full argv array for a harness launch. The prefix is the
+ * harness-specific entrypoint (e.g. `['-p']`, `['exec']`, `['run']`).
+ * The slash payload is the skill name plus optional trailing arguments.
+ * Shared across all adapters; each harness only declares its prefix.
+ */
+export function buildLaunchArgs(
+  prefix: readonly string[],
+  skill: string,
+  passedArgs?: string
+): string[] {
+  const passed = passedArgs?.trim() ?? '';
+  const slashPayload = passed.length > 0 ? `/${skill} ${passed}` : `/${skill}`;
+  return [...prefix, slashPayload];
+}
+
+/**
  * Resolves the active harness, builds the slash-command argv, and spawns
  * the harness binary with the user's stdio inherited (so Ctrl-C, TTY
  * prompts, and the harness's rich output flow naturally). Exits the
@@ -62,9 +78,7 @@ export function launchSkill(opts: LaunchSkillOptions): void {
   });
 
   const binary = harness.launchBinary;
-  const passed = opts.passedArgs?.trim() ?? '';
-  const slashPayload = passed.length > 0 ? `/${opts.skill} ${passed}` : `/${opts.skill}`;
-  const args: string[] = ['-p', slashPayload];
+  const args = buildLaunchArgs(harness.launchArgsPrefix, opts.skill, opts.passedArgs);
 
   const spawnImpl = opts.spawnFn ?? spawn;
   const exitImpl = opts.exitFn ?? ((code: number): never => process.exit(code));

--- a/tests/commands/launchers.test.ts
+++ b/tests/commands/launchers.test.ts
@@ -15,8 +15,9 @@ import { launchSkill } from '../../src/lib/launch-skill.js';
  * actually spawned and the test process is never terminated.
  *
  * The contract we are pinning down: the launcher exec's `<harness-binary>
- * -p "/kk-<skill> …"` with `KENKEEP_BUILDER_INTERNAL=1` set on the child env
- * and `stdio: 'inherit'`. Plus the deprecation alias must write a
+ * <harness-specific-args> "/kk-<skill> …"` with `KENKEEP_BUILDER_INTERNAL=1`
+ * set on the child env and `stdio: 'inherit'`. Most harnesses use `-p`, but
+ * OpenCode uses `run`. Plus the deprecation alias must write a
  * `[deprecated]` notice to stderr before launching.
  */
 
@@ -127,7 +128,7 @@ describe('launchSkill', () => {
     const { spawnFn, captured } = makeFakeSpawn();
     const exitFn = vi.fn((_code: number) => undefined as never);
     launchSkill({ skill: 'kk-curate', harness: 'codex', spawnFn, exitFn });
-    expect(captured[0]!.args.args).toEqual(['-p', '/kk-curate']);
+    expect(captured[0]!.args.args).toEqual(['exec', '/kk-curate']);
     expect(captured[0]!.args.binary).toBe('codex');
   });
 
@@ -144,6 +145,22 @@ describe('launchSkill', () => {
       launchSkill({ skill: 'kk-add', harness, spawnFn, exitFn });
       expect(captured[0]!.args.binary, `harness ${harness}`).toBe(expectedBinary);
     }
+  });
+
+  it('uses opencode run instead of -p for the opencode harness', () => {
+    const { spawnFn, captured } = makeFakeSpawn();
+    const exitFn = vi.fn((_code: number) => undefined as never);
+    launchSkill({ skill: 'kk-curate', harness: 'opencode', spawnFn, exitFn });
+    expect(captured[0]!.args.binary).toBe('opencode');
+    expect(captured[0]!.args.args).toEqual(['run', '/kk-curate']);
+  });
+
+  it('uses codex exec instead of -p for the codex harness', () => {
+    const { spawnFn, captured } = makeFakeSpawn();
+    const exitFn = vi.fn((_code: number) => undefined as never);
+    launchSkill({ skill: 'kk-curate', harness: 'codex', spawnFn, exitFn });
+    expect(captured[0]!.args.binary).toBe('codex');
+    expect(captured[0]!.args.args).toEqual(['exec', '/kk-curate']);
   });
 });
 


### PR DESCRIPTION
The launcher hardcoded  for every harness, but neither codex nor opencode support a  flag.

Codex non-interactive mode is .
OpenCode non-interactive mode is .

Added  to the  interface so each adapter declares its own native argv. Claude, Cursor, and Copilot keep ; Codex and OpenCode now use  and  respectively.