### PR TITLE
docs: tell users to run `index rebuild` after a `git restore` that drops nodes

### DIFF
--- a/.agents/skills/kk-bootstrap/SKILL.md
+++ b/.agents/skills/kk-bootstrap/SKILL.md
@@ -260,7 +260,7 @@ When you're done, summarize for the user:
 - Any docs that looked stale or contradictory that the user should double-check.
 - Confirmation that `ENTRY.md` and `GRAPH.md` were refreshed.
 
-Then tell the user to review the written files, accept by leaving them in place, and reject by deleting them (`rm nodes/<folder>/<file>.md`).
+Then tell the user to review the written files, accept by leaving them in place, and reject by deleting them (`rm nodes/<folder>/<file>.md`). The indices were already rebuilt above to include every written node, so if they delete any, they must run `npx kenkeep index rebuild` afterward to drop the removed nodes from `ENTRY.md`/`GRAPH.md` and the per-folder `index.md` tree.
 
 ## Constraints
 

--- a/.agents/skills/kk-curate/SKILL.md
+++ b/.agents/skills/kk-curate/SKILL.md
@@ -461,7 +461,7 @@ It prints one JSON line, the structural summary you carry into Step 7:
 {"moves":[{"operation":"...","id":"...","from":"...","to":"...","newIds":["..."],"redirectFrom":"..."}, ...]}
 ```
 
-Capture it. Do not commit, add, or restore anything: the structural moves and the curation leaf writes now sit together in one uncommitted working-tree diff. The human accepts by `git commit` and rejects just the structural moves by path-scoped `git restore`.
+Capture it. Do not commit, add, or restore anything: the structural moves and the curation leaf writes now sit together in one uncommitted working-tree diff. The human accepts by `git commit` and rejects just the structural moves by path-scoped `git restore` — after which they must run `npx kenkeep index rebuild`, since reverting moves leaves the generated index pointing at the old layout.
 
 ## 7. Report the summary, then handle conflicts
 
@@ -470,7 +470,7 @@ Tell the user the headline numbers (`kept`, `conflicts`, `stamped`, `runId`), th
 **Structural summary (rebalance).** Then print the structural summary from the rebalance phase (Step 6b), distinct from and additional to the content summary above so the human gets a legend for the structural diff:
 
 - If 6b.1 reported no action, print one line: `Rebalance: no structural action (tree balanced).`
-- Otherwise, for each move in the `{"moves":[...]}` summary, print one line naming the operation and the affected branch: a `split-folder` / `merge` / `create-branch` shows `<id>: <from> -> <to>`; a `split-leaf` shows `<old-id> -> <new-id>, <new-id>, ... (redirect recorded)`. Close with: `Review the structural diff with \`git diff --summary\` (R entries are renames); accept by \`git commit\`, reject just the structural moves with a path-scoped \`git restore\`.`
+- Otherwise, for each move in the `{"moves":[...]}` summary, print one line naming the operation and the affected branch: a `split-folder` / `merge` / `create-branch` shows `<id>: <from> -> <to>`; a `split-leaf` shows `<old-id> -> <new-id>, <new-id>, ... (redirect recorded)`. Close with: `Review the structural diff with \`git diff --summary\` (R entries are renames); accept by \`git commit\`, reject just the structural moves with a path-scoped \`git restore\` (then run \`npx kenkeep index rebuild\` to resync the generated index).`
 
 **If `conflicts == 0`**, print the placement lines, the structural summary, and then exactly one summary line, and stop:
 
@@ -549,7 +549,7 @@ After every conflict in a group is decided, move to the next group.
 
 ## 8. Hand off
 
-Tell the user to review the changed nodes and conflict files under `.ai/kenkeep/`. `ENTRY.md` and `GRAPH.md` were refreshed in step 6 (and again by the rebalance move primitive if the rebalance phase acted). Any structural moves from Step 6b sit in the same uncommitted diff; the human accepts everything by `git commit` or rejects just the structural moves with a path-scoped `git restore`.
+Tell the user to review the changed nodes and conflict files under `.ai/kenkeep/`. `ENTRY.md` and `GRAPH.md` were refreshed in step 6 (and again by the rebalance move primitive if the rebalance phase acted). Any structural moves from Step 6b sit in the same uncommitted diff; the human accepts everything by `git commit` or rejects just the structural moves with a path-scoped `git restore`. After any `git restore` that drops a written leaf or reverts a move, they must run `npx kenkeep index rebuild` so `ENTRY.md`/`GRAPH.md` and the per-folder `index.md` tree stop referencing the removed content.
 
 ## Constraints
 

--- a/.agents/skills/kk-migrate/SKILL.md
+++ b/.agents/skills/kk-migrate/SKILL.md
@@ -171,7 +171,7 @@ Tell the user the migration is staged in the working tree and **no git command w
 git diff
 ```
 
-Leaves moved into their topical folders show as renames (ids and bytes preserved); each created folder's `index.md` carries its authored summary; `ENTRY.md` / `GRAPH.md` are refreshed. The user accepts the migration with `git commit` and rejects it with `git restore` (path-scoped or whole-tree). Do not stage, commit, or restore anything yourself.
+Leaves moved into their topical folders show as renames (ids and bytes preserved); each created folder's `index.md` carries its authored summary; `ENTRY.md` / `GRAPH.md` are refreshed. The user accepts the migration with `git commit` and rejects it with `git restore` (path-scoped or whole-tree). A path-scoped `git restore` that keeps only part of the migration must be followed by `npx kenkeep index rebuild` to resync the generated index with the on-disk tree (a whole-tree `git restore` reverts the generated files too, so it needs no rebuild). Do not stage, commit, or restore anything yourself.
 
 ## Constraints
 

--- a/.ai/kenkeep/ENTRY.md
+++ b/.ai/kenkeep/ENTRY.md
@@ -1,6 +1,6 @@
 ---
 schema_version: 2
-nodes_hash: 'sha256:61b4ed8a7e279be93630d38ac7a2069aa0dc1ebac525406a44bf882339bdf459'
+nodes_hash: 'sha256:50186d4278db0e99240298a5c9152f42469fa2f87a2b275923466d6b01c6ac7c'
 node_count: 68
 ---
 # kenkeep

--- a/.ai/kenkeep/GRAPH.md
+++ b/.ai/kenkeep/GRAPH.md
@@ -1,6 +1,6 @@
 ---
 schema_version: 2
-nodes_hash: 'sha256:61b4ed8a7e279be93630d38ac7a2069aa0dc1ebac525406a44bf882339bdf459'
+nodes_hash: 'sha256:50186d4278db0e99240298a5c9152f42469fa2f87a2b275923466d6b01c6ac7c'
 node_count: 68
 ---
 # kenkeep Graph

--- a/.ai/kenkeep/nodes/conventions/index.md
+++ b/.ai/kenkeep/nodes/conventions/index.md
@@ -1,6 +1,6 @@
 ---
 schema_version: 2
-nodes_hash: 'sha256:e8fd5c6e0a98c451c83f2a52aa891852a9cd182e99571e626200f58d87c068aa'
+nodes_hash: 'sha256:e4c2d65d9742ff3042ec52496c182f5b9f90da5ef153577feae2103986120356'
 node_count: 8
 summary: >-
   commit, release, testing, CI, and writing-style rules; read before committing,

--- a/.ai/kenkeep/nodes/conventions/practice-review-nodes-via-git.md
+++ b/.ai/kenkeep/nodes/conventions/practice-review-nodes-via-git.md
@@ -27,7 +27,7 @@ summary: >-
 Every path that writes to `nodes/` (the curator, `/kk-bootstrap`, `bootstrap-incremental`, `node add`, manual hand-edits) lands changes in the working tree for review with `git diff`. There is no separate review UI.
 
 - **Accept** — `git add nodes/<folder>/<file>.md && git commit`.
-- **Reject** — `git restore nodes/<folder>/<file>.md` (or delete the file if it's a new addition).
+- **Reject** — `git restore nodes/<folder>/<file>.md` (or delete the file if it's a new addition). When the writer already rebuilt the index over the node (the curator and `/kk-bootstrap` both do), rejecting it without committing another `nodes/` change leaves the generated index stale — run `npx kenkeep index rebuild` afterward to drop it from `ENTRY.md`/`GRAPH.md` and the per-folder `index.md` tree.
 - **Tooling** — `git diff nodes/` or a tool like [self-review](https://github.com/e0ipso/self-review).
 
 **Why:** nodes affect how the agent behaves in every future session, so each one deserves a code-review-grade decision. Reusing the existing git review workflow means no new tools to learn, and the commit history doubles as the timeline of record (this is why node frontmatter carries no timestamps).

--- a/.claude/skills/kk-bootstrap/SKILL.md
+++ b/.claude/skills/kk-bootstrap/SKILL.md
@@ -260,7 +260,7 @@ When you're done, summarize for the user:
 - Any docs that looked stale or contradictory that the user should double-check.
 - Confirmation that `ENTRY.md` and `GRAPH.md` were refreshed.
 
-Then tell the user to review the written files, accept by leaving them in place, and reject by deleting them (`rm nodes/<folder>/<file>.md`).
+Then tell the user to review the written files, accept by leaving them in place, and reject by deleting them (`rm nodes/<folder>/<file>.md`). The indices were already rebuilt above to include every written node, so if they delete any, they must run `npx kenkeep index rebuild` afterward to drop the removed nodes from `ENTRY.md`/`GRAPH.md` and the per-folder `index.md` tree.
 
 ## Constraints
 

--- a/.claude/skills/kk-curate/SKILL.md
+++ b/.claude/skills/kk-curate/SKILL.md
@@ -461,7 +461,7 @@ It prints one JSON line, the structural summary you carry into Step 7:
 {"moves":[{"operation":"...","id":"...","from":"...","to":"...","newIds":["..."],"redirectFrom":"..."}, ...]}
 ```
 
-Capture it. Do not commit, add, or restore anything: the structural moves and the curation leaf writes now sit together in one uncommitted working-tree diff. The human accepts by `git commit` and rejects just the structural moves by path-scoped `git restore`.
+Capture it. Do not commit, add, or restore anything: the structural moves and the curation leaf writes now sit together in one uncommitted working-tree diff. The human accepts by `git commit` and rejects just the structural moves by path-scoped `git restore` — after which they must run `npx kenkeep index rebuild`, since reverting moves leaves the generated index pointing at the old layout.
 
 ## 7. Report the summary, then handle conflicts
 
@@ -470,7 +470,7 @@ Tell the user the headline numbers (`kept`, `conflicts`, `stamped`, `runId`), th
 **Structural summary (rebalance).** Then print the structural summary from the rebalance phase (Step 6b), distinct from and additional to the content summary above so the human gets a legend for the structural diff:
 
 - If 6b.1 reported no action, print one line: `Rebalance: no structural action (tree balanced).`
-- Otherwise, for each move in the `{"moves":[...]}` summary, print one line naming the operation and the affected branch: a `split-folder` / `merge` / `create-branch` shows `<id>: <from> -> <to>`; a `split-leaf` shows `<old-id> -> <new-id>, <new-id>, ... (redirect recorded)`. Close with: `Review the structural diff with \`git diff --summary\` (R entries are renames); accept by \`git commit\`, reject just the structural moves with a path-scoped \`git restore\`.`
+- Otherwise, for each move in the `{"moves":[...]}` summary, print one line naming the operation and the affected branch: a `split-folder` / `merge` / `create-branch` shows `<id>: <from> -> <to>`; a `split-leaf` shows `<old-id> -> <new-id>, <new-id>, ... (redirect recorded)`. Close with: `Review the structural diff with \`git diff --summary\` (R entries are renames); accept by \`git commit\`, reject just the structural moves with a path-scoped \`git restore\` (then run \`npx kenkeep index rebuild\` to resync the generated index).`
 
 **If `conflicts == 0`**, print the placement lines, the structural summary, and then exactly one summary line, and stop:
 
@@ -549,7 +549,7 @@ After every conflict in a group is decided, move to the next group.
 
 ## 8. Hand off
 
-Tell the user to review the changed nodes and conflict files under `.ai/kenkeep/`. `ENTRY.md` and `GRAPH.md` were refreshed in step 6 (and again by the rebalance move primitive if the rebalance phase acted). Any structural moves from Step 6b sit in the same uncommitted diff; the human accepts everything by `git commit` or rejects just the structural moves with a path-scoped `git restore`.
+Tell the user to review the changed nodes and conflict files under `.ai/kenkeep/`. `ENTRY.md` and `GRAPH.md` were refreshed in step 6 (and again by the rebalance move primitive if the rebalance phase acted). Any structural moves from Step 6b sit in the same uncommitted diff; the human accepts everything by `git commit` or rejects just the structural moves with a path-scoped `git restore`. After any `git restore` that drops a written leaf or reverts a move, they must run `npx kenkeep index rebuild` so `ENTRY.md`/`GRAPH.md` and the per-folder `index.md` tree stop referencing the removed content.
 
 ## Constraints
 

--- a/.claude/skills/kk-migrate/SKILL.md
+++ b/.claude/skills/kk-migrate/SKILL.md
@@ -171,7 +171,7 @@ Tell the user the migration is staged in the working tree and **no git command w
 git diff
 ```
 
-Leaves moved into their topical folders show as renames (ids and bytes preserved); each created folder's `index.md` carries its authored summary; `ENTRY.md` / `GRAPH.md` are refreshed. The user accepts the migration with `git commit` and rejects it with `git restore` (path-scoped or whole-tree). Do not stage, commit, or restore anything yourself.
+Leaves moved into their topical folders show as renames (ids and bytes preserved); each created folder's `index.md` carries its authored summary; `ENTRY.md` / `GRAPH.md` are refreshed. The user accepts the migration with `git commit` and rejects it with `git restore` (path-scoped or whole-tree). A path-scoped `git restore` that keeps only part of the migration must be followed by `npx kenkeep index rebuild` to resync the generated index with the on-disk tree (a whole-tree `git restore` reverts the generated files too, so it needs no rebuild). Do not stage, commit, or restore anything yourself.
 
 ## Constraints
 

--- a/.cursor/skills/kk-bootstrap/SKILL.md
+++ b/.cursor/skills/kk-bootstrap/SKILL.md
@@ -259,7 +259,7 @@ When you're done, summarize for the user:
 - Any docs that looked stale or contradictory that the user should double-check.
 - Confirmation that `ENTRY.md` and `GRAPH.md` were refreshed.
 
-Then tell the user to review the written files, accept by leaving them in place, and reject by deleting them (`rm nodes/<folder>/<file>.md`).
+Then tell the user to review the written files, accept by leaving them in place, and reject by deleting them (`rm nodes/<folder>/<file>.md`). The indices were already rebuilt above to include every written node, so if they delete any, they must run `npx kenkeep index rebuild` afterward to drop the removed nodes from `ENTRY.md`/`GRAPH.md` and the per-folder `index.md` tree.
 
 ## Constraints
 

--- a/.cursor/skills/kk-curate/SKILL.md
+++ b/.cursor/skills/kk-curate/SKILL.md
@@ -460,7 +460,7 @@ It prints one JSON line, the structural summary you carry into Step 7:
 {"moves":[{"operation":"...","id":"...","from":"...","to":"...","newIds":["..."],"redirectFrom":"..."}, ...]}
 ```
 
-Capture it. Do not commit, add, or restore anything: the structural moves and the curation leaf writes now sit together in one uncommitted working-tree diff. The human accepts by `git commit` and rejects just the structural moves by path-scoped `git restore`.
+Capture it. Do not commit, add, or restore anything: the structural moves and the curation leaf writes now sit together in one uncommitted working-tree diff. The human accepts by `git commit` and rejects just the structural moves by path-scoped `git restore` — after which they must run `npx kenkeep index rebuild`, since reverting moves leaves the generated index pointing at the old layout.
 
 ## 7. Report the summary, then handle conflicts
 
@@ -469,7 +469,7 @@ Tell the user the headline numbers (`kept`, `conflicts`, `stamped`, `runId`), th
 **Structural summary (rebalance).** Then print the structural summary from the rebalance phase (Step 6b), distinct from and additional to the content summary above so the human gets a legend for the structural diff:
 
 - If 6b.1 reported no action, print one line: `Rebalance: no structural action (tree balanced).`
-- Otherwise, for each move in the `{"moves":[...]}` summary, print one line naming the operation and the affected branch: a `split-folder` / `merge` / `create-branch` shows `<id>: <from> -> <to>`; a `split-leaf` shows `<old-id> -> <new-id>, <new-id>, ... (redirect recorded)`. Close with: `Review the structural diff with \`git diff --summary\` (R entries are renames); accept by \`git commit\`, reject just the structural moves with a path-scoped \`git restore\`.`
+- Otherwise, for each move in the `{"moves":[...]}` summary, print one line naming the operation and the affected branch: a `split-folder` / `merge` / `create-branch` shows `<id>: <from> -> <to>`; a `split-leaf` shows `<old-id> -> <new-id>, <new-id>, ... (redirect recorded)`. Close with: `Review the structural diff with \`git diff --summary\` (R entries are renames); accept by \`git commit\`, reject just the structural moves with a path-scoped \`git restore\` (then run \`npx kenkeep index rebuild\` to resync the generated index).`
 
 **If `conflicts == 0`**, print the placement lines, the structural summary, and then exactly one summary line, and stop:
 
@@ -548,7 +548,7 @@ After every conflict in a group is decided, move to the next group.
 
 ## 8. Hand off
 
-Tell the user to review the changed nodes and conflict files under `.ai/kenkeep/`. `ENTRY.md` and `GRAPH.md` were refreshed in step 6 (and again by the rebalance move primitive if the rebalance phase acted). Any structural moves from Step 6b sit in the same uncommitted diff; the human accepts everything by `git commit` or rejects just the structural moves with a path-scoped `git restore`.
+Tell the user to review the changed nodes and conflict files under `.ai/kenkeep/`. `ENTRY.md` and `GRAPH.md` were refreshed in step 6 (and again by the rebalance move primitive if the rebalance phase acted). Any structural moves from Step 6b sit in the same uncommitted diff; the human accepts everything by `git commit` or rejects just the structural moves with a path-scoped `git restore`. After any `git restore` that drops a written leaf or reverts a move, they must run `npx kenkeep index rebuild` so `ENTRY.md`/`GRAPH.md` and the per-folder `index.md` tree stop referencing the removed content.
 
 ## Constraints
 

--- a/.opencode/skills/kk-bootstrap/SKILL.md
+++ b/.opencode/skills/kk-bootstrap/SKILL.md
@@ -260,7 +260,7 @@ When you're done, summarize for the user:
 - Any docs that looked stale or contradictory that the user should double-check.
 - Confirmation that `ENTRY.md` and `GRAPH.md` were refreshed.
 
-Then tell the user to review the written files, accept by leaving them in place, and reject by deleting them (`rm nodes/<folder>/<file>.md`).
+Then tell the user to review the written files, accept by leaving them in place, and reject by deleting them (`rm nodes/<folder>/<file>.md`). The indices were already rebuilt above to include every written node, so if they delete any, they must run `npx kenkeep index rebuild` afterward to drop the removed nodes from `ENTRY.md`/`GRAPH.md` and the per-folder `index.md` tree.
 
 ## Constraints
 

--- a/.opencode/skills/kk-curate/SKILL.md
+++ b/.opencode/skills/kk-curate/SKILL.md
@@ -461,7 +461,7 @@ It prints one JSON line, the structural summary you carry into Step 7:
 {"moves":[{"operation":"...","id":"...","from":"...","to":"...","newIds":["..."],"redirectFrom":"..."}, ...]}
 ```
 
-Capture it. Do not commit, add, or restore anything: the structural moves and the curation leaf writes now sit together in one uncommitted working-tree diff. The human accepts by `git commit` and rejects just the structural moves by path-scoped `git restore`.
+Capture it. Do not commit, add, or restore anything: the structural moves and the curation leaf writes now sit together in one uncommitted working-tree diff. The human accepts by `git commit` and rejects just the structural moves by path-scoped `git restore` — after which they must run `npx kenkeep index rebuild`, since reverting moves leaves the generated index pointing at the old layout.
 
 ## 7. Report the summary, then handle conflicts
 
@@ -470,7 +470,7 @@ Tell the user the headline numbers (`kept`, `conflicts`, `stamped`, `runId`), th
 **Structural summary (rebalance).** Then print the structural summary from the rebalance phase (Step 6b), distinct from and additional to the content summary above so the human gets a legend for the structural diff:
 
 - If 6b.1 reported no action, print one line: `Rebalance: no structural action (tree balanced).`
-- Otherwise, for each move in the `{"moves":[...]}` summary, print one line naming the operation and the affected branch: a `split-folder` / `merge` / `create-branch` shows `<id>: <from> -> <to>`; a `split-leaf` shows `<old-id> -> <new-id>, <new-id>, ... (redirect recorded)`. Close with: `Review the structural diff with \`git diff --summary\` (R entries are renames); accept by \`git commit\`, reject just the structural moves with a path-scoped \`git restore\`.`
+- Otherwise, for each move in the `{"moves":[...]}` summary, print one line naming the operation and the affected branch: a `split-folder` / `merge` / `create-branch` shows `<id>: <from> -> <to>`; a `split-leaf` shows `<old-id> -> <new-id>, <new-id>, ... (redirect recorded)`. Close with: `Review the structural diff with \`git diff --summary\` (R entries are renames); accept by \`git commit\`, reject just the structural moves with a path-scoped \`git restore\` (then run \`npx kenkeep index rebuild\` to resync the generated index).`
 
 **If `conflicts == 0`**, print the placement lines, the structural summary, and then exactly one summary line, and stop:
 
@@ -549,7 +549,7 @@ After every conflict in a group is decided, move to the next group.
 
 ## 8. Hand off
 
-Tell the user to review the changed nodes and conflict files under `.ai/kenkeep/`. `ENTRY.md` and `GRAPH.md` were refreshed in step 6 (and again by the rebalance move primitive if the rebalance phase acted). Any structural moves from Step 6b sit in the same uncommitted diff; the human accepts everything by `git commit` or rejects just the structural moves with a path-scoped `git restore`.
+Tell the user to review the changed nodes and conflict files under `.ai/kenkeep/`. `ENTRY.md` and `GRAPH.md` were refreshed in step 6 (and again by the rebalance move primitive if the rebalance phase acted). Any structural moves from Step 6b sit in the same uncommitted diff; the human accepts everything by `git commit` or rejects just the structural moves with a path-scoped `git restore`. After any `git restore` that drops a written leaf or reverts a move, they must run `npx kenkeep index rebuild` so `ENTRY.md`/`GRAPH.md` and the per-folder `index.md` tree stop referencing the removed content.
 
 ## Constraints
 

--- a/.opencode/skills/kk-migrate/SKILL.md
+++ b/.opencode/skills/kk-migrate/SKILL.md
@@ -171,7 +171,7 @@ Tell the user the migration is staged in the working tree and **no git command w
 git diff
 ```
 
-Leaves moved into their topical folders show as renames (ids and bytes preserved); each created folder's `index.md` carries its authored summary; `ENTRY.md` / `GRAPH.md` are refreshed. The user accepts the migration with `git commit` and rejects it with `git restore` (path-scoped or whole-tree). Do not stage, commit, or restore anything yourself.
+Leaves moved into their topical folders show as renames (ids and bytes preserved); each created folder's `index.md` carries its authored summary; `ENTRY.md` / `GRAPH.md` are refreshed. The user accepts the migration with `git commit` and rejects it with `git restore` (path-scoped or whole-tree). A path-scoped `git restore` that keeps only part of the migration must be followed by `npx kenkeep index rebuild` to resync the generated index with the on-disk tree (a whole-tree `git restore` reverts the generated files too, so it needs no rebuild). Do not stage, commit, or restore anything yourself.
 
 ## Constraints
 

--- a/docs/daily-use.md
+++ b/docs/daily-use.md
@@ -17,7 +17,7 @@ After install, kenkeep runs itself. Capture and injection happen on their own; t
 4. Inspect the resulting changes under `.ai/kenkeep/nodes/` with `git diff` (or your preferred diff tool, e.g. [self-review](https://github.com/e0ipso/self-review)).
 5. `git commit` what you want to keep; `git restore <path>` to discard.
 
-The pre-commit hook regenerates `ENTRY.md` and `GRAPH.md` and stages them into the same commit, so the injected index never drifts from the committed nodes.
+The pre-commit hook regenerates `ENTRY.md` and `GRAPH.md` and stages them into the same commit, so the injected index never drifts from the committed nodes. If you `git restore <path>` to discard nodes without committing another `nodes/` change, that hook doesn't fire — run `npx kenkeep index rebuild` so the regenerated index drops the removed nodes too.
 
 That is the entire daily workflow. The rest of this page is reference: the three skills, and the two manual actions you reach for occasionally.
 
@@ -60,7 +60,7 @@ The home folder is chosen in the same pass that links a note to its neighbors. C
 
 Structural upkeep folds into curate as its last phase — no separate command, no extra nudge. A deterministic, LLM-free trigger checks the per-folder metrics with a hysteresis margin; if nothing trips, the phase is skipped. When a threshold trips, the LLM splits a folder, splits a bloated note, merges a sparse branch, or creates a branch for a new topic, on the affected branches only.
 
-The moves land in the **same** diff as the note writes (act-and-fold), reviewed with the gate you already use: `git diff` to inspect, `git commit` to accept, or a path-scoped `git restore <path>` to reject just the moves. They preserve content byte-for-byte, so `git diff --summary` shows them as `R` renames; ids stay stable, so cross references survive. Curate prints a structural summary as a legend for the diff.
+The moves land in the **same** diff as the note writes (act-and-fold), reviewed with the gate you already use: `git diff` to inspect, `git commit` to accept, or a path-scoped `git restore <path>` to reject just the moves. They preserve content byte-for-byte, so `git diff --summary` shows them as `R` renames; ids stay stable, so cross references survive. Curate prints a structural summary as a legend for the diff. If you `git restore` the moves rather than committing them, run `npx kenkeep index rebuild` afterward so the generated index matches the restored layout.
 
 ### Fast path
 

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -31,9 +31,9 @@ When a threshold trips, the LLM reworks the affected branches only: split a fold
 
 ## 3. Review (you decide)
 
-The files under `nodes/` are plain markdown. Review them with `git diff`, then keep with `git commit` or drop with `git restore <path>`. These notes shape every future session, so this is the one place a human stays in the loop.
+The files under `nodes/` are plain markdown. Review them with `git diff`, then keep with `git commit` or drop with `git restore <path>`. These notes shape every future session, so this is the one place a human stays in the loop. After a `git restore` that drops a note, run `npx kenkeep index rebuild` so the generated index stops referencing it — committing a `nodes/` change instead refreshes the index through the pre-commit hook.
 
-Rebalance moves land in this same diff (act-and-fold), reviewed alongside the note writes. `git restore` is path-scoped, so you can reject just the moves and keep the writes, or the reverse.
+Rebalance moves land in this same diff (act-and-fold), reviewed alongside the note writes. `git restore` is path-scoped, so you can reject just the moves and keep the writes, or the reverse. Either way, follow a `git restore` with `npx kenkeep index rebuild` to resync the generated index with the on-disk tree.
 
 ## 4. Recall (automatic)
 

--- a/docs/internals/manual-test-plan.md
+++ b/docs/internals/manual-test-plan.md
@@ -54,7 +54,7 @@ Quality judgment.
 3. [ ] `_sessions/` shows one `proposal_status: pending` log.
 4. [ ] Open a new session. Wait 30-90s. `_logs/proposal/` has a new `.jsonl`. Log flips to `proposal_status: done`.
 5. [ ] `curate` writes 1-4 nodes under `nodes/` and regenerates `ENTRY.md`. Are these the **right** facts to remember? (Target: ≥80% acceptance.)
-6. [ ] `git diff nodes/` shows the new files. `git add` the ones you want, `git commit`. The pre-commit hook regenerates and stages a fresh `ENTRY.md`/`GRAPH.md` into the same commit. `git restore nodes/<unwanted>.md` to drop the rest.
+6. [ ] `git diff nodes/` shows the new files. `git add` the ones you want, `git commit`. The pre-commit hook regenerates and stages a fresh `ENTRY.md`/`GRAPH.md` into the same commit. `git restore nodes/<unwanted>.md` to drop the rest. (If you `git restore` nodes without committing another `nodes/` change, the hook won't fire — run `npx kenkeep index rebuild` so the generated index drops them too.)
 7. [ ] One more session. Ask Claude "what do you know about this project?" The response references something committed.
 
 If curator output is clearly noise, bump the proposal prompt's `Version:` and tighten "what to skip".
@@ -84,7 +84,7 @@ If curator output is clearly noise, bump the proposal prompt's `Version:` and ti
 
 - [ ] In a sandbox with a small public repo (README + architecture.md), `init` and open Claude Code.
 - [ ] Run `/kk-bootstrap`. Agent reads source docs, writes nodes directly under `nodes/` (topical folders), reports a summary including any collisions skipped.
-- [ ] Walk `git diff nodes/` (or use a tool like [self-review](https://github.com/e0ipso/self-review)). `git commit` the ones you want; `git restore <path>` the rest.
+- [ ] Walk `git diff nodes/` (or use a tool like [self-review](https://github.com/e0ipso/self-review)). `git commit` the ones you want; `git restore <path>` the rest. Bootstrap already rebuilt the index over every written node, so if you `git restore` without committing another `nodes/` change, run `npx kenkeep index rebuild` to drop the removed nodes from the generated index.
 - [ ] No node carries a literal secret or stale TODO from the source docs.
 
 ## 7. `bootstrap` discovery and hash-aware re-run

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -68,7 +68,7 @@ This deletes `*.jsonl` files older than `logsRetentionDays` (default 30) across 
 
 ## Reviewing changes to `nodes/`
 
-The curator writes directly to `.ai/kenkeep/nodes/<folder>/<id>.md`. Review with `git diff nodes/`, your editor, or a tool like [self-review](https://github.com/e0ipso/self-review). Accept with `git commit` (the pre-commit hook regenerates and stages a fresh INDEX/GRAPH). Reject with `git restore <path>`.
+The curator writes directly to `.ai/kenkeep/nodes/<folder>/<id>.md`. Review with `git diff nodes/`, your editor, or a tool like [self-review](https://github.com/e0ipso/self-review). Accept with `git commit` (the pre-commit hook regenerates and stages a fresh INDEX/GRAPH). Reject with `git restore <path>` — then run `npx kenkeep index rebuild`, because the curator already rebuilt the index over the rejected node and restoring it without committing a `nodes/` change leaves that index stale.
 
 ## Resolving curator contradictions
 

--- a/src/templates-source/kenkeep/README.md
+++ b/src/templates-source/kenkeep/README.md
@@ -10,7 +10,7 @@ When you (or a teammate) run an AI coding session against this repo, the tool wa
 
 1. **Capture.** During an AI session, a hook records redacted slices of the transcript to `_sessions/`.
 2. **Curate.** When enough sessions accumulate, you run `/kk-curate` (or `npx kenkeep curate`). The curator reads pending sessions and applies its decisions directly to `nodes/`: new files for `add` actions, in-place rewrites for `modify`. Contradictions are written as markdown files under `conflicts/` for the curate skill to surface to you in-session; you review them with `git diff` and accept by committing or reject with `git restore`.
-3. **Review.** The changes show up in `git status` like any other code change. Inspect with `git diff`, accept with `git commit`, reject with `git restore <file>`. The lint-staged pre-commit hook regenerates `ENTRY.md` and `GRAPH.md` and stages them into the same commit.
+3. **Review.** The changes show up in `git status` like any other code change. Inspect with `git diff`, accept with `git commit`, reject with `git restore <file>`. The lint-staged pre-commit hook regenerates `ENTRY.md` and `GRAPH.md` and stages them into the same commit. The curator already rebuilt the index over every written node, so if you reject some with `git restore` and don't commit another `nodes/` change, run `npx kenkeep index rebuild` to drop the removed nodes from the generated index (the pre-commit hook only fires when a `nodes/` change is committed).
 4. **Consume.** Every future session sees the new nodes in its injected index.
 
 ## How to read a node

--- a/src/templates-source/skills/kk-bootstrap/SKILL.md
+++ b/src/templates-source/skills/kk-bootstrap/SKILL.md
@@ -260,7 +260,7 @@ When you're done, summarize for the user:
 - Any docs that looked stale or contradictory that the user should double-check.
 - Confirmation that `ENTRY.md` and `GRAPH.md` were refreshed.
 
-Then tell the user to review the written files, accept by leaving them in place, and reject by deleting them (`rm nodes/<folder>/<file>.md`).
+Then tell the user to review the written files, accept by leaving them in place, and reject by deleting them (`rm nodes/<folder>/<file>.md`). The indices were already rebuilt above to include every written node, so if they delete any, they must run `npx kenkeep index rebuild` afterward to drop the removed nodes from `ENTRY.md`/`GRAPH.md` and the per-folder `index.md` tree.
 
 ## Constraints
 

--- a/src/templates-source/skills/kk-curate/SKILL.md
+++ b/src/templates-source/skills/kk-curate/SKILL.md
@@ -461,7 +461,7 @@ It prints one JSON line, the structural summary you carry into Step 7:
 {"moves":[{"operation":"...","id":"...","from":"...","to":"...","newIds":["..."],"redirectFrom":"..."}, ...]}
 ```
 
-Capture it. Do not commit, add, or restore anything: the structural moves and the curation leaf writes now sit together in one uncommitted working-tree diff. The human accepts by `git commit` and rejects just the structural moves by path-scoped `git restore`.
+Capture it. Do not commit, add, or restore anything: the structural moves and the curation leaf writes now sit together in one uncommitted working-tree diff. The human accepts by `git commit` and rejects just the structural moves by path-scoped `git restore` — after which they must run `npx kenkeep index rebuild`, since reverting moves leaves the generated index pointing at the old layout.
 
 ## 7. Report the summary, then handle conflicts
 
@@ -470,7 +470,7 @@ Tell the user the headline numbers (`kept`, `conflicts`, `stamped`, `runId`), th
 **Structural summary (rebalance).** Then print the structural summary from the rebalance phase (Step 6b), distinct from and additional to the content summary above so the human gets a legend for the structural diff:
 
 - If 6b.1 reported no action, print one line: `Rebalance: no structural action (tree balanced).`
-- Otherwise, for each move in the `{"moves":[...]}` summary, print one line naming the operation and the affected branch: a `split-folder` / `merge` / `create-branch` shows `<id>: <from> -> <to>`; a `split-leaf` shows `<old-id> -> <new-id>, <new-id>, ... (redirect recorded)`. Close with: `Review the structural diff with \`git diff --summary\` (R entries are renames); accept by \`git commit\`, reject just the structural moves with a path-scoped \`git restore\`.`
+- Otherwise, for each move in the `{"moves":[...]}` summary, print one line naming the operation and the affected branch: a `split-folder` / `merge` / `create-branch` shows `<id>: <from> -> <to>`; a `split-leaf` shows `<old-id> -> <new-id>, <new-id>, ... (redirect recorded)`. Close with: `Review the structural diff with \`git diff --summary\` (R entries are renames); accept by \`git commit\`, reject just the structural moves with a path-scoped \`git restore\` (then run \`npx kenkeep index rebuild\` to resync the generated index).`
 
 **If `conflicts == 0`**, print the placement lines, the structural summary, and then exactly one summary line, and stop:
 
@@ -549,7 +549,7 @@ After every conflict in a group is decided, move to the next group.
 
 ## 8. Hand off
 
-Tell the user to review the changed nodes and conflict files under `.ai/kenkeep/`. `ENTRY.md` and `GRAPH.md` were refreshed in step 6 (and again by the rebalance move primitive if the rebalance phase acted). Any structural moves from Step 6b sit in the same uncommitted diff; the human accepts everything by `git commit` or rejects just the structural moves with a path-scoped `git restore`.
+Tell the user to review the changed nodes and conflict files under `.ai/kenkeep/`. `ENTRY.md` and `GRAPH.md` were refreshed in step 6 (and again by the rebalance move primitive if the rebalance phase acted). Any structural moves from Step 6b sit in the same uncommitted diff; the human accepts everything by `git commit` or rejects just the structural moves with a path-scoped `git restore`. After any `git restore` that drops a written leaf or reverts a move, they must run `npx kenkeep index rebuild` so `ENTRY.md`/`GRAPH.md` and the per-folder `index.md` tree stop referencing the removed content.
 
 ## Constraints
 

--- a/src/templates-source/skills/kk-migrate/SKILL.md
+++ b/src/templates-source/skills/kk-migrate/SKILL.md
@@ -171,7 +171,7 @@ Tell the user the migration is staged in the working tree and **no git command w
 git diff
 ```
 
-Leaves moved into their topical folders show as renames (ids and bytes preserved); each created folder's `index.md` carries its authored summary; `ENTRY.md` / `GRAPH.md` are refreshed. The user accepts the migration with `git commit` and rejects it with `git restore` (path-scoped or whole-tree). Do not stage, commit, or restore anything yourself.
+Leaves moved into their topical folders show as renames (ids and bytes preserved); each created folder's `index.md` carries its authored summary; `ENTRY.md` / `GRAPH.md` are refreshed. The user accepts the migration with `git commit` and rejects it with `git restore` (path-scoped or whole-tree). A path-scoped `git restore` that keeps only part of the migration must be followed by `npx kenkeep index rebuild` to resync the generated index with the on-disk tree (a whole-tree `git restore` reverts the generated files too, so it needs no rebuild). Do not stage, commit, or restore anything yourself.
 
 ## Constraints
 


### PR DESCRIPTION
When a knowledge item (or structural move) is rejected with `git restore`
after the writer already rebuilt the index over it, the generated
`ENTRY.md`/`GRAPH.md` and per-folder `index.md` tree are left referencing a
node that no longer exists. The pre-commit hook only self-heals when a
`nodes/` change is committed, so a restore-without-commit needs a manual
`npx kenkeep index rebuild`.

Add that instruction wherever we tell the user to `git restore` to drop a
node or revert a rebalance/migrate move:
- kk-curate, kk-migrate, kk-bootstrap skills (source + dogfood copies)
- shipped knowledge-base README template
- docs/how-it-works, daily-use, troubleshooting, internals/manual-test-plan
- the `practice-review-nodes-via-git` knowledge node

Conflict-file restores are left untouched (they don't drop `nodes/` content,
so no rebuild is required). Regenerated the dogfood index.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01JqrXKnvgVDYZzSxj7hFnZQ