### PR TITLE
docs(research): OpenWiki comparison, landscape analysis, and outreach notes

### DIFF
--- a/research/openwiki-2026-07/README.md
+++ b/research/openwiki-2026-07/README.md
@@ -1,0 +1,21 @@
+# OpenWiki × kenkeep comparative research (July 2026)
+
+Research artifacts from a comparison of kenkeep against [langchain-ai/openwiki](https://github.com/langchain-ai/openwiki) and the wider AI-coding-memory landscape. Working notes for the maintainer — not product documentation; may be pruned or deleted once harvested.
+
+## Contents
+
+| File | What it is |
+|---|---|
+| [openwiki-deepdive.md](openwiki-deepdive.md) | Full inventory of OpenWiki (architecture, prompt engineering, incremental-update flow, GitHub Action), nine improvement ideas for kenkeep with constitution-fit analysis, and where kenkeep is stronger. |
+| [landscape-and-value-prop.md](landscape-and-value-prop.md) | Mid-2026 landscape (claude-mem, MemPalace, mem0, Letta, ByteRover, DeepWiki, Claude Code auto-memory, Cursor memories), feature comparison table, kenkeep-vs-OpenWiki value props, and an honest "is kenkeep worth maintaining?" verdict. |
+| [social-links-and-comments.md](social-links-and-comments.md) | Verified public links discussing OpenWiki (HN, X, LinkedIn, Medium) with per-link drafted comments that mention kenkeep with disclosure, plus per-platform do/don't guidance. |
+
+## Issues spawned from this research
+
+- [#89](https://github.com/e0ipso/kenkeep/issues/89) — git-anchored freshness signal (the biggest gap)
+- [#90](https://github.com/e0ipso/kenkeep/issues/90) — deletable plan-file checkpoint in kk-curate/kk-bootstrap
+- [#91](https://github.com/e0ipso/kenkeep/issues/91) — surgical-update discipline; no-op is a valid curate outcome
+- [#92](https://github.com/e0ipso/kenkeep/issues/92) — "what to watch when editing" guidance on map nodes
+- [#93](https://github.com/e0ipso/kenkeep/issues/93) — read-only CI KB-health workflow (lint + doctor + freshness)
+- [#94](https://github.com/e0ipso/kenkeep/issues/94) — "one canonical home" dedup guardrail
+- [#95](https://github.com/e0ipso/kenkeep/issues/95) — doctor diagnostics polish

--- a/research/openwiki-2026-07/landscape-and-value-prop.md
+++ b/research/openwiki-2026-07/landscape-and-value-prop.md
@@ -1,0 +1,162 @@
+# AI Coding Memory & Repo-Knowledge Landscape — mid-2026
+
+Strategic analysis for **kenkeep** (git-native, human-curated, team-shared knowledge base built from AI coding sessions; npm package; multi-harness: Claude Code, Codex CLI, Cursor, OpenCode, Copilot CLI; no daemons, no DB, no API keys).
+
+---
+
+## 1. The tools
+
+The space has split into three families that are often lumped together but solve different problems:
+
+- **A. Session/agent memory** — capture what the agent did, recall it later. (claude-mem, MemPalace, mem0, Letta, ByteRover, Cline Memory Bank, Claude Code auto-memory, Cursor memories)
+- **B. Code-derived documentation** — read the source, generate a wiki. (OpenWiki, DeepWiki)
+- **C. Curated tribal knowledge** — distill durable, reviewed facts from sessions into a shared, versioned base. (**kenkeep**; ByteRover partially)
+
+kenkeep sits in **C**, closest in mechanics to A (session-derived) but closest in intent to B (a durable, shared artifact) — while being the only one that is simultaneously human-curated, git-reviewed, zero-infra, no-key, and genuinely multi-harness.
+
+### kenkeep (the subject)
+- **Source:** durable knowledge distilled from AI coding sessions (conventions, gotchas, named modules, decision rationale).
+- **Storage:** plain markdown in git, one node per fact, under `.ai/kenkeep/nodes/`; a conformant Open Knowledge Format (OKF v0.1) bundle. Tree-over-DAG with generated index nodes and progressive-disclosure retrieval. **No DB, no vectors, no embeddings.**
+- **Team vs per-user:** committed team artifact; per-user state (`_sessions/`, `_logs/`, `.state/`) is gitignored.
+- **Curation:** human-in-the-loop. Nothing enters the base without `/kk-curate` (LLM drafts) + `git commit` (human accepts) / `git restore` (rejects). Contradictions surface as conflict files the human resolves; the curator never auto-resolves.
+- **Infra:** none. One-shot CLI + host-harness hooks. No daemons/services/Docker.
+- **API keys:** none. Runs inside whatever assistant subscription you already pay for.
+- **Harness coverage:** Claude Code, Codex CLI, Cursor, OpenCode, Copilot CLI (5). Prompt-time injection wired for Claude + Codex today.
+- **Retrieval/injection:** deterministic. SessionStart injects the root `ENTRY.md` catalog; agent descends by relevance (progressive disclosure). Optional prompt-time hook injects lexically-ranked leaf summaries. No LLM, no store at retrieval time.
+- **Signals:** small/early npm package (`kenkeep`), single-maintainer (e0ipso / Lullabot orbit), actively developed; ships knowledge packs for shared framework/domain trees.
+
+### OpenWiki (LangChain)
+- **Source:** the **codebase** — reads source and generates wiki-style docs.
+- **Storage:** markdown in the repo under `openwiki/`; committed to git. Config/keys in `~/.openwiki/.env`.
+- **Team vs per-user:** the wiki is a committed team artifact; runs per-developer or via CI.
+- **Curation:** **automatic** — an agent generates/refreshes docs; a GitHub Action opens a **daily PR** with updates. Human review is the PR merge, but content is machine-authored end-to-end.
+- **Infra:** CLI + optional GitHub Action. No DB.
+- **API keys:** **required.** Configure an inference provider + key (OpenRouter, Fireworks, Baseten, OpenAI, Anthropic; GLM 5.2 / Kimi K2.6 / Sonnet 5, custom model IDs). Optional LangSmith key for tracing.
+- **Harness coverage:** harness-agnostic rather than multi-harness — it is its own CLI/agent and *appends pointers to* `AGENTS.md`/`CLAUDE.md` so any coding agent references the generated wiki. Not a plugin into 5 harnesses.
+- **Retrieval/injection:** indirect — the agent reads the `openwiki/` markdown via the pointer added to AGENTS.md/CLAUDE.md.
+- **Signals:** ~4.9k stars, ~360 forks; backed by LangChain (langchain-ai org).
+
+### claude-mem
+- **Source:** everything the agent does — tool observations captured live via 5 hooks (SessionStart, PostToolUse, Stop, UserPromptSubmit, SessionEnd), AI-compressed into semantic summaries.
+- **Storage:** local store with a background worker service; HTTP API on **port 37777**. DB/index-backed, not plain reviewable markdown.
+- **Team vs per-user:** **per-user / per-machine** (local observations).
+- **Curation:** **automatic**, no human review — observer agent records and injects the relevant slice next session.
+- **Infra:** background worker/daemon + local HTTP service. (Feb 2026 community audit rated it HIGH risk: the port-37777 API has no auth, so any local process can read stored observations/settings.)
+- **API keys:** none separate (uses the harness/subscription for compression).
+- **Harness coverage:** broad plugin — Claude Code, Gemini CLI, Codex, OpenCode, OpenClaw, Copilot.
+- **Retrieval/injection:** automatic context injection of the relevant compressed slice at session start.
+- **Signals:** very popular — ~84k stars, 7.2k forks, 288 releases, v13.8.0 (Jun 2026). The runaway leader by mindshare in family A.
+
+### MemPalace
+- **Source:** conversation history stored **verbatim** (no summarize/extract/paraphrase); human "mining" chooses what to file.
+- **Storage:** vector — ChromaDB default (+ SQLite exact), optional Qdrant/pgvector. Hierarchical temporal structure (Wings > Rooms > Closets > Drawers).
+- **Team vs per-user:** **local per-user** ("nothing leaves your machine unless you opt in").
+- **Curation:** human decides what gets mined in; **retrieval is automated semantic search**, not editorially reviewed. Verbatim, not distilled.
+- **Infra:** local vector DB (ChromaDB/SQLite); optional external backends.
+- **API keys:** none for core (zero API calls; runs local embeddings).
+- **Harness coverage:** Claude Code, Cursor, Gemini CLI via hooks + MCP.
+- **Retrieval/injection:** vector semantic search, ~170 tokens to recall; MCP-exposed. Tops LongMemEval among free tools (96.6% raw).
+- **Signals:** viral — ~57k stars, 7.4k forks; MIT. Launched Apr 2026 (Milla Jovovich + Ben Sigman).
+
+### DeepWiki (Cognition)
+- **Source:** the **codebase** — Devin-generated docs (architecture diagrams, module explanations, dependency maps) for any public GitHub repo.
+- **Storage:** **hosted by Cognition** — not in your repo, not local. Swap `github.com` → `deepwiki.com`.
+- **Team vs per-user:** public/shared hosted docs; free for open source. Private repos via paid.
+- **Curation:** fully automatic; conversational Q&A grounded in source.
+- **Infra:** none for you (it's a SaaS); an official MCP server at `mcp.deepwiki.com` exposes it to agents.
+- **API keys:** none for public use.
+- **Harness coverage:** any MCP client (Claude Code, Cursor, etc.) via the MCP server.
+- **Signals:** ~50k+ repos indexed; backed by Cognition (Devin).
+
+### Claude Code — native memory (CLAUDE.md + auto-memory)
+- **Source:** persistent instructions (hand-written CLAUDE.md) **plus auto-memory** — Claude autonomously writes useful learnings (build commands, gotchas, style, workflow) back to CLAUDE.md across sessions.
+- **Storage:** plain markdown (CLAUDE.md) in git — same medium as kenkeep.
+- **Team vs per-user:** project CLAUDE.md is committable/team-shared; auto-memory writes are effectively per-user until committed and can bloat a single file.
+- **Curation:** auto-memory is **automatic** and **on by default** (v2.1.59+); the human only reviews if they happen to diff CLAUDE.md.
+- **Infra / keys:** none (built into the harness).
+- **Harness coverage:** **Claude Code only.**
+- **Retrieval:** whole file read at session start (no progressive disclosure; scales poorly as it grows).
+- **This is the single biggest commoditization threat to kenkeep's mechanics** (see §3).
+
+### Cursor — rules + memories
+- **Source:** memories auto-generated from chat, scoped to project; plus `.cursor/rules`.
+- **Storage:** memories in Cursor's own store (per-user/per-project); rules as files in-repo.
+- **Team vs per-user:** memories are per-user; the **Business plan ($40/user/mo)** adds a team marketplace for shared rules/skills and org-wide standards.
+- **Curation:** memories automatic; rules hand-authored.
+- **Infra/keys:** none extra (in-product).
+- **Harness coverage:** **Cursor only** (editor + its CLI share one bank).
+
+### mem0 / Letta / ByteRover / Cline Memory Bank (family A, briefly)
+- **mem0:** vector-DB memory layer/SDK for agents; automatic extraction; needs infra + keys; ~51k stars, $24M raised. Framework, not a curated repo artifact.
+- **Letta (ex-MemGPT):** OS-style stateful-agent framework (main context = RAM, archival = disk); DB-backed; ~13k stars; self-hosted control. Agent-autonomy focused.
+- **ByteRover:** the closest philosophical cousin outside kenkeep — a **git-like, curated, version-controlled "context tree"** synced across teammates, provider-agnostic CLI (20 providers), works with any agent. Differs from kenkeep: it's a separate memory layer/product (not zero-infra plain-markdown-in-your-repo), leans on its own structured store, and is a standalone tool rather than harness-native hooks.
+- **Cline Memory Bank:** a markdown documentation *methodology* (structured .md files in-repo) that Cline reads to survive context-window clears. In-repo markdown like kenkeep, but Cline-specific, manually structured, and not session-distilled/curated with a review gate.
+
+---
+
+## 2. Feature-set comparison table
+
+| Dimension | **kenkeep** | **OpenWiki** | **claude-mem** | **MemPalace** | **DeepWiki** | **CC auto-memory** |
+|---|---|---|---|---|---|---|
+| Knowledge source | Sessions -> distilled facts | **Code** -> docs | Sessions (tool obs) | Sessions (verbatim) | **Code** -> docs | Sessions (autonomous) |
+| Storage | Markdown in git (OKF) | Markdown in git | Local DB + worker | Vector DB (Chroma/SQLite) | **Hosted SaaS** | Markdown (CLAUDE.md) |
+| Curation | **Human-reviewed** (commit/restore) | Automatic (daily PR) | Automatic | Human-mine / auto-retrieve | Automatic | Automatic (default on) |
+| Team-shared | **Yes (git)** | Yes (git) | No (per-user) | No (per-user) | Public hosted | Partial (commit CLAUDE.md) |
+| Multi-harness | **Yes (5, native hooks)** | Agnostic (pointer file) | Yes (6, plugin) | Yes (3, hooks/MCP) | Any MCP client | **Claude only** |
+| Infra | **None** | CLI + Action | Daemon + HTTP:37777 | Vector DB | None (SaaS) | None |
+| API keys | **None** | **Required** | None | None | None | None |
+| Review workflow | **git diff / PR per fact** | PR (machine-authored) | None | None | None | None (diff if noticed) |
+| Retrieval/injection | Deterministic progressive disclosure + lexical prompt-time; no LLM/vectors | Agent reads openwiki/ via pointer | Auto-inject compressed slice | Vector semantic (MCP) | MCP Q&A | Whole-file read at start |
+| Popularity | Early/small | ~4.9k stars | ~84k stars | ~57k stars | 50k+ repos | Built-in |
+
+---
+
+## 3. kenkeep vs OpenWiki — value props (crisp)
+
+**They answer different questions.**
+
+- **OpenWiki answers "what is this code?"** — it derives *documentation* from *source*. Ground truth is the tree; output is architecture/module/dependency description. It is automatic, exhaustive, and machine-authored, refreshed on a schedule.
+- **kenkeep answers "what do we know about working here that the code doesn't say?"** — it derives *tribal knowledge* from *sessions*. Ground truth is human experience: the gotcha that cost someone an afternoon, the rationale behind an odd choice, the convention that isn't enforced anywhere. This is exactly the knowledge that is **not** recoverable from source, which is why OpenWiki structurally cannot produce it.
+
+**Curation philosophy is the sharpest contrast.** OpenWiki trusts the model to write docs and asks a human to merge a PR. kenkeep distrusts the model by design: the constitution forbids anything entering the base without an explicit human `git commit`, and forbids the curator from auto-resolving contradictions. OpenWiki optimizes for *coverage*; kenkeep optimizes for *trust and signal*.
+
+**Other axes:** OpenWiki **requires an API key** and an inference provider; kenkeep requires **neither** (runs on the subscription in the harness). OpenWiki is effectively single-tool + a pointer file; kenkeep natively targets 5 harnesses. Both store markdown in git — so both are reviewable and travel with `git pull`.
+
+**Overlap:** both produce a committed markdown knowledge artifact that agents consult; both improve session context without a hosted DB. A team could reasonably run one and feel "covered."
+
+**Complementary, not competitive.** The ideal setup runs **both**: OpenWiki keeps the *structural map* of the code fresh automatically (cheap to regenerate, tolerant of being machine-authored because it's checkable against source), while kenkeep accumulates the *experiential layer* that only humans can validate (expensive to get wrong, so gated on review). One is breadth-from-code; the other is depth-from-experience. They even share the injection surface — OpenWiki appends to AGENTS.md/CLAUDE.md; kenkeep injects its ENTRY.md — and don't collide.
+
+---
+
+## 4. Is kenkeep worth maintaining? — honest verdict
+
+**Verdict: Yes, conditionally — it occupies a real and currently unoccupied niche, but its moat is narrow and one native feature (Claude Code auto-memory) is already eroding the easy version of its value. It is worth maintaining *if and only if* the team leans hard into the four properties no competitor combines, and treats "team-reviewed shared knowledge" — not "session memory" — as the product.**
+
+### The defensible niche (be specific)
+No other tool in this landscape is **all four** of:
+1. **Team-shared** as a first-class git artifact (claude-mem, MemPalace, mem0, Letta, Cursor memories, CC auto-memory are all per-user/per-machine or paywalled-team).
+2. **Human-reviewed with a hard gate** — nothing lands without a `git commit`; contradictions never auto-resolve (everyone else is automatic; OpenWiki's "review" is merging machine-authored bulk).
+3. **Genuinely multi-harness via native hooks** across 5 tools (native memories lock you to one vendor; OpenWiki is agnostic-but-single-tool).
+4. **Zero-infra and zero-API-key** (no daemon like claude-mem's port 37777, no vector DB like MemPalace/mem0, no SaaS like DeepWiki, no separate provider key like OpenWiki).
+
+The intersection of {shared + reviewed + multi-harness + zero-infra + no-key} is **kenkeep alone**. The nearest competitor is ByteRover (git-like curated context tree, team-synced, multi-provider) — but it's a heavier standalone product with its own store, not plain markdown living in your repo with no infra. That gap is kenkeep's real, differentiated territory: the **compliance/enterprise-friendly, trust-first, vendor-neutral** corner of the market — teams that cannot or will not run a daemon, ship data to a SaaS, hold another API key, or let a model write to their knowledge base unreviewed.
+
+### What threatens it
+- **Native harness memory commoditizing the mechanic.** Claude Code **auto-memory is on by default** and writes learnings to CLAUDE.md (markdown in git) autonomously. For a Claude-only shop, that covers the 60% case for free with zero adoption cost. This is the primary threat: it makes "salvage knowledge from sessions and inject it back" a checkbox, not a product.
+- **Mindshare asymmetry.** claude-mem (~84k stars) and MemPalace (~57k stars) dominate attention. Even though they solve a *different* (per-user, automatic, unreviewed) problem, they define what "AI memory" means to most developers, and kenkeep must constantly re-explain that it is not that.
+- **Cursor/vendor team tiers.** Cursor's Business plan already sells shared rules/skills org-wide; vendors are moving toward org-knowledge bases. If Anthropic/Cursor ship *reviewed, shared, multi-project* memory, they compress kenkeep's niche from the top.
+- **"Good enough" substitution.** A team could run OpenWiki (auto docs) + rely on auto-memory and never feel the specific pain kenkeep removes.
+
+### Why the threats don't (yet) close the niche
+- Auto-memory is **single-vendor, unreviewed, and per-user-flavored**, and dumps into one growing file with no progressive disclosure — it degrades at team scale and offers no trust gate. kenkeep's OKF tree + review gate + multi-harness reach are exactly the things native memory omits.
+- claude-mem/MemPalace/mem0 are **explicitly per-user and automatic** — structurally the opposite of a curated team artifact. They cannot become kenkeep without abandoning their design (local, verbatim/compressed, no review).
+- The **no-daemon / no-key / no-SaaS** posture is a hard requirement in regulated and security-conscious orgs; claude-mem's unauthenticated port-37777 and DeepWiki's hosting are non-starters there. kenkeep is one of the few that clears that bar.
+
+### Conditions under which it stops being worth maintaining
+1. **Anthropic (or Cursor) ships reviewed, team-shared, multi-project memory** with a diff/approve gate — that would absorb the niche wholesale for that vendor's users. (Multi-harness neutrality would still be a residual reason to exist, but a shrinking one.)
+2. **Auto-memory adds a review/curation gate and progressive disclosure** and a team-commit story — collapsing kenkeep's differentiation for the dominant harness.
+3. **The maintenance cost outruns the user base.** It's effectively single-maintainer against 5 moving harness targets (hook APIs, event names, transcript formats all drift). If harness churn makes the multi-harness promise a treadmill while adoption stays flat, the ROI inverts.
+4. **The "human-reviewed" value fails to convert** — i.e., in practice teams find automatic memory's occasional wrongness tolerable and won't pay the curation tax. If the market votes for convenience over trust at scale, kenkeep's core bet is wrong.
+
+### Bottom line
+kenkeep is worth maintaining as a **deliberately narrow, principled tool for teams that treat their knowledge base like code**: reviewed, versioned, vendor-neutral, and infra-free. Its differentiation is real and, as of mid-2026, uncontested in combination. But it is a **niche, not a market** — the strategy should be to double down on the review-gate + team-sharing + zero-infra + multi-harness story (and assets like knowledge packs and OKF conformance that native memory can't match), explicitly *ceding* the per-user automatic-recall use case to claude-mem/MemPalace rather than competing there. The moment a major vendor ships *reviewed, shared* memory, reassess hard.

--- a/research/openwiki-2026-07/openwiki-deepdive.md
+++ b/research/openwiki-2026-07/openwiki-deepdive.md
@@ -1,0 +1,47 @@
+# OpenWiki Deep-Dive & Improvement Ideas for kenkeep
+
+## Part 1 — OpenWiki Inventory
+
+**What it is.** LangChain's `openwiki` npm CLI (v0.0.1) runs an LLM agent that generates/maintains a markdown wiki under `openwiki/`. Ink terminal app + one-shot modes + a GitHub Action for scheduled updates. ~10 source files.
+
+**Feature list.** Three modes `chat`/`init`/`update` (`src/agent/types.ts:1`). CLI: bare chat, `openwiki "msg"`, `--init`, `--update`, `-p/--print`, `--modelId`, `--help`, dev `--dry-run` (`src/commands.ts:38-164`). Auto-exit for init/update in a TTY. Five providers (OpenRouter default, Baseten, Fireworks, OpenAI, Anthropic) each with curated + custom model ids (`src/constants.ts:42-95`). OpenRouter multi-model fallback + 5xx retry (`src/agent/index.ts:92-151,381-437`). Credential onboarding to `~/.openwiki/.env` (0600). Optional LangSmith tracing. Incremental updates via `openwiki/.last-update.json` gitHead. Content-snapshot no-op detection. Auto-inserts an `## OpenWiki` block into AGENTS.md/CLAUDE.md. SQLite checkpointer. Read-only subagents. Secret-redacting OpenRouter debug capture.
+
+**Architecture & loop.** Built on `deepagents` `createDeepAgent` with a `LocalShellBackend` (`virtualMode:true`, `rootDir:cwd`, `maxOutputBytes:100_000`, `timeout:120`; `index.ts:180-191`). Empty explicit-tools array — the agent uses backend fs/shell tools + a `task` subagent. Models via `ChatAnthropic`/`ChatOpenRouter`/`ChatOpenAI` (`createModel`, `index.ts:381-411`) — **BYO API key**. Loop: load env → resolve provider/key/model → model-fallback wrapper → build `RunContext` (git + last-update) → snapshot `openwiki/` hash → stream (`streamMode:["messages","tools"], subgraphs:true`) → a large hand-rolled normalizer emits text/tool events to Ink → if post-snapshot ≠ pre-snapshot, write `.last-update.json`. `thread_id = openwiki-<sha256(cwd)[:32]>-<runId>` persisted in SQLite.
+
+**Prompt engineering (verbatim, `src/agent/prompt.ts`).** The product is basically one system prompt.
+- Grounding (`:18`): "Do not invent files, modules, APIs… Ground every important claim in source files, existing docs, or git evidence you have inspected."
+- Sampling discipline (`:24-26`): "Do not exhaustively read every file… Do not call glob with `**/*` from the repository root… Prefer grep/glob and short targeted reads."
+- Plan file (`:39-43`): "create a temporary `openwiki/_plan.md`… lists the intended wiki pages, source evidence for each page, and remaining questions… Before completing the run, delete `openwiki/_plan.md`."
+- Git-as-why (`:46-50`): "Use git heavily where it helps explain why code exists, not just what code exists… inspect commits added since the previous successful OpenWiki run. Prefer the gitHead recorded in `openwiki/.last-update.json`."
+- Anti-thin-page (`:109-118`): "Avoid thin pages… For small repositories with about 10 or fewer primary source files, prefer `openwiki/quickstart.md` plus at most 1-2 supporting pages."
+- Surgical update / diff budget (`:159-174`): "Update runs must be surgical… Prefer replacing one stale sentence over adding new paragraphs… if fewer than about 5 source files changed, update at most 1-2 wiki pages… Updates may be a no-op… Say that the wiki is already current."
+- Docs-impact plan (`:164`): "source change -> docs affected -> edit needed -> why."
+- One canonical home (`:106`); read-only subagent discipline (`:31-37`); no-secrets (`:91-96`); exact AGENTS/CLAUDE template with "refresh only if stale, don't reformat" (`:57-78`). Init caps at ≤8 pages.
+
+**GitHub Action update flow — incremental & diff-based.** `.last-update.json` records `updatedAt/command/gitHead/model` (`utils.ts:39-58`). Next `update` uses `git log <gitHead>..HEAD --name-status`, falling back to `--since <updatedAt>`, plus `git status --short` and `git diff --name-status HEAD` (`utils.ts:181-246`), injected into the prompt. SHA-256 content snapshot over `openwiki/` (minus `.last-update.json`) gates the metadata write so no-op runs produce no diff (`index.ts:231-244`). Workflow: `workflow_dispatch` + daily cron `0 8 * * *`, `contents/pull-requests: write`, installs openwiki globally, runs `openwiki --update --print`, opens a PR via `peter-evans/create-pull-request` on branch `openwiki/update` scoped to `openwiki`. **Fully unattended** — no human gate before the PR.
+
+**Wiki structure.** `quickstart.md` mandated entrypoint; section dirs (`architecture/`, `agent/`, `cli/`, `operations/`). Every page ends with "Things to watch when editing" + "Source map" + a git-evidence commit list, written explicitly for future agents.
+
+**Credentials/DX.** `~/.openwiki/.env` (dir 0700/file 0600); process-env wins over file; secret-safe diagnostics (source, masked preview, whitespace/quote/newline/invalid-id warnings); regex-redacted OpenRouter error bodies; arrow-key provider/model menus; clear non-TTY errors; in-session `/init /update /provider /model /exit`.
+
+## Part 2 — Improvement ideas for kenkeep
+
+1. **Repo-change staleness signal for nodes (the gitHead trick) — fits.** OpenWiki diffs `git log <gitHead>..HEAD` to catch docs describing changed code. kenkeep only has *structural* index staleness (`nodes_hash`, `doctor.ts:263-268`) and *backlog age* (`DEFAULT_STALE_DAYS=7`, `session-start.ts`). No signal that code under a node's topic changed since curation. Propose a deterministic read-only `kenkeep freshness` primitive: stamp a `curated_at` commit sha and diff changed paths against nodes' `derived_from`/referenced files; surface a count in the nudge + `doctor`. Git-native, no LLM, human decides. **Biggest gap.**
+2. **Explicit deletable plan file in curate/bootstrap — fits.** OpenWiki's `_plan.md` (`prompt.ts:39-43`). kenkeep has no reviewable plan before nodes land. Write a gitignored `.ai/kenkeep/_curate-plan.md` (candidate → target node → action → evidence) as a mid-run checkpoint + self-check. Per-user scratch, keeps human-in-loop.
+3. **Adopt surgical-update / no-op-is-valid prompt language in kk-curate — fits.** kenkeep is strong on *admission* but lighter on *modification restraint*. Add "prefer minimal in-place edits; a no-op curate is correct; don't churn accurate nodes" to `knowledge-admission.md`/kk-curate (bump prompt Version). Keeps diffs small — reinforces review value.
+4. **Change-oriented "what to watch when editing" on map nodes — adaptation.** OpenWiki puts this on every page. Encourage (in prompts, not schema) map nodes to carry a "when changing this, verify…" clause + edges to relevant practice nodes. No frontmatter field (avoid schema bump); keep optional to avoid phantom guidance.
+5. **Diagnostic polish à la OpenWiki — fits.** Borrow the secret-safe, actionable diagnostics bar for `doctor`: per-harness registered-vs-missing files, detection status, and frontmatter hygiene warnings (stray whitespace in tags, non-resolving `derived_from`).
+6. **Ship a CI workflow — but as a check/nudge, adaptation (partial conflict).** OpenWiki's unattended daily agent-PR **conflicts** with kenkeep's "no LLM pipelines in CI / human-in-the-loop." Safe slice: a deterministic read-only workflow running `lint` + `doctor` + the freshness check (Idea 1) that annotates a PR when the index is stale/edges dangle and comments "N nodes may be stale; consider `/kk-curate`." Never mutates `nodes/`. Flag OpenWiki's auto-commit model as off-limits.
+7. **Resilience / redaction hygiene — adaptation.** OpenWiki hardens with model fallback + 5xx retry. kenkeep's pending-log retry is already graceful and it deliberately has no provider layer, so mostly confirmation; the borrowable piece is secret-redacting the `_logs/` stream-json and captured shell commands (optional defense-in-depth; PRD §6 already accepts "safe by review, not scanner").
+8. **"One canonical home + link, don't duplicate" dedup guardrail — fits.** Make OpenWiki's canonical-home rule explicit in kk-curate's dedup step to bias toward merging overlapping nodes + edges over near-duplicates. Prompt-level, strengthens existing `curate-dedup`.
+9. **SessionStart advisory from freshness — fits (depends on Idea 1).** If Idea 1 lands, append one line to the injected context ("nodes under branch/x may be stale — code changed since curation") so the descending agent applies mild skepticism. Reuses existing sync SessionStart surface.
+
+## Part 3 — Where kenkeep is BETTER (value-prop contrast)
+
+1. **Human-in-the-loop by construction** vs OpenWiki's unattended daily agent-PR.
+2. **No API keys / no separate spend** — runs on the harness subscription, not BYO OpenRouter/Anthropic keys.
+3. **Deterministic, schema-validated writes via primitives** vs OpenWiki's LLM writing files directly through the shell backend.
+4. **Progressive disclosure** — injects only root `ENTRY.md` and descends by relevance (payload bounded by branch count) vs OpenWiki's static pointer + ad-hoc page reads.
+5. **Fact-grained, evolvable nodes** with `kind`/tags/typed edges/id-stable relocation/redirects and an explicit **no-auto-resolve conflict workflow** vs OpenWiki silently rewriting prose.
+6. **Multi-harness portability** (5 harnesses, one format) vs single-tool.
+7. **Open OKF v0.1 bundle** vs bespoke markdown + private `.last-update.json`.

--- a/research/openwiki-2026-07/social-links-and-comments.md
+++ b/research/openwiki-2026-07/social-links-and-comments.md
@@ -1,0 +1,95 @@
+# OpenWiki social links + kenkeep comment drafts
+
+**Research date:** 2026-07-05. OpenWiki launched by LangChain ~July 1, 2026. All URLs below were surfaced by live web search and are real. Reddit could **not** be verified (reddit.com was blocked from the search tool) — no link was fabricated. GitHub Discussions is **not enabled** on langchain-ai/openwiki (the `/discussions` URL 404s).
+
+**Framing used in every draft:** OpenWiki documents *the code itself* (agent derives/maintains a wiki from source). kenkeep captures *tribal knowledge from AI sessions* — conventions, gotchas, rationale — with a **human review gate in git**. Complementary, not competitors: OpenWiki = the "what," kenkeep = the "why / watch-out."
+
+## Overall recommendation (per platform)
+
+- **X/Twitter — best ROI, lowest risk.** Short replies are normal. **Highest-value target is Harrison Chase's "What do you want in your wiki?" post** — he's literally soliciting input.
+- **Hacker News — comment once, carefully.** Thread is skeptical about staleness and "who curates" — that's kenkeep's exact wedge. Lead with the substantive point, disclose, mention kenkeep once, no link-first, no reply-bombing.
+- **LinkedIn — fine, polished, low frequency.** Comment on the official post + one reshare max (don't paste the same comment across every reshare).
+- **Medium "Stop stuffing CLAUDE.md" article — strong fit** (kenkeep also argues against monolithic CLAUDE.md).
+- **Reddit — unverified.** If you find a live thread manually, comment inside it with disclosure; never start a promo thread. Fallback draft at the bottom.
+- **DO NOT comment on:** aggregator/SEO blogs (aitechpartner, themenonlab, youmind, digg) — auto-generated, no real audience, pure spam signal. Don't open a GitHub **issue** on openwiki to promote kenkeep. Don't repeat the same comment across LinkedIn reshares.
+
+## Links + suggested comments
+
+### 1. Hacker News — Show/launch thread
+
+- **Link:** https://news.ycombinator.com/item?id=48752949
+- **Context:** by `handfuloflight`, ~Jul 1–2, ~64 pts / ~17 comments. Skeptical tone: wikis go stale, "who curates," "over-engineered vs a good prompt."
+- **Suggested comment:**
+
+> The "wikis go stale / who actually curates this" worry here matches what we kept hitting. Auto-generated repo docs describe *what the code is* well, but can't capture what never lands in source: why an abstraction exists, the gotcha that cost someone a day. That lives in AI-session transcripts and evaporates when the session ends. Disclosure: I maintain kenkeep (open source), the complementary half — it distills durable facts *out of your AI sessions*, and nothing enters the base without a human approving it as an ordinary git diff. So "who curates it" = a person, in a PR, with full history/blame/revert. The failure mode you're describing is mostly the *unreviewed* auto-update loop, not docs themselves.
+
+### 2. X — LangChain official launch post
+
+- **Link:** https://x.com/LangChain/status/2072376975545798792
+- **Suggested comment:**
+
+> Nice — the agent-consumable docs angle is right. We've been on the other half: OpenWiki derives docs from code; kenkeep (disclosure: I maintain it) captures tribal knowledge from AI sessions — conventions, gotchas, rationale — with a human review step in git. Pair them and the agent gets the "what" and the "why." Congrats on the launch.
+
+### 3. X — Harrison Chase, launch commentary
+
+- **Link:** https://x.com/hwchase17/status/2072375664314081287 ("wikis for memory are all the rage")
+- **Suggested comment:**
+
+> "Wikis for memory" is the right frame. The bit I'd add: some memory shouldn't be auto-written — the conventions/gotchas an agent learns mid-session need a human to bless them before they're team truth. That's kenkeep's niche (disclosure: I build it) — human-curated session knowledge in git, complementary to auto-derived repo docs.
+
+### 4. X — Harrison Chase, "what do you want in your wiki?" ⭐ HIGHEST PRIORITY
+
+- **Link:** https://x.com/hwchase17/status/2072532749374898176
+- **Context:** Open solicitation for input — the single best place to engage.
+- **Suggested comment:**
+
+> One source I'd love in the mix: the AI coding sessions themselves. Half the durable knowledge ("why we did X", "watch out for Y") is stated in chat and never makes it into code, so a code-derived wiki can't see it. A capture-from-transcripts source + a human review gate before commit would be huge. (Disclosure: that's basically what I built kenkeep to do — happy to compare notes on structure/curation.)
+
+### 5. X — Micha Bladowski (@michabbb)
+
+- **Link:** https://x.com/michabbb/status/2072457248887259175
+- **Context:** dev sharing install steps.
+- **Suggested comment:**
+
+> Good writeup. Complementary piece: capturing what your AI *sessions* learn (conventions, gotchas) into git with a human review step — that's kenkeep (I maintain it). OpenWiki = docs from code, kenkeep = reviewed memory from sessions. They stack.
+
+### 6. LinkedIn — LangChain official
+
+- **Link:** https://www.linkedin.com/posts/langchain_openwiki-can-generate-repo-docs-automatically-activity-7478159637293318144-5QZ3
+- **Suggested comment:**
+
+> Really like the "docs built for agents, kept fresh automatically" framing — drift is a real tax. One complementary layer: a lot of a repo's most valuable knowledge (why an approach was chosen, the non-obvious gotcha) is generated in AI sessions and never lands in source, so a code-derived wiki can't capture it. Disclosure: I maintain kenkeep, open source, which distills that session knowledge into human-reviewed, git-versioned notes — complementary to OpenWiki, not an alternative. Congrats to the team.
+
+### 7. LinkedIn — Sanket Prabhu (#agent #SDLC reshare)
+
+- **Link:** https://www.linkedin.com/posts/sanprabhu_openwiki-agent-sdlc-activity-7478295838939697152-Qf7h
+- **Suggested comment** *(pick #7 OR #8, not both)*:
+
+> The SDLC framing is spot on. Worth distinguishing two kinds of agent context: code-derived docs (OpenWiki) and the tacit decisions/gotchas that surface during AI work and otherwise evaporate. For the second, human-in-the-loop capture landing as reviewed git artifacts keeps it trustworthy. Disclosure: I build kenkeep, which targets that second bucket — complementary to code-doc tools like OpenWiki.
+
+### 8. LinkedIn — Divya Pratap Singh Bhadoria (dev-tools reshare)
+
+- **Link:** https://www.linkedin.com/posts/iamdivyapratap_ai-developertools-langchain-activity-7478191401856495616-n1p4
+- **Suggested comment** *(pick #7 OR #8, not both)*:
+
+> Good pick for the dev-tools feed. Mental model I've landed on: OpenWiki = auto-maintained docs *from* the code; the missing half is the tribal knowledge your AI sessions produce. Disclosure: I maintain kenkeep, which captures that with a human review gate in git. Together they cover the "what" and the "why."
+
+### 9. Medium — "Stop Stuffing Your Repo Into CLAUDE.md" (Kristopher Dunham)
+
+- **Link:** https://medium.com/@creativeaininja/stop-stuffing-your-repo-into-claude-md-openwiki-has-a-better-pattern-817affd4bd0b
+- **Context:** has a comment section; argument aligns with kenkeep's anti-monolithic-CLAUDE.md stance.
+- **Suggested comment:**
+
+> Strong agreement on "don't stuff everything into CLAUDE.md" — it blows the context budget and mixes code facts with human decisions that need different handling. OpenWiki nails the first. The piece I'd add is the human-decision half — conventions/gotchas from actual AI sessions. Disclosure: I maintain kenkeep, which captures those into small per-fact markdown nodes with a human review step and progressive disclosure (agent loads an index, descends only into what's relevant), so the payload stays small as it grows. Complementary to OpenWiki, not competing.
+
+## Reference-only (do not comment)
+
+- LangChain blog: https://www.langchain.com/blog/introducing-openwiki-an-open-source-agent-for-repo-documentation (no comment section)
+- GitHub repo: https://github.com/langchain-ai/openwiki (Discussions disabled — don't self-promo via issues)
+- Trendshift: https://trendshift.io/repositories/70339
+
+## Reddit fallback draft
+
+Only if you locate a real thread manually; never as a new post:
+
+> Been using OpenWiki-style code docs alongside something that captures the *session* side — the conventions/gotchas that come up while pairing with an agent and otherwise vanish. Full disclosure, that second thing is my project (kenkeep, open source): distills durable facts out of AI sessions into git with a human review step. OpenWiki does the code map, this does the "why/watch-out." They stack. Happy to answer Qs.


### PR DESCRIPTION
Comparative research against langchain-ai/openwiki: deep-dive with nine
improvement proposals (filed as issues #89-#95), mid-2026 memory-tool
landscape with a maintenance verdict, and verified social links with
drafted disclosure-first comments.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Sgj62NdT6bwhdhTbaRBFxa