### PR TITLE
fix: render skill partial includes

### DIFF
--- a/scripts/build-templates.mjs
+++ b/scripts/build-templates.mjs
@@ -2,19 +2,29 @@
 // Builds the shipped `templates/` directory.
 //
 // 1. Copies `src/templates-source/` (static markdown, settings, etc.) into `templates/`.
-// 2. Copies compiled hook scripts from `dist/hooks/<harness>/*.cjs` into
+// 2. Renders source-only markdown partial includes in the copied templates.
+// 3. Copies compiled hook scripts from `dist/hooks/<harness>/*.cjs` into
 //    `templates/<harness>/hooks/*.cjs` (or `templates/<harness>/kk-hooks/*.cjs`
 //    for adapters that ship a plugin shim or carry a `.kk-hooks-output`
 //    marker, to keep our dispatch tree separate from a `hooks/` directory the
 //    host reserves or that holds the hook-config artifact).
-// 3. Copies compiled plugin modules from `dist/plugins/<harness>/*.mjs` into
+// 4. Copies compiled plugin modules from `dist/plugins/<harness>/*.mjs` into
 //    `templates/<harness>/plugins/*.mjs` for adapters that ship a plugin shim.
 //
 // Run after `tsup` so the compiled artifacts exist; the package's `prepare`
 // script wires this up.
 
-import { cpSync, existsSync, mkdirSync, readdirSync, rmSync, statSync } from 'node:fs';
-import { dirname, join, resolve } from 'node:path';
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { dirname, join, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const here = dirname(fileURLToPath(import.meta.url));
@@ -24,6 +34,8 @@ const dest = resolve(root, 'templates');
 const compiledHooksRoot = resolve(root, 'dist/hooks');
 const compiledPluginsRoot = resolve(root, 'dist/plugins');
 const harnessSrcRoot = resolve(root, 'src/harnesses');
+const includePattern = /^<!--\s*kk-include:\s*([A-Za-z0-9._/-]+)(?:\s+(\{.*\}))?\s*-->$/gm;
+const partialVariablePattern = /\{\{\s*([A-Za-z][A-Za-z0-9_]*)\s*\}\}/g;
 
 if (!existsSync(src)) {
   console.error(`Source not found: ${src}`);
@@ -34,6 +46,87 @@ rmSync(dest, { recursive: true, force: true });
 mkdirSync(dest, { recursive: true });
 cpSync(src, dest, { recursive: true });
 console.log(`Copied ${src} -> ${dest}`);
+
+function walkFiles(dir) {
+  const files = [];
+  for (const name of readdirSync(dir)) {
+    const path = join(dir, name);
+    const stat = statSync(path);
+    if (stat.isDirectory()) {
+      files.push(...walkFiles(path));
+    } else if (stat.isFile()) {
+      files.push(path);
+    }
+  }
+  return files;
+}
+
+function parseIncludeArgs(raw, name) {
+  if (!raw) return {};
+  const parsed = JSON.parse(raw);
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error(`Template partial include args must be a JSON object: ${name}`);
+  }
+  for (const [key, value] of Object.entries(parsed)) {
+    if (!/^[A-Za-z][A-Za-z0-9_]*$/.test(key) || typeof value !== 'string') {
+      throw new Error(`Template partial include args must be string values: ${name}`);
+    }
+  }
+  return parsed;
+}
+
+function loadPartial(name, args = {}) {
+  const path = resolve(src, name);
+  const rel = relative(src, path);
+  if (rel.startsWith('..') || rel === '' || rel.includes('\\')) {
+    throw new Error(`Invalid template partial include: ${name}`);
+  }
+  if (!existsSync(path) || !statSync(path).isFile()) {
+    throw new Error(`Template partial not found: ${name}`);
+  }
+  const text = readFileSync(path, 'utf8').trimEnd();
+  return text.replace(partialVariablePattern, (_match, key) => {
+    if (!Object.hasOwn(args, key)) {
+      throw new Error(`Missing value for {{${key}}} in template partial: ${name}`);
+    }
+    return args[key];
+  });
+}
+
+function renderTemplateIncludes(dir) {
+  let rendered = 0;
+  for (const file of walkFiles(dir)) {
+    if (!file.endsWith('.md')) continue;
+    if (relative(join(dir, '_partials'), file).startsWith('..') === false) continue;
+
+    const original = readFileSync(file, 'utf8');
+    const next = original.replace(includePattern, (_match, name, rawArgs) => {
+      rendered += 1;
+      return loadPartial(name, parseIncludeArgs(rawArgs, name));
+    });
+    if (next !== original) {
+      writeFileSync(file, next);
+    }
+  }
+
+  rmSync(join(dir, '_partials'), { recursive: true, force: true });
+
+  for (const file of walkFiles(dir)) {
+    if (!file.endsWith('.md')) continue;
+    const text = readFileSync(file, 'utf8');
+    if (includePattern.test(text)) {
+      includePattern.lastIndex = 0;
+      throw new Error(`Unresolved template include marker in ${file}`);
+    }
+    includePattern.lastIndex = 0;
+  }
+
+  if (rendered > 0) {
+    console.log(`Rendered ${rendered} template partial include(s)`);
+  }
+}
+
+renderTemplateIncludes(dest);
 
 function usesKkHooksOutput(harnessId) {
   const adapterDir = join(harnessSrcRoot, harnessId);

--- a/src/templates-source/_partials/index-rebuild-command.md
+++ b/src/templates-source/_partials/index-rebuild-command.md
@@ -1,0 +1,3 @@
+```bash
+npx --yes kenkeep@latest index rebuild --harness "$HARNESS"
+```

--- a/src/templates-source/_partials/index-rebuild-section.md
+++ b/src/templates-source/_partials/index-rebuild-section.md
@@ -1,0 +1,7 @@
+{{heading}}
+
+{{lead}}
+
+```bash
+npx --yes kenkeep@latest index rebuild --harness "$HARNESS"
+```

--- a/src/templates-source/_partials/resolve-active-harness.md
+++ b/src/templates-source/_partials/resolve-active-harness.md
@@ -1,0 +1,31 @@
+## Resolve the active harness
+
+Substitute your own best-guess id for `<hint>` based on the runtime you are running inside (one of `claude`, `codex`, `copilot`, `cursor`, `opencode`). Run the materialization block exactly as-is (it lazy-writes `/tmp/kk-detect-root.mjs` on first invocation):
+
+```bash
+if [ ! -f /tmp/kk-detect-root.mjs ]; then
+cat << 'EOF' > /tmp/kk-detect-root.mjs
+#!/usr/bin/env node
+// kk-detect-root: resolves the project root containing .ai/kenkeep.
+import { existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+let dir = process.cwd();
+while (true) {
+  if (existsSync(join(dir, '.ai', 'kenkeep'))) {
+    process.stdout.write(dir);
+    process.exit(0);
+  }
+  const parent = dirname(dir);
+  if (parent === dir) {
+    process.stderr.write('kk-detect-root: no .ai/kenkeep found in this directory or its parents.\n');
+    process.exit(2);
+  }
+  dir = parent;
+}
+EOF
+fi
+KK_REPO_ROOT=$(node /tmp/kk-detect-root.mjs) || exit $?
+cd "$KK_REPO_ROOT" || exit $?
+HARNESS=$(node .ai/kenkeep/scripts/kk-detect-harness.mjs --hint <hint> --root "$KK_REPO_ROOT")
+pwd
+```

--- a/src/templates-source/skills/kk-add/SKILL.md
+++ b/src/templates-source/skills/kk-add/SKILL.md
@@ -13,37 +13,7 @@ Ask the user for seven values (do not invent any): **kind** (`practice` or `map`
 
 Before invoking, skim `.ai/kenkeep/ENTRY.md` (already in context) and grep `nodes/` for an overlapping node. If one exists, offer to edit it, refine the candidate's title, or drop the capture instead. Push back if the candidate is: code that speaks for itself, history, a debugging recipe, in-flight plan/task content, or general programming knowledge.
 
-## Resolve the active harness
-
-Substitute your own best-guess id for `<hint>` based on the runtime you are running inside (one of `claude`, `codex`, `copilot`, `cursor`, `opencode`). Run the materialization block exactly as-is (it lazy-writes `/tmp/kk-detect-root.mjs` on first invocation):
-
-```bash
-if [ ! -f /tmp/kk-detect-root.mjs ]; then
-cat << 'EOF' > /tmp/kk-detect-root.mjs
-#!/usr/bin/env node
-// kk-detect-root: resolves the project root containing .ai/kenkeep.
-import { existsSync } from 'node:fs';
-import { dirname, join } from 'node:path';
-let dir = process.cwd();
-while (true) {
-  if (existsSync(join(dir, '.ai', 'kenkeep'))) {
-    process.stdout.write(dir);
-    process.exit(0);
-  }
-  const parent = dirname(dir);
-  if (parent === dir) {
-    process.stderr.write('kk-detect-root: no .ai/kenkeep found in this directory or its parents.\n');
-    process.exit(2);
-  }
-  dir = parent;
-}
-EOF
-fi
-KK_REPO_ROOT=$(node /tmp/kk-detect-root.mjs) || exit $?
-cd "$KK_REPO_ROOT" || exit $?
-HARNESS=$(node .ai/kenkeep/scripts/kk-detect-harness.mjs --hint <hint> --root "$KK_REPO_ROOT")
-pwd
-```
+<!-- kk-include: _partials/resolve-active-harness.md -->
 
 `$HARNESS` is not consumed by `node write`, but other kenkeep commands invoked downstream still require it. Treat the printed path as the working directory for every command below.
 

--- a/src/templates-source/skills/kk-bootstrap/SKILL.md
+++ b/src/templates-source/skills/kk-bootstrap/SKILL.md
@@ -21,37 +21,7 @@ Survey the project's existing markdown documentation, extract candidate knowledg
 
 Before you start, read `.ai/kenkeep/config.yaml` (falling back to `~/.config/kenkeep/config.yaml`) for any user preferences (tags vocabulary, scope hints, etc.). Apply what is relevant.
 
-## Resolve the active harness
-
-Substitute your own best-guess id for `<hint>` based on the runtime you are running inside (one of `claude`, `codex`, `copilot`, `cursor`, `opencode`). Run the materialization block exactly as-is (it lazy-writes `/tmp/kk-detect-root.mjs` on first invocation):
-
-```bash
-if [ ! -f /tmp/kk-detect-root.mjs ]; then
-cat << 'EOF' > /tmp/kk-detect-root.mjs
-#!/usr/bin/env node
-// kk-detect-root: resolves the project root containing .ai/kenkeep.
-import { existsSync } from 'node:fs';
-import { dirname, join } from 'node:path';
-let dir = process.cwd();
-while (true) {
-  if (existsSync(join(dir, '.ai', 'kenkeep'))) {
-    process.stdout.write(dir);
-    process.exit(0);
-  }
-  const parent = dirname(dir);
-  if (parent === dir) {
-    process.stderr.write('kk-detect-root: no .ai/kenkeep found in this directory or its parents.\n');
-    process.exit(2);
-  }
-  dir = parent;
-}
-EOF
-fi
-KK_REPO_ROOT=$(node /tmp/kk-detect-root.mjs) || exit $?
-cd "$KK_REPO_ROOT" || exit $?
-HARNESS=$(node .ai/kenkeep/scripts/kk-detect-harness.mjs --hint <hint> --root "$KK_REPO_ROOT")
-pwd
-```
+<!-- kk-include: _partials/resolve-active-harness.md -->
 
 `$HARNESS` is not consumed by `finddocs` or `node write`, but downstream commands in this skill (`index rebuild`) require it. Treat the printed path as the working directory for every command below.
 
@@ -209,13 +179,7 @@ On success the primitive prints the resolved node id and exits 0. Capture it. If
 
 **Multi-source nodes.** If a candidate is sourced from multiple docs (you found the same convention discussed in two places), pick the most authoritative doc as the `--source-doc` / `--source-hash` pair and mention the other sources in the body (e.g. "Also documented in `docs/auth.md`."). Do not write duplicate nodes.
 
-### 7. Refresh ENTRY.md and GRAPH.md
-
-After all writes, rebuild the indices so the reviewer sees them in sync with the new nodes:
-
-```bash
-npx --yes kenkeep@latest index rebuild --harness "$HARNESS"
-```
+<!-- kk-include: _partials/index-rebuild-section.md {"heading":"### 7. Refresh ENTRY.md and GRAPH.md","lead":"After all writes, rebuild the indices so the reviewer sees them in sync with the new nodes:"} -->
 
 ### 8. Report back
 

--- a/src/templates-source/skills/kk-curate/SKILL.md
+++ b/src/templates-source/skills/kk-curate/SKILL.md
@@ -9,37 +9,7 @@ description: Curate pending session logs into kenkeep nodes by reading sessions 
 
 You are the curator. Read pending session logs in this session, decide an action per candidate, run a single dedup pass via the CLI primitive, persist surviving actions via `node write`, regenerate indices, and resolve any surfaced contradictions interactively with the user. There is no sub-agent and no runner — **you** are the LLM doing the curation.
 
-## Resolve the active harness
-
-Substitute your own best-guess id for `<hint>` based on the runtime you are running inside (one of `claude`, `codex`, `copilot`, `cursor`, `opencode`). Run the materialization block exactly as-is (it lazy-writes `/tmp/kk-detect-root.mjs` on first invocation):
-
-```bash
-if [ ! -f /tmp/kk-detect-root.mjs ]; then
-cat << 'EOF' > /tmp/kk-detect-root.mjs
-#!/usr/bin/env node
-// kk-detect-root: resolves the project root containing .ai/kenkeep.
-import { existsSync } from 'node:fs';
-import { dirname, join } from 'node:path';
-let dir = process.cwd();
-while (true) {
-  if (existsSync(join(dir, '.ai', 'kenkeep'))) {
-    process.stdout.write(dir);
-    process.exit(0);
-  }
-  const parent = dirname(dir);
-  if (parent === dir) {
-    process.stderr.write('kk-detect-root: no .ai/kenkeep found in this directory or its parents.\n');
-    process.exit(2);
-  }
-  dir = parent;
-}
-EOF
-fi
-KK_REPO_ROOT=$(node /tmp/kk-detect-root.mjs) || exit $?
-cd "$KK_REPO_ROOT" || exit $?
-HARNESS=$(node .ai/kenkeep/scripts/kk-detect-harness.mjs --hint <hint> --root "$KK_REPO_ROOT")
-pwd
-```
+<!-- kk-include: _partials/resolve-active-harness.md -->
 
 `$HARNESS` is not consumed by `curate-dedup` or `node write`, but `index rebuild` requires it. Treat the printed path as the working directory for every command below.
 
@@ -368,13 +338,7 @@ For each `add` or `modify`:
 
 On any non-zero exit from `node write`, surface the stderr to the user and continue with the next action. Do not retry blindly.
 
-## 6. Rebuild the indices
-
-After all writes:
-
-```bash
-npx --yes kenkeep@latest index rebuild --harness "$HARNESS"
-```
+<!-- kk-include: _partials/index-rebuild-section.md {"heading":"## 6. Rebuild the indices","lead":"After all writes:"} -->
 
 ## 6b. Rebalance (final phase, act-and-fold)
 

--- a/src/templates-source/skills/kk-migrate/SKILL.md
+++ b/src/templates-source/skills/kk-migrate/SKILL.md
@@ -9,37 +9,7 @@ description: Run any pending knowledge-base migration by querying the determinis
 
 You are the migrator — for **any** pending knowledge-base migration, not one specific hop. The knowledge base stores its on-disk layout at a numbered `schema_version`, and each registered migration step takes the tree from one version to the next. Whatever judgment a step requires, you exercise **in this session**: there is no sub-agent, no runner, and no `-p` spawn — **you** are the LLM doing the judgment work. Every file write is delegated to the step's deterministic CLI primitives so ids and bytes are preserved by tested code, never by you.
 
-## Resolve the active harness
-
-Substitute your own best-guess id for `<hint>` based on the runtime you are running inside (one of `claude`, `codex`, `copilot`, `cursor`, `opencode`). Run the materialization block exactly as-is (it lazy-writes `/tmp/kk-detect-root.mjs` on first invocation):
-
-```bash
-if [ ! -f /tmp/kk-detect-root.mjs ]; then
-cat << 'EOF' > /tmp/kk-detect-root.mjs
-#!/usr/bin/env node
-// kk-detect-root: resolves the project root containing .ai/kenkeep.
-import { existsSync } from 'node:fs';
-import { dirname, join } from 'node:path';
-let dir = process.cwd();
-while (true) {
-  if (existsSync(join(dir, '.ai', 'kenkeep'))) {
-    process.stdout.write(dir);
-    process.exit(0);
-  }
-  const parent = dirname(dir);
-  if (parent === dir) {
-    process.stderr.write('kk-detect-root: no .ai/kenkeep found in this directory or its parents.\n');
-    process.exit(2);
-  }
-  dir = parent;
-}
-EOF
-fi
-KK_REPO_ROOT=$(node /tmp/kk-detect-root.mjs) || exit $?
-cd "$KK_REPO_ROOT" || exit $?
-HARNESS=$(node .ai/kenkeep/scripts/kk-detect-harness.mjs --hint <hint> --root "$KK_REPO_ROOT")
-pwd
-```
+<!-- kk-include: _partials/resolve-active-harness.md -->
 
 `$HARNESS` is not consumed by the `place` primitives, but `index rebuild` (the closing command of the flat-to-tree procedure) requires it. Treat the printed path as the working directory for every command below.
 
@@ -122,13 +92,7 @@ On success it prints one JSON line, the placement summary:
 {"placed":[{"id":"<id>","targetFolder":"<folder>"}, ...]}
 ```
 
-### 4. Rebuild the indices
-
-Regenerate `ENTRY.md`, `GRAPH.md`, and every folder `index.md` from the relocated tree:
-
-```bash
-npx --yes kenkeep@latest index rebuild --harness "$HARNESS"
-```
+<!-- kk-include: _partials/index-rebuild-section.md {"heading":"### 4. Rebuild the indices","lead":"Regenerate `ENTRY.md`, `GRAPH.md`, and every folder `index.md` from the relocated tree:"} -->
 
 The rebuild self-preserves the folder summaries you stamped in step 3. A folder you left without an authored summary renders the Title-cased folder-name fallback; `index rebuild` warns and exits zero (warn, never block).
 

--- a/src/templates-source/skills/kk-session-extract/SKILL.md
+++ b/src/templates-source/skills/kk-session-extract/SKILL.md
@@ -13,37 +13,7 @@ Extract durable project knowledge from the **visible current session**, stage it
 
 **Partial context warning:** if compaction has occurred, the visible context may be incomplete. Describe your extraction as visible-context extraction, not full-session extraction, unless the runtime exposes the full transcript.
 
-## Resolve the active harness
-
-Substitute your own best-guess id for `<hint>` based on the runtime you are running inside (one of `claude`, `codex`, `copilot`, `cursor`, `opencode`). Run the materialization block exactly as-is (it lazy-writes `/tmp/kk-detect-root.mjs` on first invocation):
-
-```bash
-if [ ! -f /tmp/kk-detect-root.mjs ]; then
-cat << 'EOF' > /tmp/kk-detect-root.mjs
-#!/usr/bin/env node
-// kk-detect-root: resolves the project root containing .ai/kenkeep.
-import { existsSync } from 'node:fs';
-import { dirname, join } from 'node:path';
-let dir = process.cwd();
-while (true) {
-  if (existsSync(join(dir, '.ai', 'kenkeep'))) {
-    process.stdout.write(dir);
-    process.exit(0);
-  }
-  const parent = dirname(dir);
-  if (parent === dir) {
-    process.stderr.write('kk-detect-root: no .ai/kenkeep found in this directory or its parents.\n');
-    process.exit(2);
-  }
-  dir = parent;
-}
-EOF
-fi
-KK_REPO_ROOT=$(node /tmp/kk-detect-root.mjs) || exit $?
-cd "$KK_REPO_ROOT" || exit $?
-HARNESS=$(node .ai/kenkeep/scripts/kk-detect-harness.mjs --hint <hint> --root "$KK_REPO_ROOT")
-pwd
-```
+<!-- kk-include: _partials/resolve-active-harness.md -->
 
 `$HARNESS` is required for `index rebuild`. Treat the printed path as the working directory for every command below.
 
@@ -112,9 +82,7 @@ Follow `/kk-curate` Step 5 exactly: persist `$SURVIVORS` via `curate-persist`, s
 
 ## 6. Rebuild the indices
 
-```bash
-npx --yes kenkeep@latest index rebuild --harness "$HARNESS"
-```
+<!-- kk-include: _partials/index-rebuild-command.md -->
 
 ## 6b. Rebalance (final phase)
 

--- a/tests/skills/root-discovery.test.ts
+++ b/tests/skills/root-discovery.test.ts
@@ -4,7 +4,7 @@ import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
 const here = resolve(fileURLToPath(import.meta.url), '..');
-const skillsDir = join(here, '../../src/templates-source/skills');
+const skillsDir = join(here, '../../templates/skills');
 
 const skills = [
   ['kk-add', '6'],

--- a/tests/skills/template-includes.test.ts
+++ b/tests/skills/template-includes.test.ts
@@ -1,0 +1,99 @@
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const here = resolve(fileURLToPath(import.meta.url), '..');
+const root = resolve(here, '../..');
+const sourceSkillsDir = join(root, 'src/templates-source/skills');
+const templatesDir = join(root, 'templates');
+const renderedSkillsDir = join(templatesDir, 'skills');
+
+const includeMarker = '<!-- kk-include: _partials/resolve-active-harness.md -->';
+const indexRebuildCommand = 'npx --yes kenkeep@latest index rebuild --harness "$HARNESS"';
+const skillsWithHarnessPartial = [
+  'kk-add',
+  'kk-bootstrap',
+  'kk-curate',
+  'kk-migrate',
+  'kk-session-extract',
+] as const;
+const skillsWithIndexRebuildPartial = [
+  'kk-bootstrap',
+  'kk-curate',
+  'kk-migrate',
+  'kk-session-extract',
+] as const;
+
+function walkFiles(dir: string): string[] {
+  const files: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...walkFiles(path));
+    } else if (entry.isFile()) {
+      files.push(path);
+    }
+  }
+  return files;
+}
+
+describe('template partial includes', () => {
+  it('keeps active-harness resolution as a shared source partial', () => {
+    const partial = readFileSync(
+      join(root, 'src/templates-source/_partials/resolve-active-harness.md'),
+      'utf8'
+    );
+
+    expect(partial).toContain('## Resolve the active harness');
+    expect(partial).toContain('/tmp/kk-detect-root.mjs');
+    expect(partial).toContain('cd "$KK_REPO_ROOT"');
+    expect(partial).toContain('.ai/kenkeep/scripts/kk-detect-harness.mjs');
+
+    for (const skill of skillsWithHarnessPartial) {
+      const source = readFileSync(join(sourceSkillsDir, skill, 'SKILL.md'), 'utf8');
+      expect(source, skill).toContain(includeMarker);
+    }
+  });
+
+  it('renders shipped skill templates without unresolved include markers', () => {
+    expect(existsSync(join(templatesDir, '_partials'))).toBe(false);
+
+    for (const skill of skillsWithHarnessPartial) {
+      const rendered = readFileSync(join(renderedSkillsDir, skill, 'SKILL.md'), 'utf8');
+      expect(rendered, skill).not.toContain('kk-include:');
+      expect(rendered, skill).toContain('## Resolve the active harness');
+      expect(rendered, skill).toContain('/tmp/kk-detect-root.mjs');
+      expect(rendered, skill).toContain('cd "$KK_REPO_ROOT"');
+      expect(rendered, skill).toContain('.ai/kenkeep/scripts/kk-detect-harness.mjs');
+    }
+  });
+
+  it('renders parameterized index-rebuild partials into shipped skill templates', () => {
+    const sectionPartial = readFileSync(
+      join(root, 'src/templates-source/_partials/index-rebuild-section.md'),
+      'utf8'
+    );
+
+    expect(sectionPartial).toContain('{{heading}}');
+    expect(sectionPartial).toContain('{{lead}}');
+    expect(sectionPartial).toContain(indexRebuildCommand);
+
+    for (const skill of skillsWithIndexRebuildPartial) {
+      const source = readFileSync(join(sourceSkillsDir, skill, 'SKILL.md'), 'utf8');
+      const rendered = readFileSync(join(renderedSkillsDir, skill, 'SKILL.md'), 'utf8');
+
+      expect(source, skill).toContain('kk-include: _partials/index-rebuild');
+      expect(rendered, skill).toContain(indexRebuildCommand);
+      expect(rendered, skill).not.toMatch(/\{\{\s*[A-Za-z][A-Za-z0-9_]*\s*\}\}/);
+    }
+  });
+
+  it('ships no markdown files with unresolved include markers', () => {
+    for (const file of walkFiles(templatesDir).filter(path => path.endsWith('.md'))) {
+      const text = readFileSync(file, 'utf8');
+      expect(text, file).not.toContain('kk-include:');
+      expect(text, file).not.toMatch(/\{\{\s*[A-Za-z][A-Za-z0-9_]*\s*\}\}/);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- add build-time markdown partial rendering to the existing `build:templates` flow
- resolve include paths relative to `src/templates-source` and reject paths that escape that tree
- extract shared active-harness resolution and index-rebuild snippets into source partials
- keep generated `templates/skills/*/SKILL.md` self-contained with no unresolved include markers
- cover plain and parameterized includes in skill template tests

Fixes #63.

## Tests

- `npm test`
- `npm run typecheck`
- targeted ESLint on changed template/include files
