### PR TITLE
fix: split docs Pages build and deploy jobs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,9 @@ name: Deploy Documentation
 on:
   push:
     branches: [main]
-    paths: ['docs/**']
+    paths:
+      - 'docs/**'
+      - '.github/workflows/docs.yml'
   workflow_dispatch:
 
 permissions:
@@ -16,17 +18,14 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v5
 
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v5
 
       - name: Build with Jekyll
         uses: actions/jekyll-build-pages@v1
@@ -36,7 +35,16 @@ jobs:
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./_site
 
+  deploy:
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Summary
- Investigated failed run https://github.com/e0ipso/kenkeep/actions/runs/28806092750
- Original failure: deploy-pages reported "Deployment failed, try again later" after a successful Jekyll build
- Rerun failure: duplicate `github-pages` artifacts because build+deploy were in one job
- Fix: split into build/deploy jobs, upgrade Pages actions to v5, explicit artifact path, trigger on workflow changes

## Test plan
- [ ] Merge PR and verify Deploy Documentation workflow succeeds
- [ ] Confirm site updates at https://kenkeep.canpicasoft.com