### PR TITLE
docs: add Cursor Cloud setup instructions to AGENTS.md

### DIFF
--- a/.cursor/cloud-instructions.md
+++ b/.cursor/cloud-instructions.md
@@ -1,0 +1,10 @@
+# Cursor Cloud specific instructions
+
+Durable, non-obvious setup/run caveats for developing this repo inside a Cursor Cloud Agent VM. Standard commands live in [`AGENTS.md`](../AGENTS.md) `## Commands`.
+
+Dependencies are installed automatically on VM startup (`npm install`). Node 22+ is present. The repo is a pure CLI npm package — no daemons or services to run (see the Constitution).
+
+- **Build before running the CLI.** `npm install` only runs `husky`; it does **not** build. Run `npm run build` to produce `dist/` (and the `templates/` tree) before `node dist/cli.js <subcommand>`. `npm test` self-builds via its `pretest` hook, so lint/typecheck/test work without a manual build, but running the CLI does not.
+- **Standard commands** are in `## Commands` in `AGENTS.md` (`npm run build`, `npm test`, `npm run typecheck`, `npm run lint`, `npm run format`). All pass green in this environment (436 tests).
+- **`init` uses `--harnesses` (plural):** `node dist/cli.js init --harnesses claude`. The global active-harness selector is the singular `--harness <id>` (e.g. `node dist/cli.js --harness claude doctor`); pass it explicitly since env-based detection only fires inside a real host harness session.
+- **`doctor` reports one expected "error" here:** `claude CLI on PATH: not runnable (spawn claude ENOENT)` — no harness binary is installed in the cloud VM. This is an environment limitation, not a repo defect; every other check passes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,6 +152,15 @@ We dogfood the tool. [`.ai/kenkeep/nodes/`](.ai/kenkeep/nodes/) contains the cur
 
 To add to the knowledge base during a session: invoke the `kk-add` skill. To process accumulated session captures: invoke `kk-curate` ([map-curate-command](.ai/kenkeep/nodes/curation/map-curate-command.md)). To seed from existing docs: invoke `kk-bootstrap` ([map-kk-bootstrap-skill](.ai/kenkeep/nodes/bootstrap/map-kk-bootstrap-skill.md)). All three write to `nodes/` directly; review with `git diff`, accept with `git commit`, reject with `git restore`.
 
+## Cursor Cloud specific instructions
+
+Dependencies are installed automatically on VM startup (`npm install`). Node 22+ is present. The repo is a pure CLI npm package — no daemons or services to run (see the Constitution).
+
+- **Build before running the CLI.** `npm install` only runs `husky`; it does **not** build. Run `npm run build` to produce `dist/` (and the `templates/` tree) before `node dist/cli.js <subcommand>`. `npm test` self-builds via its `pretest` hook, so lint/typecheck/test work without a manual build, but running the CLI does not.
+- **Standard commands** are in `## Commands` above (`npm run build`, `npm test`, `npm run typecheck`, `npm run lint`, `npm run format`). All pass green in this environment (436 tests).
+- **`init` uses `--harnesses` (plural):** `node dist/cli.js init --harnesses claude`. The global active-harness selector is the singular `--harness <id>` (e.g. `node dist/cli.js --harness claude doctor`); pass it explicitly since env-based detection only fires inside a real host harness session.
+- **`doctor` reports one expected "error" here:** `claude CLI on PATH: not runnable (spawn claude ENOENT)` — no harness binary is installed in the cloud VM. This is an environment limitation, not a repo defect; every other check passes.
+
 <!-- >>> kenkeep:kk-index >>> -->
 Curated project knowledge lives in [.ai/kenkeep/ENTRY.md](.ai/kenkeep/ENTRY.md), the entry catalog of the knowledge base. Enter there and descend before designing a non-trivial change:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,12 +154,7 @@ To add to the knowledge base during a session: invoke the `kk-add` skill. To pro
 
 ## Cursor Cloud specific instructions
 
-Dependencies are installed automatically on VM startup (`npm install`). Node 22+ is present. The repo is a pure CLI npm package — no daemons or services to run (see the Constitution).
-
-- **Build before running the CLI.** `npm install` only runs `husky`; it does **not** build. Run `npm run build` to produce `dist/` (and the `templates/` tree) before `node dist/cli.js <subcommand>`. `npm test` self-builds via its `pretest` hook, so lint/typecheck/test work without a manual build, but running the CLI does not.
-- **Standard commands** are in `## Commands` above (`npm run build`, `npm test`, `npm run typecheck`, `npm run lint`, `npm run format`). All pass green in this environment (436 tests).
-- **`init` uses `--harnesses` (plural):** `node dist/cli.js init --harnesses claude`. The global active-harness selector is the singular `--harness <id>` (e.g. `node dist/cli.js --harness claude doctor`); pass it explicitly since env-based detection only fires inside a real host harness session.
-- **`doctor` reports one expected "error" here:** `claude CLI on PATH: not runnable (spawn claude ENOENT)` — no harness binary is installed in the cloud VM. This is an environment limitation, not a repo defect; every other check passes.
+When developing in a Cursor Cloud Agent VM, read [`.cursor/cloud-instructions.md`](.cursor/cloud-instructions.md) for environment setup and run caveats (build-before-run, the `--harnesses` flag, the expected `doctor` error). Load it on demand — it is not needed for routine local work.
 
 <!-- >>> kenkeep:kk-index >>> -->
 Curated project knowledge lives in [.ai/kenkeep/ENTRY.md](.ai/kenkeep/ENTRY.md), the entry catalog of the knowledge base. Enter there and descend before designing a non-trivial change:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Documents the non-obvious setup/run details for developing this repo in a Cursor Cloud Agent VM. The detail lives in a standalone **`.cursor/cloud-instructions.md`** and `AGENTS.md` carries a short on-demand pointer (loaded only when relevant, not inline).

Captured guidance:
- `npm install` only runs `husky` — `npm run build` is required before running `node dist/cli.js` (tests self-build via `pretest`).
- `init` uses the plural `--harnesses` flag; the active-harness selector is the singular `--harness <id>`, which must be passed explicitly outside a real host session.
- `doctor` reports one expected `claude CLI on PATH` error in the cloud VM (no harness binary installed) — an environment limitation, not a defect.

## Verification

All run from a fresh install in the Cloud VM:
- `npm run lint` — pass
- `npm run typecheck` — pass
- `npm test` — 436 tests pass
- `node dist/cli.js init --harnesses claude` + `doctor` — knowledge base scaffolds and verifies end to end

No source code changes; docs only.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-63bb6dce-6c5d-46f9-8c79-53a165d64ac7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-63bb6dce-6c5d-46f9-8c79-53a165d64ac7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

