### PR TITLE
fix: wrap Codex hook context output

### DIFF
--- a/docs/internals/hooks.md
+++ b/docs/internals/hooks.md
@@ -127,7 +127,7 @@ Per `SessionStart`:
 4. Compare the root index node's `nodes_hash` (the global hash over the whole leaf set) against the live hash of `nodes/`. On drift, append `> kenkeep index is stale, run \`npx kenkeep index rebuild\``.
 5. Count pending logs. If the count is at or above `curationThreshold` (default 20) and the last nudge was over an hour ago, append a one-line nudge and write `last_nudged_at`. The nudge escalates to a loud `🚨 kenkeep curation queue is overdue` heading when the queue is large or stale: `pending >= 10`, or `pending >= curationThreshold` with the oldest log at least `staleDays` (default 7) old.
 6. For actionable nudges only — stale index, curation backlog, and lint findings — attempt a native OS notification when `notifications.enabled` is true (the default) and the platform has a local backend. macOS uses `osascript`; Linux uses `notify-send`. If several signals fire on the same SessionStart, they are batched into one urgency-aware desktop notification. The attempt is fire-and-forget, shell-free, and best effort: missing commands, denied permissions, headless sessions, SSH, WSL, missing DBus, and notification-daemon failures are silent skips. No network backend such as `ntfy` is used.
-7. Emit through the host's native channel, with no event-name translation: Claude and Codex return `additionalContext`; Cursor relays `additional_context` (dropped where the host doesn't consume it); OpenCode writes `.opencode/AGENTS.md`; Copilot writes the `.github/copilot-instructions.md` sentinel block. The Claude shape is:
+7. Emit through the host's native channel, with no event-name translation: Claude and Codex return `hookSpecificOutput.additionalContext`; Cursor relays `additional_context` (dropped where the host doesn't consume it); OpenCode writes `.opencode/AGENTS.md`; Copilot writes the `.github/copilot-instructions.md` sentinel block. The Claude and Codex shape is:
 
    ```json
    {"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"..."}}
@@ -145,7 +145,7 @@ Per `UserPromptSubmit`:
 2. Read the native `prompt` field. Empty or missing → exit 0 with no context.
 3. Resolve the repo root from the payload `cwd`; if the project is not initialized, exit 0.
 4. Call the shared deterministic retrieval core (`src/lib/prompt-retrieval.ts`): read the current on-disk leaf nodes via `readAllNodes`, score each against the prompt (lexical matches in `title`/`tags`/`summary` weighted above body, with a small graph-neighbor boost resolved through `nodes/.redirects.json`), and render a bounded **summaries-plus-links** block.
-5. Emit through the host's native channel — Claude `{"hookSpecificOutput":{"hookEventName":"UserPromptSubmit","additionalContext":"..."}}`; Codex `{"additionalContext":"..."}`. When nothing is relevant, emit nothing.
+5. Emit through the host's native channel — Claude and Codex `{"hookSpecificOutput":{"hookEventName":"UserPromptSubmit","additionalContext":"..."}}`. When nothing is relevant, emit nothing.
 
 The payload carries each match's title, id, repo-relative markdown link (`.ai/kenkeep/nodes/<relPath>`), summary, and tags — **never full leaf bodies** — plus a one-line instruction to open the linked node before relying on details and to verify named files/functions/flags against the live tree. Output is bounded by an internal node-count cap and a rendered-character budget (no `config.yaml` setting in the MVP).
 
@@ -158,7 +158,7 @@ The payload carries each match's title, id, repo-relative markdown link (`.ai/ke
 | Harness | Prompt-time injection | Channel |
 |---|---|---|
 | Claude Code | ✅ | native `UserPromptSubmit` → `hookSpecificOutput.additionalContext` |
-| Codex CLI | ✅ | native `UserPromptSubmit` → `{ additionalContext }` |
+| Codex CLI | ✅ | native `UserPromptSubmit` → `hookSpecificOutput.additionalContext` |
 | Cursor | ❌ | no verified native prompt-submit context channel in this repo |
 | OpenCode | ❌ | plugin events list no documented prompt-submit model-context channel |
 | GitHub Copilot CLI | ❌ | `userPromptSubmitted` output is documented as not processed |

--- a/src/harnesses/codex/hook-spec.ts
+++ b/src/harnesses/codex/hook-spec.ts
@@ -20,8 +20,8 @@ export const codexHookSpecs: readonly HookSpec[] = [
   { event: 'SessionStart', scriptPath: 'kk-proposal-drain.cjs', async: true },
   { event: 'Stop', scriptPath: 'kk-lint-tick.cjs' },
   // Prompt-time injection: Codex natively fires `UserPromptSubmit` with the
-  // user's `prompt` and consumes a synchronous `{ additionalContext }` reply.
-  // Synchronous (not routed through the async launcher) so its stdout reaches
-  // the session.
+  // user's `prompt` and consumes a synchronous `hookSpecificOutput`
+  // additionalContext reply. Synchronous (not routed through the async
+  // launcher) so its stdout reaches the session.
   { event: 'UserPromptSubmit', scriptPath: 'kk-prompt-context.cjs' },
 ];

--- a/src/harnesses/codex/hooks/kk-prompt-context.ts
+++ b/src/harnesses/codex/hooks/kk-prompt-context.ts
@@ -6,9 +6,9 @@
  * relevant nodes. This is the prompt-time complement to the SessionStart
  * `ENTRY.md` orientation injection; both surfaces coexist.
  *
- * Output format: Codex consumes `{ "additionalContext": "<text>" }` on stdout
- * and injects the string into the active turn. Registered WITHOUT async so
- * stdout reaches the session.
+ * Output format: Codex's `UserPromptSubmit` JSON contract —
+ * `{ hookSpecificOutput: { hookEventName: "UserPromptSubmit", additionalContext } }`.
+ * Registered WITHOUT async so stdout reaches the session.
  *
  * Bounded and fail-open: a short hard deadline guards the prompt path, and any
  * missing prompt, missing/empty/malformed knowledge base, or error yields no
@@ -41,6 +41,13 @@ runHookEntry({
       return;
     }
     if (context.trim().length === 0) return;
-    process.stdout.write(JSON.stringify({ additionalContext: context }));
+    process.stdout.write(
+      `${JSON.stringify({
+        hookSpecificOutput: {
+          hookEventName: 'UserPromptSubmit',
+          additionalContext: context,
+        },
+      })}\n`
+    );
   },
 });

--- a/src/harnesses/codex/hooks/kk-session-start.ts
+++ b/src/harnesses/codex/hooks/kk-session-start.ts
@@ -2,9 +2,10 @@
  * SessionStart hook (sync) for the Codex CLI adapter.
  *
  * Emits the current `ENTRY.md` body (plus the standard staleness and nudge
- * lines) as Codex's documented additionalContext payload. Codex consumes
- * `{ "additionalContext": "<text>" }` on stdout and injects the string into
- * the active session.
+ * lines) as Codex's documented additionalContext payload.
+ *
+ * Output format: Codex's `SessionStart` JSON contract —
+ * `{ hookSpecificOutput: { hookEventName: "SessionStart", additionalContext } }`.
  */
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
@@ -46,7 +47,14 @@ runHookEntry({
       });
       sendSessionStartNotifications(settings, result);
       const { statusLine, content } = buildNudgeContent(result);
-      process.stdout.write(JSON.stringify({ additionalContext: content }));
+      process.stdout.write(
+        `${JSON.stringify({
+          hookSpecificOutput: {
+            hookEventName: 'SessionStart',
+            additionalContext: content,
+          },
+        })}\n`
+      );
       process.stderr.write(`${statusLine}\n`);
       process.stderr.write('🧠 kenkeep Index: Knowledge base loaded.\n');
     } catch (err) {

--- a/tests/hooks/kk-prompt-context.test.ts
+++ b/tests/hooks/kk-prompt-context.test.ts
@@ -109,8 +109,11 @@ function claudeContext(stdout: string): string {
 
 function codexContext(stdout: string): string {
   if (stdout.trim().length === 0) return '';
-  const parsed = JSON.parse(stdout) as { additionalContext?: string };
-  return parsed.additionalContext ?? '';
+  const parsed = JSON.parse(stdout) as {
+    hookSpecificOutput?: { hookEventName?: string; additionalContext?: string };
+  };
+  expect(parsed.hookSpecificOutput?.hookEventName).toBe('UserPromptSubmit');
+  return parsed.hookSpecificOutput?.additionalContext ?? '';
 }
 
 describe('prompt-time injection hooks (built bundles)', () => {
@@ -133,7 +136,7 @@ describe('prompt-time injection hooks (built bundles)', () => {
     expect(ctx).not.toContain('SECRET_BODY_TEXT');
   });
 
-  it('Codex injects the same payload via its additionalContext channel', async () => {
+  it('Codex injects the same payload via its hookSpecificOutput channel', async () => {
     const res = await runHook(hookPath('codex'), sb.root, {
       cwd: sb.root,
       prompt: 'wire codex hooks',

--- a/tests/hooks/kk-session-start.test.ts
+++ b/tests/hooks/kk-session-start.test.ts
@@ -74,6 +74,14 @@ function runHookRaw(
   });
 }
 
+function codexSessionStartContext(stdout: string): string {
+  const parsed = JSON.parse(stdout) as {
+    hookSpecificOutput?: { hookEventName?: string; additionalContext?: string };
+  };
+  expect(parsed.hookSpecificOutput?.hookEventName).toBe('SessionStart');
+  return parsed.hookSpecificOutput?.additionalContext ?? '';
+}
+
 async function waitForFileLines(file: string, expected: number): Promise<string[]> {
   const deadline = Date.now() + 2_000;
   while (Date.now() < deadline) {
@@ -220,11 +228,10 @@ describe('per-harness SessionStart injection (tree descent)', () => {
     expect(ctx).not.toContain('practice-deep-leaf');
   });
 
-  it('Codex injects the same payload via its additionalContext channel', async () => {
+  it('Codex injects the same payload via its hookSpecificOutput channel', async () => {
     const res = await runHook(hookPath('codex'), sb.root, { cwd: sb.root });
     expect(res.exitCode).toBe(0);
-    const parsed = JSON.parse(res.stdout) as { additionalContext?: string };
-    const ctx = parsed.additionalContext ?? '';
+    const ctx = codexSessionStartContext(res.stdout);
     expect(ctx).toContain('# kenkeep');
     expect(ctx).toContain(DESCENT_PHRASE);
     expect(ctx).not.toContain(GREP_RECIPE);
@@ -237,8 +244,7 @@ describe('per-harness SessionStart injection (tree descent)', () => {
   it('Codex session-start keeps stdout machine JSON and ignores malformed stdin', async () => {
     const res = await runHookRaw(hookPath('codex'), sb.root, 'not json');
     expect(res.exitCode).toBe(0);
-    const parsed = JSON.parse(res.stdout) as { additionalContext?: string };
-    expect(parsed.additionalContext).toContain('# kenkeep');
+    expect(codexSessionStartContext(res.stdout)).toContain('# kenkeep');
     expect(res.stderr).toContain('Loading knowledge base');
 
     const dateStr = new Date().toISOString().slice(0, 10);
@@ -341,8 +347,7 @@ describe('per-harness SessionStart injection (tree descent)', () => {
         harness: 'codex',
         input: { cwd: sb.root },
         assertOutput: (res: SpawnResult) => {
-          const parsed = JSON.parse(res.stdout) as { additionalContext?: string };
-          expect(parsed.additionalContext).toContain(
+          expect(codexSessionStartContext(res.stdout)).toContain(
             'Issue: ENTRY.md is stale because nodes changed since the last index rebuild.'
           );
         },
@@ -415,22 +420,20 @@ describe('per-harness SessionStart injection (tree descent)', () => {
       }
     );
     expect(res.exitCode).toBe(0);
-    const parsed = JSON.parse(res.stdout) as { additionalContext?: string };
-    expect(parsed.additionalContext).toContain('# kenkeep');
-    expect(parsed.additionalContext).toContain('Project:');
-    expect(parsed.additionalContext).toContain(`Host: ${osHostname()}`);
-    expect(parsed.additionalContext).toContain(`Path: ${sb.root}`);
-    expect(parsed.additionalContext).toContain(
+    const ctx = codexSessionStartContext(res.stdout);
+    expect(ctx).toContain('# kenkeep');
+    expect(ctx).toContain('Project:');
+    expect(ctx).toContain(`Host: ${osHostname()}`);
+    expect(ctx).toContain(`Path: ${sb.root}`);
+    expect(ctx).toContain(
       'Issue: ENTRY.md is stale because nodes changed since the last index rebuild.'
     );
-    expect(parsed.additionalContext).toContain(
+    expect(ctx).toContain(
       'Issue: Curation queue is overdue: 1 pending session log(s), 1 candidate proposal(s). Oldest pending capture:'
     );
-    expect(parsed.additionalContext).toContain('Action: Run /kk-curate.');
-    expect(parsed.additionalContext).toContain(
-      'Issue: Lint findings were recorded in the last kenkeep lint run.'
-    );
-    expect(parsed.additionalContext).toContain('Action: Run npx kenkeep lint --verbose.');
+    expect(ctx).toContain('Action: Run /kk-curate.');
+    expect(ctx).toContain('Issue: Lint findings were recorded in the last kenkeep lint run.');
+    expect(ctx).toContain('Action: Run npx kenkeep lint --verbose.');
 
     const notifications = await waitForFileLines(fake.logFile, 1);
     expect(notifications).toHaveLength(1);
@@ -460,8 +463,7 @@ describe('per-harness SessionStart injection (tree descent)', () => {
       }
     );
     expect(res.exitCode).toBe(0);
-    const parsed = JSON.parse(res.stdout) as { additionalContext?: string };
-    expect(parsed.additionalContext).toContain('Action: Run /kk-curate.');
+    expect(codexSessionStartContext(res.stdout)).toContain('Action: Run /kk-curate.');
 
     await settleNotifications();
     expect(existsSync(fake.logFile)).toBe(false);


### PR DESCRIPTION
## Summary
- wrap Codex SessionStart context output in hookSpecificOutput
- wrap Codex UserPromptSubmit context output in hookSpecificOutput
- update hook tests and internals docs for the current Codex envelope

Fixes #80.

## Tests
- npm test
- npm run typecheck
- npm run lint
- npx vitest run tests/hooks/kk-session-start.test.ts tests/hooks/kk-prompt-context.test.ts