### PR TITLE
fix: authenticate OpenCode install in host-drift workflow

### DIFF
--- a/.github/workflows/host-drift.yml
+++ b/.github/workflows/host-drift.yml
@@ -30,12 +30,22 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Install latest harness CLIs
+      - name: Install npm harness CLIs
+        run: npm install -g @anthropic-ai/claude-code @openai/codex @github/copilot
+
+      - name: Install Cursor CLI
         run: |
-          npm install -g @anthropic-ai/claude-code @openai/codex @github/copilot
           curl -fsSL https://cursor.com/install | bash
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-          curl -fsSL https://opencode.ai/install | bash
+
+      - name: Install OpenCode CLI
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          VERSION=$(curl -sf -H "Authorization: Bearer $GITHUB_TOKEN" \
+            https://api.github.com/repos/anomalyco/opencode/releases/latest \
+            | jq -r .tag_name | sed 's/^v//')
+          curl -fsSL https://opencode.ai/install | bash -s -- --version "$VERSION"
           echo "$HOME/.opencode/bin" >> "$GITHUB_PATH"
 
       - name: Probe host contracts


### PR DESCRIPTION
Fix #97: split harness CLI installs into separate steps and resolve OpenCode's latest release via github.token to avoid unauthenticated GitHub API rate limits on shared runners.