### PR TITLE
docs: strengthen and de-duplicate the AGENTS.md kenkeep pointer (#64)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,7 +157,7 @@ To add to the knowledge base during a session: invoke the `kk-add` skill. To pro
 When developing in a Cursor Cloud Agent VM, read [`.cursor/cloud-instructions.md`](.cursor/cloud-instructions.md) for environment setup and run caveats (build-before-run, the `--harnesses` flag, the expected `doctor` error). Load it on demand — it is not needed for routine local work.
 
 <!-- >>> kenkeep:kk-index >>> -->
-You need to read [.ai/kenkeep/ENTRY.md](.ai/kenkeep/ENTRY.md) before designing any non-trivial change. It is the entry catalog of curated project knowledge for this repo. Enter there and descend:
+You are required to load [.ai/kenkeep/ENTRY.md](.ai/kenkeep/ENTRY.md), the small curated entry catalog for this repo, before any non-trivial change. Enter there and descend using progressive disclosure principles.
 
 
 <!-- <<< kenkeep:kk-index <<< -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 `kenkeep` — npm package that builds and maintains a per-repo knowledge base from AI coding sessions for Claude Code, OpenAI Codex CLI, Cursor, OpenCode, and GitHub Copilot CLI. It installs harness hooks, captures session slices, runs human-supervised curation, and injects the resulting `ENTRY.md` into every new session. TypeScript, Node 22+, ESM, bundled via `tsup`.
 
-Authoritative product spec: [PRD.md](PRD.md). Curated project knowledge: [.ai/kenkeep/ENTRY.md](.ai/kenkeep/ENTRY.md) — skim it before designing a non-trivial change.
+Authoritative product spec: [PRD.md](PRD.md). Curated project knowledge index: [.ai/kenkeep/ENTRY.md](.ai/kenkeep/ENTRY.md).
 
 ## Constitution
 
@@ -157,7 +157,7 @@ To add to the knowledge base during a session: invoke the `kk-add` skill. To pro
 When developing in a Cursor Cloud Agent VM, read [`.cursor/cloud-instructions.md`](.cursor/cloud-instructions.md) for environment setup and run caveats (build-before-run, the `--harnesses` flag, the expected `doctor` error). Load it on demand — it is not needed for routine local work.
 
 <!-- >>> kenkeep:kk-index >>> -->
-Curated project knowledge lives in [.ai/kenkeep/ENTRY.md](.ai/kenkeep/ENTRY.md), the entry catalog of the knowledge base. Enter there and descend before designing a non-trivial change:
+You need to read [.ai/kenkeep/ENTRY.md](.ai/kenkeep/ENTRY.md) before designing any non-trivial change. It is the entry catalog of curated project knowledge for this repo — enter there and descend:
 
 
 <!-- <<< kenkeep:kk-index <<< -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,7 +157,7 @@ To add to the knowledge base during a session: invoke the `kk-add` skill. To pro
 When developing in a Cursor Cloud Agent VM, read [`.cursor/cloud-instructions.md`](.cursor/cloud-instructions.md) for environment setup and run caveats (build-before-run, the `--harnesses` flag, the expected `doctor` error). Load it on demand — it is not needed for routine local work.
 
 <!-- >>> kenkeep:kk-index >>> -->
-You are required to load [.ai/kenkeep/ENTRY.md](.ai/kenkeep/ENTRY.md), the small curated entry catalog for this repo, before any non-trivial change. Enter there and descend using progressive disclosure principles.
+You are required to load [.ai/kenkeep/ENTRY.md](.ai/kenkeep/ENTRY.md), the small curated entry catalog for this repo. Enter there and descend using progressive disclosure principles.
 
 
 <!-- <<< kenkeep:kk-index <<< -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 `kenkeep` — npm package that builds and maintains a per-repo knowledge base from AI coding sessions for Claude Code, OpenAI Codex CLI, Cursor, OpenCode, and GitHub Copilot CLI. It installs harness hooks, captures session slices, runs human-supervised curation, and injects the resulting `ENTRY.md` into every new session. TypeScript, Node 22+, ESM, bundled via `tsup`.
 
-Authoritative product spec: [PRD.md](PRD.md). You are required to load the small & curated project knowledge index: [.ai/kenkeep/ENTRY.md](.ai/kenkeep/ENTRY.md).
+Authoritative product spec: [PRD.md](PRD.md).
 
 ## Constitution
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 `kenkeep` — npm package that builds and maintains a per-repo knowledge base from AI coding sessions for Claude Code, OpenAI Codex CLI, Cursor, OpenCode, and GitHub Copilot CLI. It installs harness hooks, captures session slices, runs human-supervised curation, and injects the resulting `ENTRY.md` into every new session. TypeScript, Node 22+, ESM, bundled via `tsup`.
 
-Authoritative product spec: [PRD.md](PRD.md). Curated project knowledge index: [.ai/kenkeep/ENTRY.md](.ai/kenkeep/ENTRY.md).
+Authoritative product spec: [PRD.md](PRD.md). You are required to load the small & curated project knowledge index: [.ai/kenkeep/ENTRY.md](.ai/kenkeep/ENTRY.md).
 
 ## Constitution
 
@@ -157,7 +157,7 @@ To add to the knowledge base during a session: invoke the `kk-add` skill. To pro
 When developing in a Cursor Cloud Agent VM, read [`.cursor/cloud-instructions.md`](.cursor/cloud-instructions.md) for environment setup and run caveats (build-before-run, the `--harnesses` flag, the expected `doctor` error). Load it on demand — it is not needed for routine local work.
 
 <!-- >>> kenkeep:kk-index >>> -->
-You need to read [.ai/kenkeep/ENTRY.md](.ai/kenkeep/ENTRY.md) before designing any non-trivial change. It is the entry catalog of curated project knowledge for this repo — enter there and descend:
+You need to read [.ai/kenkeep/ENTRY.md](.ai/kenkeep/ENTRY.md) before designing any non-trivial change. It is the entry catalog of curated project knowledge for this repo. Enter there and descend:
 
 
 <!-- <<< kenkeep:kk-index <<< -->

--- a/src/lib/agents-block.ts
+++ b/src/lib/agents-block.ts
@@ -20,7 +20,7 @@ export const AGENTS_BLOCK_END = '<!-- <<< kenkeep:kk-index <<< -->';
 // one source of truth and cannot drift. The descent body itself is never
 // re-typed here; it comes from KK_NAVIGATION_DIRECTIVE.
 export const AGENTS_POINTER = [
-  'You need to read [.ai/kenkeep/ENTRY.md](.ai/kenkeep/ENTRY.md) before designing any non-trivial change. It is the entry catalog of curated project knowledge for this repo. Enter there and descend:',
+  'You are required to load [.ai/kenkeep/ENTRY.md](.ai/kenkeep/ENTRY.md), the small curated entry catalog for this repo, before any non-trivial change. Enter there and descend using progressive disclosure principles.',
   '',
   KK_NAVIGATION_DIRECTIVE,
 ].join('\n');

--- a/src/lib/agents-block.ts
+++ b/src/lib/agents-block.ts
@@ -20,7 +20,7 @@ export const AGENTS_BLOCK_END = '<!-- <<< kenkeep:kk-index <<< -->';
 // one source of truth and cannot drift. The descent body itself is never
 // re-typed here; it comes from KK_NAVIGATION_DIRECTIVE.
 export const AGENTS_POINTER = [
-  'You are required to load [.ai/kenkeep/ENTRY.md](.ai/kenkeep/ENTRY.md), the small curated entry catalog for this repo, before any non-trivial change. Enter there and descend using progressive disclosure principles.',
+  'You are required to load [.ai/kenkeep/ENTRY.md](.ai/kenkeep/ENTRY.md), the small curated entry catalog for this repo. Enter there and descend using progressive disclosure principles.',
   '',
   KK_NAVIGATION_DIRECTIVE,
 ].join('\n');

--- a/src/lib/agents-block.ts
+++ b/src/lib/agents-block.ts
@@ -20,7 +20,7 @@ export const AGENTS_BLOCK_END = '<!-- <<< kenkeep:kk-index <<< -->';
 // one source of truth and cannot drift. The descent body itself is never
 // re-typed here; it comes from KK_NAVIGATION_DIRECTIVE.
 export const AGENTS_POINTER = [
-  'Curated project knowledge lives in [.ai/kenkeep/ENTRY.md](.ai/kenkeep/ENTRY.md), the entry catalog of the knowledge base. Enter there and descend before designing a non-trivial change:',
+  'You need to read [.ai/kenkeep/ENTRY.md](.ai/kenkeep/ENTRY.md) before designing any non-trivial change. It is the entry catalog of curated project knowledge for this repo — enter there and descend:',
   '',
   KK_NAVIGATION_DIRECTIVE,
 ].join('\n');

--- a/src/lib/agents-block.ts
+++ b/src/lib/agents-block.ts
@@ -20,7 +20,7 @@ export const AGENTS_BLOCK_END = '<!-- <<< kenkeep:kk-index <<< -->';
 // one source of truth and cannot drift. The descent body itself is never
 // re-typed here; it comes from KK_NAVIGATION_DIRECTIVE.
 export const AGENTS_POINTER = [
-  'You need to read [.ai/kenkeep/ENTRY.md](.ai/kenkeep/ENTRY.md) before designing any non-trivial change. It is the entry catalog of curated project knowledge for this repo — enter there and descend:',
+  'You need to read [.ai/kenkeep/ENTRY.md](.ai/kenkeep/ENTRY.md) before designing any non-trivial change. It is the entry catalog of curated project knowledge for this repo. Enter there and descend:',
   '',
   KK_NAVIGATION_DIRECTIVE,
 ].join('\n');

--- a/tests/lib/agents-block.test.ts
+++ b/tests/lib/agents-block.test.ts
@@ -34,11 +34,11 @@ describe('ensureAgentsKkBlock', () => {
     expect(body).toContain(AGENTS_BLOCK_START);
 
     // Corrupt the block content; ensure restores it without touching the rest.
-    body = body.replace('Curated project knowledge', 'STALE WORDING');
+    body = body.replace('You need to read', 'STALE WORDING');
     writeFileSync(file, body);
     expect(ensureAgentsKkBlock(file)).toBe(true);
     const restored = readFileSync(file, 'utf8');
-    expect(restored).toContain('Curated project knowledge');
+    expect(restored).toContain('You need to read');
     expect(restored).not.toContain('STALE WORDING');
     expect(restored.startsWith('# My project')).toBe(true);
   });

--- a/tests/lib/agents-block.test.ts
+++ b/tests/lib/agents-block.test.ts
@@ -34,11 +34,11 @@ describe('ensureAgentsKkBlock', () => {
     expect(body).toContain(AGENTS_BLOCK_START);
 
     // Corrupt the block content; ensure restores it without touching the rest.
-    body = body.replace('You need to read', 'STALE WORDING');
+    body = body.replace('You are required to load', 'STALE WORDING');
     writeFileSync(file, body);
     expect(ensureAgentsKkBlock(file)).toBe(true);
     const restored = readFileSync(file, 'utf8');
-    expect(restored).toContain('You need to read');
+    expect(restored).toContain('You are required to load');
     expect(restored).not.toContain('STALE WORDING');
     expect(restored.startsWith('# My project')).toBe(true);
   });


### PR DESCRIPTION
## Summary

Addresses #64. Strengthens the managed AGENTS.md kk-index pointer into an explicit instruction and removes hand-written restatement drift, keeping `AGENTS_POINTER` (`src/lib/agents-block.ts`) plus `KK_NAVIGATION_DIRECTIVE` as the single source of truth.

## Changes

- `src/lib/agents-block.ts`: reword `AGENTS_POINTER` to a forceful, explicit instruction to load `ENTRY.md` before any non-trivial change and descend using progressive disclosure principles.
- `AGENTS.md`: update the line-5 reference and the managed kk-index block to match; drop the weaker duplicate phrasing.
- `tests/lib/agents-block.test.ts`: update the stale-wording test anchor.

No runtime or behavior change. 3 files changed, +5/-5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)